### PR TITLE
[rc3] Various settings

### DIFF
--- a/play/src/front/Components/Menu/SettingsSubMenu.svelte
+++ b/play/src/front/Components/Menu/SettingsSubMenu.svelte
@@ -11,6 +11,7 @@
     import { isMediaBreakpointUp } from "../../Utils/BreakpointsUtils";
     import { audioManagerVolumeStore } from "../../Stores/AudioManagerStore";
     import { onMount } from "svelte";
+    import { gameManager } from "../../Phaser/Game/GameManager";
 
     import infoImg from "../images/info.svg";
     import { iframeListener } from "../../Api/IframeListener";
@@ -24,6 +25,7 @@
     let ignoreFollowRequests: boolean = localUserStore.getIgnoreFollowRequests();
     let decreaseAudioPlayerVolumeWhileTalking: boolean = localUserStore.getDecreaseAudioPlayerVolumeWhileTalking();
     let alwaysSilent: boolean = localUserStore.getAlwaysSilent();
+    let disableAnimations: boolean = localUserStore.getDisableAnimations();
     let valueVideo: number = localUserStore.getVideoQualityValue();
     let valueLocale: string = $locale;
     let valueCameraPrivacySettings = localUserStore.getCameraPrivacySettings();
@@ -142,6 +144,15 @@
     function changeAlwaysSilent() {
         localUserStore.setAlwaysSilent(alwaysSilent);
         proximityMeetingStore.set(!alwaysSilent);
+    }
+
+    function changeDisableAnimations() {
+        localUserStore.setDisableAnimations(disableAnimations);
+        if (disableAnimations) {
+            gameManager.getCurrentGameScene().animatedTiles.pause();
+        } else {
+            gameManager.getCurrentGameScene().animatedTiles.resume();
+        }
     }
 
     function closeMenu() {
@@ -278,6 +289,10 @@
         <label>
             <input type="checkbox" bind:checked={alwaysSilent} on:change={changeAlwaysSilent} />
             <span>{$LL.menu.settings.silentMode()}</span>
+        </label>
+        <label>
+            <input type="checkbox" bind:checked={disableAnimations} on:change={changeDisableAnimations} />
+            <span>{$LL.menu.settings.disableAnimations()}</span>
         </label>
     </section>
 </div>

--- a/play/src/front/Components/Menu/SettingsSubMenu.svelte
+++ b/play/src/front/Components/Menu/SettingsSubMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { localUserStore } from "../../Connexion/LocalUserStore";
     import { videoConstraintStore } from "../../Stores/MediaStore";
+    import { proximityMeetingStore } from "../../Stores/MyMediaStore";
     import { audioManagerFileStore, audioManagerVisibilityStore } from "../../Stores/AudioManagerStore";
     import { HtmlUtils } from "../../WebRtc/HtmlUtils";
     import { menuVisiblilityStore } from "../../Stores/MenuStore";
@@ -22,6 +23,7 @@
     let forceCowebsiteTrigger: boolean = localUserStore.getForceCowebsiteTrigger();
     let ignoreFollowRequests: boolean = localUserStore.getIgnoreFollowRequests();
     let decreaseAudioPlayerVolumeWhileTalking: boolean = localUserStore.getDecreaseAudioPlayerVolumeWhileTalking();
+    let alwaysSilent: boolean = localUserStore.getAlwaysSilent();
     let valueVideo: number = localUserStore.getVideoQualityValue();
     let valueLocale: string = $locale;
     let valueCameraPrivacySettings = localUserStore.getCameraPrivacySettings();
@@ -135,6 +137,11 @@
         analyticsClient.settingDecreaseAudioVolume(decreaseAudioPlayerVolumeWhileTalking ? "true" : "false");
 
         localUserStore.setDecreaseAudioPlayerVolumeWhileTalking(decreaseAudioPlayerVolumeWhileTalking);
+    }
+
+    function changeAlwaysSilent() {
+        localUserStore.setAlwaysSilent(alwaysSilent);
+        proximityMeetingStore.set(!alwaysSilent);
     }
 
     function closeMenu() {
@@ -267,6 +274,10 @@
         <label>
             <input type="checkbox" bind:checked={blockAudio} on:change={changeBlockAudio} />
             <span>{$LL.menu.settings.blockAudio()}</span>
+        </label>
+        <label>
+            <input type="checkbox" bind:checked={alwaysSilent} on:change={changeAlwaysSilent} />
+            <span>{$LL.menu.settings.silentMode()}</span>
         </label>
     </section>
 </div>

--- a/play/src/front/Components/Menu/SettingsSubMenu.svelte
+++ b/play/src/front/Components/Menu/SettingsSubMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { localUserStore } from "../../Connexion/LocalUserStore";
     import { videoConstraintStore } from "../../Stores/MediaStore";
+    import { audioManagerFileStore, audioManagerVisibilityStore } from "../../Stores/AudioManagerStore";
     import { HtmlUtils } from "../../WebRtc/HtmlUtils";
     import { menuVisiblilityStore } from "../../Stores/MenuStore";
     import LL, { locale } from "../../../i18n/i18n-svelte";
@@ -17,6 +18,7 @@
     let fullscreen: boolean = localUserStore.getFullscreen();
     let notification: boolean = localUserStore.getNotification();
     let chatSounds: boolean = localUserStore.getChatSounds();
+    let blockAudio: boolean = localUserStore.getBlockAudio();
     let forceCowebsiteTrigger: boolean = localUserStore.getForceCowebsiteTrigger();
     let ignoreFollowRequests: boolean = localUserStore.getIgnoreFollowRequests();
     let decreaseAudioPlayerVolumeWhileTalking: boolean = localUserStore.getDecreaseAudioPlayerVolumeWhileTalking();
@@ -104,6 +106,14 @@
     function changeChatSounds() {
         localUserStore.setChatSounds(chatSounds);
         iframeListener.sendSettingsToChatIframe();
+    }
+
+    function changeBlockAudio() {
+        if (blockAudio) {
+            audioManagerFileStore.unloadAudio();
+            audioManagerVisibilityStore.set(false);
+        }
+        localUserStore.setBlockAudio(blockAudio);
     }
 
     function changeForceCowebsiteTrigger() {
@@ -253,6 +263,10 @@
                 on:change={changeDecreaseAudioPlayerVolumeWhileTalking}
             />
             <span>{$LL.audio.manager.reduce()}</span>
+        </label>
+        <label>
+            <input type="checkbox" bind:checked={blockAudio} on:change={changeBlockAudio} />
+            <span>{$LL.menu.settings.blockAudio()}</span>
         </label>
     </section>
 </div>

--- a/play/src/front/Connexion/LocalUserStore.ts
+++ b/play/src/front/Connexion/LocalUserStore.ts
@@ -20,6 +20,7 @@ const forceCowebsiteTriggerKey = "forceCowebsiteTrigger";
 const ignoreFollowRequests = "ignoreFollowRequests";
 const decreaseAudioPlayerVolumeWhileTalking = "decreaseAudioPlayerVolumeWhileTalking";
 const alwaysSilent = "alwaysSilent";
+const disableAnimations = "disableAnimations";
 const lastRoomUrl = "lastRoomUrl";
 const authToken = "authToken";
 const notification = "notificationPermission";
@@ -205,6 +206,13 @@ class LocalUserStore {
     }
     getAlwaysSilent(): boolean {
         return localStorage.getItem(alwaysSilent) === "true";
+    }
+
+    setDisableAnimations(value: boolean): void {
+        localStorage.setItem(disableAnimations, value.toString());
+    }
+    getDisableAnimations(): boolean {
+        return localStorage.getItem(disableAnimations) === "true";
     }
 
     async setLastRoomUrl(roomUrl: string): Promise<void> {

--- a/play/src/front/Connexion/LocalUserStore.ts
+++ b/play/src/front/Connexion/LocalUserStore.ts
@@ -19,6 +19,7 @@ const blockAudio = "blockAudio";
 const forceCowebsiteTriggerKey = "forceCowebsiteTrigger";
 const ignoreFollowRequests = "ignoreFollowRequests";
 const decreaseAudioPlayerVolumeWhileTalking = "decreaseAudioPlayerVolumeWhileTalking";
+const alwaysSilent = "alwaysSilent";
 const lastRoomUrl = "lastRoomUrl";
 const authToken = "authToken";
 const notification = "notificationPermission";
@@ -191,11 +192,19 @@ class LocalUserStore {
     getIgnoreFollowRequests(): boolean {
         return localStorage.getItem(ignoreFollowRequests) === "true";
     }
+
     setDecreaseAudioPlayerVolumeWhileTalking(value: boolean): void {
         localStorage.setItem(decreaseAudioPlayerVolumeWhileTalking, value.toString());
     }
     getDecreaseAudioPlayerVolumeWhileTalking(): boolean {
         return localStorage.getItem(decreaseAudioPlayerVolumeWhileTalking) === "true";
+    }
+
+    setAlwaysSilent(value: boolean): void {
+        localStorage.setItem(alwaysSilent, value.toString());
+    }
+    getAlwaysSilent(): boolean {
+        return localStorage.getItem(alwaysSilent) === "true";
     }
 
     async setLastRoomUrl(roomUrl: string): Promise<void> {

--- a/play/src/front/Connexion/LocalUserStore.ts
+++ b/play/src/front/Connexion/LocalUserStore.ts
@@ -15,6 +15,7 @@ const audioPlayerVolumeKey = "audioVolume";
 const audioPlayerMuteKey = "audioMute";
 const helpCameraSettingsShown = "helpCameraSettingsShown";
 const fullscreenKey = "fullscreen";
+const blockAudio = "blockAudio";
 const forceCowebsiteTriggerKey = "forceCowebsiteTrigger";
 const ignoreFollowRequests = "ignoreFollowRequests";
 const decreaseAudioPlayerVolumeWhileTalking = "decreaseAudioPlayerVolumeWhileTalking";
@@ -166,6 +167,13 @@ class LocalUserStore {
 
     getFullscreen(): boolean {
         return localStorage.getItem(fullscreenKey) === "true";
+    }
+
+    setBlockAudio(value: boolean): void {
+        localStorage.setItem(blockAudio, value.toString());
+    }
+    getBlockAudio(): boolean {
+        return localStorage.getItem(blockAudio) === "true";
     }
 
     setForceCowebsiteTrigger(value: boolean): void {

--- a/play/src/front/Connexion/RoomConnection.ts
+++ b/play/src/front/Connexion/RoomConnection.ts
@@ -25,6 +25,7 @@ import {
     warningContainerStore,
 } from "../Stores/MenuStore";
 import { localUserStore } from "./LocalUserStore";
+import { proximityMeetingStore } from "../Stores/MyMediaStore";
 import {
     apiVersionHash,
     AnswerMessage,
@@ -446,6 +447,10 @@ export class RoomConnection implements RoomConnection {
                     const characterLayers = roomJoinedMessage.characterLayer.map(
                         this.mapCharacterLayerToBodyResourceDescription.bind(this)
                     );
+
+                    if (localUserStore.getAlwaysSilent()) {
+                        proximityMeetingStore.set(false);
+                    }
 
                     this._roomJoinedMessageStream.next({
                         connection: this,

--- a/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
@@ -207,6 +207,9 @@ export class GameMapPropertiesListener {
         });
 
         this.gameMapFrontWrapper.onPropertyChange(GameMapProperties.PLAY_AUDIO, (newValue, oldValue, allProps) => {
+            if (localUserStore.getBlockAudio()) {
+                return;
+            }
             const volume = allProps.get(GameMapProperties.AUDIO_VOLUME) as number | undefined;
             const loop = allProps.get(GameMapProperties.AUDIO_LOOP) as boolean | undefined;
             newValue === undefined

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -685,6 +685,9 @@ export class GameScene extends DirtyScene {
 
         this.animatedTiles.init(this.Map);
         this.events.on("tileanimationupdate", () => (this.dirty = true));
+        if (localUserStore.getDisableAnimations()) {
+            this.animatedTiles.pause();
+        }
 
         this.initCirclesCanvas();
 

--- a/play/src/i18n/ca-ES/menu.ts
+++ b/play/src/i18n/ca-ES/menu.ts
@@ -62,6 +62,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         cowebsiteTrigger: "Preguntar sempre abans d'obrir llocs web i habitacions Jitsi Meet",
         ignoreFollowRequest: "Ignorar peticions de seguir altres usuaris",
         blockAudio: "Block ambient sounds and music",
+        silentMode: "Silent mode (disable proximity chat)",
     },
     invite: {
         description: "Compartir l'enllaç de l'habitació!",

--- a/play/src/i18n/ca-ES/menu.ts
+++ b/play/src/i18n/ca-ES/menu.ts
@@ -63,6 +63,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         ignoreFollowRequest: "Ignorar peticions de seguir altres usuaris",
         blockAudio: "Block ambient sounds and music",
         silentMode: "Silent mode (disable proximity chat)",
+        disableAnimations: "Disable map tile animations",
     },
     invite: {
         description: "Compartir l'enllaç de l'habitació!",

--- a/play/src/i18n/ca-ES/menu.ts
+++ b/play/src/i18n/ca-ES/menu.ts
@@ -61,6 +61,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Notificacions",
         cowebsiteTrigger: "Preguntar sempre abans d'obrir llocs web i habitacions Jitsi Meet",
         ignoreFollowRequest: "Ignorar peticions de seguir altres usuaris",
+        blockAudio: "Block ambient sounds and music",
     },
     invite: {
         description: "Compartir l'enllaç de l'habitació!",

--- a/play/src/i18n/de-DE/menu.ts
+++ b/play/src/i18n/de-DE/menu.ts
@@ -60,6 +60,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Benachrichtigungen",
         cowebsiteTrigger: "Jedes mal nachfragen bevor Webseiten oder Jitsi Meet Räume geöffnet werden",
         ignoreFollowRequest: "Ignoriere Folgen-Anfragen anderer Nutzer",
+        blockAudio: "Musik und Hintergrund-Geräusche deaktivieren",
     },
     invite: {
         description: "Link zu diesem Raum teilen!",

--- a/play/src/i18n/de-DE/menu.ts
+++ b/play/src/i18n/de-DE/menu.ts
@@ -62,6 +62,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         ignoreFollowRequest: "Ignoriere Folgen-Anfragen anderer Nutzer",
         blockAudio: "Musik und Hintergrund-Geräusche deaktivieren",
         silentMode: "Stiller Modus (deaktiviert Audio-/Video-Chat)",
+        disableAnimations: "Karten-Animationen deaktivieren",
     },
     invite: {
         description: "Link zu diesem Raum teilen!",

--- a/play/src/i18n/de-DE/menu.ts
+++ b/play/src/i18n/de-DE/menu.ts
@@ -61,6 +61,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         cowebsiteTrigger: "Jedes mal nachfragen bevor Webseiten oder Jitsi Meet Räume geöffnet werden",
         ignoreFollowRequest: "Ignoriere Folgen-Anfragen anderer Nutzer",
         blockAudio: "Musik und Hintergrund-Geräusche deaktivieren",
+        silentMode: "Stiller Modus (deaktiviert Audio-/Video-Chat)",
     },
     invite: {
         description: "Link zu diesem Raum teilen!",

--- a/play/src/i18n/en-US/menu.ts
+++ b/play/src/i18n/en-US/menu.ts
@@ -63,6 +63,7 @@ const menu: BaseTranslation = {
         ignoreFollowRequest: "Ignore requests to follow other users",
         blockAudio: "Block ambient sounds and music",
         silentMode: "Silent mode (disable proximity chat)",
+        disableAnimations: "Disable map tile animations",
     },
     invite: {
         description: "Share the link of the room!",

--- a/play/src/i18n/en-US/menu.ts
+++ b/play/src/i18n/en-US/menu.ts
@@ -61,6 +61,7 @@ const menu: BaseTranslation = {
         chatSounds: "Sounds of chat",
         cowebsiteTrigger: "Always ask before opening websites and Jitsi Meet rooms",
         ignoreFollowRequest: "Ignore requests to follow other users",
+        blockAudio: "Block ambient sounds and music",
     },
     invite: {
         description: "Share the link of the room!",

--- a/play/src/i18n/en-US/menu.ts
+++ b/play/src/i18n/en-US/menu.ts
@@ -62,6 +62,7 @@ const menu: BaseTranslation = {
         cowebsiteTrigger: "Always ask before opening websites and Jitsi Meet rooms",
         ignoreFollowRequest: "Ignore requests to follow other users",
         blockAudio: "Block ambient sounds and music",
+        silentMode: "Silent mode (disable proximity chat)",
     },
     invite: {
         description: "Share the link of the room!",

--- a/play/src/i18n/es-ES/menu.ts
+++ b/play/src/i18n/es-ES/menu.ts
@@ -61,6 +61,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Notificaciones",
         cowebsiteTrigger: "Preguntar siempre antes de abrir sitios web y habitaciones Jitsi Meet",
         ignoreFollowRequest: "Ignorar peticiones de seguir a otros usuarios",
+        blockAudio: "Block ambient sounds and music",
     },
     invite: {
         description: "¡Compartir el enlace de la habitación!",

--- a/play/src/i18n/es-ES/menu.ts
+++ b/play/src/i18n/es-ES/menu.ts
@@ -63,6 +63,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         ignoreFollowRequest: "Ignorar peticiones de seguir a otros usuarios",
         blockAudio: "Block ambient sounds and music",
         silentMode: "Silent mode (disable proximity chat)",
+        disableAnimations: "Disable map tile animations",
     },
     invite: {
         description: "¡Compartir el enlace de la habitación!",

--- a/play/src/i18n/es-ES/menu.ts
+++ b/play/src/i18n/es-ES/menu.ts
@@ -62,6 +62,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         cowebsiteTrigger: "Preguntar siempre antes de abrir sitios web y habitaciones Jitsi Meet",
         ignoreFollowRequest: "Ignorar peticiones de seguir a otros usuarios",
         blockAudio: "Block ambient sounds and music",
+        silentMode: "Silent mode (disable proximity chat)",
     },
     invite: {
         description: "¡Compartir el enlace de la habitación!",

--- a/play/src/i18n/fr-FR/menu.ts
+++ b/play/src/i18n/fr-FR/menu.ts
@@ -63,6 +63,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         cowebsiteTrigger: "Demander toujours avant d'ouvrir des sites web et des salles de conférence Jitsi",
         ignoreFollowRequest: "Ignorer les demandes de suivi des autres utilisateurs",
         blockAudio: "Désactiver bruits ambiants et musique",
+        silentMode: "Moyen silencieuse (désactiver chatter)",
     },
     invite: {
         description: "Partager le lien de la salle!",

--- a/play/src/i18n/fr-FR/menu.ts
+++ b/play/src/i18n/fr-FR/menu.ts
@@ -62,6 +62,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         chatSounds: "Sons du chat",
         cowebsiteTrigger: "Demander toujours avant d'ouvrir des sites web et des salles de conférence Jitsi",
         ignoreFollowRequest: "Ignorer les demandes de suivi des autres utilisateurs",
+        blockAudio: "Désactiver bruits ambiants et musique",
     },
     invite: {
         description: "Partager le lien de la salle!",

--- a/play/src/i18n/fr-FR/menu.ts
+++ b/play/src/i18n/fr-FR/menu.ts
@@ -64,6 +64,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         ignoreFollowRequest: "Ignorer les demandes de suivi des autres utilisateurs",
         blockAudio: "Désactiver bruits ambiants et musique",
         silentMode: "Moyen silencieuse (désactiver chatter)",
+        disableAnimations: "Désactiver les animations de la carte",
     },
     invite: {
         description: "Partager le lien de la salle!",

--- a/play/src/i18n/pt-BR/menu.ts
+++ b/play/src/i18n/pt-BR/menu.ts
@@ -61,6 +61,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Notificações",
         cowebsiteTrigger: "Sempre pergunte antes de abrir sites e salas do Jitsi Meet",
         ignoreFollowRequest: "Ignorar solicitações para seguir outros usuários",
+        blockAudio: "Block ambient sounds and music",
     },
     invite: {
         description: "Compartilhe o link da sala!",

--- a/play/src/i18n/pt-BR/menu.ts
+++ b/play/src/i18n/pt-BR/menu.ts
@@ -62,6 +62,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         cowebsiteTrigger: "Sempre pergunte antes de abrir sites e salas do Jitsi Meet",
         ignoreFollowRequest: "Ignorar solicitações para seguir outros usuários",
         blockAudio: "Block ambient sounds and music",
+        silentMode: "Silent mode (disable proximity chat)",
     },
     invite: {
         description: "Compartilhe o link da sala!",

--- a/play/src/i18n/pt-BR/menu.ts
+++ b/play/src/i18n/pt-BR/menu.ts
@@ -63,6 +63,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         ignoreFollowRequest: "Ignorar solicitações para seguir outros usuários",
         blockAudio: "Block ambient sounds and music",
         silentMode: "Silent mode (disable proximity chat)",
+        disableAnimations: "Disable map tile animations",
     },
     invite: {
         description: "Compartilhe o link da sala!",

--- a/play/src/i18n/zh-CN/menu.ts
+++ b/play/src/i18n/zh-CN/menu.ts
@@ -61,6 +61,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "通知",
         cowebsiteTrigger: "在打开网页和Jitsi Meet会议前总是询问",
         ignoreFollowRequest: "忽略跟随其他用户的请求",
+        blockAudio: "Block ambient sounds and music",
     },
     invite: {
         description: "分享该房间的链接！",

--- a/play/src/i18n/zh-CN/menu.ts
+++ b/play/src/i18n/zh-CN/menu.ts
@@ -62,6 +62,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         cowebsiteTrigger: "在打开网页和Jitsi Meet会议前总是询问",
         ignoreFollowRequest: "忽略跟随其他用户的请求",
         blockAudio: "Block ambient sounds and music",
+        silentMode: "Silent mode (disable proximity chat)",
     },
     invite: {
         description: "分享该房间的链接！",

--- a/play/src/i18n/zh-CN/menu.ts
+++ b/play/src/i18n/zh-CN/menu.ts
@@ -63,6 +63,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         ignoreFollowRequest: "忽略跟随其他用户的请求",
         blockAudio: "Block ambient sounds and music",
         silentMode: "Silent mode (disable proximity chat)",
+        disableAnimations: "Disable map tile animations",
     },
     invite: {
         description: "分享该房间的链接！",


### PR DESCRIPTION
Implements various settings from rC3:

* Disabling the camera
* Silent mode (silent zone everywhere)
* Ignoring `playAudio` properties
* Disabling tile animations
* Forcing the Jitsi-/cowebsite trigger (you *always* get asked before opening a cowebsite)
* Blocking external content entirely (no cowebsites, Jitsis, tabs - you don't even get asked)

Supersedes #1678 

Note: Drops legacy map property `playAudioLoop`!