### PR TITLE
Limit bandwidth for video and screenshare

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,6 +95,8 @@ services:
             EJABBERD_WS_URI: ws://ejabberd:5443/ws
             ENABLE_CHAT: "$ENABLE_CHAT"
             ENABLE_CHAT_UPLOAD: "$ENABLE_CHAT_UPLOAD"
+            PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS: "$PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS"
+            PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS: "$PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS"
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.front.rule=Host(`front.workadventure.localhost`)"

--- a/front/tests/Components/Video/UtilsTest.ts
+++ b/front/tests/Components/Video/UtilsTest.ts
@@ -94,23 +94,25 @@ describe("getSdpTransform()", () => {
     });
 
     // Expected sdp where the audio and application medias have no 'b' fields
-    // and the video medias should have 'b=AS:<bw>'.
+    // and the video medias should have 'b=TIAS=:<bw*1000>' and 'b=AS:<bw>'.
     const expectedDefaultSdp = (bw: integer) => {
         return `
           m=audio
           c=IN IP4 0.0.0.0
           m=video
           c=IN IP4 0.0.0.0
+          b=TIAS:${bw * 1000}
           b=AS:${bw}
           m=video
           c=IN IP4 0.0.0.0
+          b=TIAS:${bw * 1000}
           b=AS:${bw}
           m=application
           c=IN IP4 0.0.0.0`.replace(/^[\s]*/gm, "");
     };
 
     // Expected sdp where the audio and application medias have a 'b' field
-    // and the video medias should have 'b=AS:<bw>'.
+    // and the video medias should have 'b=TIAS=:<bw*1000>' and 'b=AS:<bw>'.
     const expectedFullBWSdp = (bw: integer) => {
         return `
           m=audio
@@ -118,9 +120,11 @@ describe("getSdpTransform()", () => {
           b=AS:11
           m=video
           c=IN IP4 0.0.0.0
+          b=TIAS:${bw * 1000}
           b=AS:${bw}
           m=video
           c=IN IP4 0.0.0.0
+          b=TIAS:${bw * 1000}
           b=AS:${bw}
           m=application
           c=IN IP4 0.0.0.0

--- a/front/tests/Components/Video/UtilsTest.ts
+++ b/front/tests/Components/Video/UtilsTest.ts
@@ -1,0 +1,129 @@
+import "jasmine";
+
+import { getSdpTransform } from "../../../src/Components/Video/utils";
+
+describe("getSdpTransform()", () => {
+    it("should not do anything if bandwidth = 0", () => {
+        const bw = 0;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:22
+          m=application
+          c=IN IP4 0.0.0.0
+          b=AS:33`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(originalSdp);
+    });
+
+    it("should create the 'b' field of the video media if it doesn't exist", () => {
+        const bw = 55;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          m=application
+          c=IN IP4 0.0.0.0`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(expectedDefaultSdp(bw));
+    });
+
+    it("should update the 'b' field of the video media if it already exists", () => {
+        const bw = 66;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:22
+          m=application
+          c=IN IP4 0.0.0.0`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(expectedDefaultSdp(bw));
+    });
+
+    it("should create and update the 'b' field of each video media if one doesn't exist and the other does", () => {
+        const bw = 77;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          m=application
+          c=IN IP4 0.0.0.0`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(expectedDefaultSdp(bw));
+    });
+
+    it("should not change the 'b' field of other medias", () => {
+        const bw = 88;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:22
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:33
+          m=application
+          c=IN IP4 0.0.0.0
+          b=AS:44`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(expectedFullBWSdp(bw));
+    });
+
+    // Expected sdp where the audio and application medias have no 'b' fields
+    // and the video medias should have 'b=AS:<bw>'.
+    const expectedDefaultSdp = (bw: integer) => {
+        return `
+          m=audio
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:${bw}
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:${bw}
+          m=application
+          c=IN IP4 0.0.0.0`.replace(/^[\s]*/gm, "");
+    };
+
+    // Expected sdp where the audio and application medias have a 'b' field
+    // and the video medias should have 'b=AS:<bw>'.
+    const expectedFullBWSdp = (bw: integer) => {
+        return `
+          m=audio
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:${bw}
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:${bw}
+          m=application
+          c=IN IP4 0.0.0.0
+          b=AS:44`.replace(/^[\s]*/gm, "");
+    };
+});

--- a/play/package.json
+++ b/play/package.json
@@ -138,6 +138,7 @@
     "ts-proto-descriptors": "^1.7.1",
     "typesafe-i18n": "^5.14.0",
     "uuid": "^9.0.0",
+    "webrtc-adapter": "^8.1.1",
     "zod": "^3.19.1"
   }
 }

--- a/play/src/common/FrontConfigurationInterface.ts
+++ b/play/src/common/FrontConfigurationInterface.ts
@@ -26,4 +26,6 @@ export interface FrontConfigurationInterface {
     CHAT_URL: string | undefined;
     ENABLE_CHAT_UPLOAD: boolean;
     FALLBACK_LOCALE: string | undefined;
+    PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS: number;
+    PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS: number;
 }

--- a/play/src/front/Components/Video/utils.ts
+++ b/play/src/front/Components/Video/utils.ts
@@ -1,6 +1,5 @@
 import type { UserSimplePeerInterface } from "../../WebRtc/SimplePeer";
 import { STUN_SERVER, TURN_PASSWORD, TURN_SERVER, TURN_USER } from "../../Enum/EnvironmentVariable";
-import adapter from "webrtc-adapter";
 
 export function getColorByString(str: string): string | null {
     let hash = 0;
@@ -79,33 +78,32 @@ function updateBandwidthRestriction(sdp: string, bandwidth: integer, mediaType: 
         return sdp;
     }
 
-    let modifier = "AS";
-    // Firefox doesn't support "AS"
-    if (adapter.browserDetails.browser === "firefox") {
-        bandwidth = (bandwidth >>> 0) * 1000;
-        modifier = "TIAS";
-    }
-
     for (
         let targetMediaPos = sdp.indexOf(`m=${mediaType}`);
         targetMediaPos !== -1;
         targetMediaPos = sdp.indexOf(`m=${mediaType}`, targetMediaPos + 1)
     ) {
         const nextMediaPos = sdp.indexOf(`m=`, targetMediaPos + 1);
-        const nextBWPos = sdp.indexOf(`b=${modifier}:`, targetMediaPos + 1);
+        for (const modifier of ["TIAS", "AS"]) {
+            const newBandwidth = modifier === "TIAS" ? (bandwidth >>> 0) * 1000 : bandwidth;
+            const nextBWPos = sdp.indexOf(`b=${modifier}:`, targetMediaPos + 1);
 
-        let mediaSlice = sdp.slice(targetMediaPos);
-        const mustCreateBWField = nextBWPos === -1 || (nextBWPos > nextMediaPos && nextMediaPos !== -1);
-        if (mustCreateBWField) {
-            // insert b= after c= line.
-            mediaSlice = mediaSlice.replace(/c=IN (.*)(\r?\n)/, `c=IN $1$2b=${modifier}:${bandwidth}$2`);
-        } else {
-            // update b= with new 'bandwidth'
-            mediaSlice = mediaSlice.replace(new RegExp(`b=${modifier}:.*(\r?\n)`), `b=${modifier}:${bandwidth}$1`);
+            let mediaSlice = sdp.slice(targetMediaPos);
+            const mustCreateBWField = nextBWPos === -1 || (nextBWPos > nextMediaPos && nextMediaPos !== -1);
+            if (mustCreateBWField) {
+                // insert b= after c= line.
+                mediaSlice = mediaSlice.replace(/c=IN (.*)(\r?\n)/, `c=IN $1$2b=${modifier}:${newBandwidth}$2`);
+            } else {
+                // update b= with new 'bandwidth'
+                mediaSlice = mediaSlice.replace(
+                    new RegExp(`b=${modifier}:.*(\r?\n)`),
+                    `b=${modifier}:${newBandwidth}$1`
+                );
+            }
+
+            // update the sdp
+            sdp = sdp.slice(0, targetMediaPos) + mediaSlice;
         }
-
-        // update the sdp
-        sdp = sdp.slice(0, targetMediaPos) + mediaSlice;
     }
 
     return sdp;

--- a/play/src/front/Components/Video/utils.ts
+++ b/play/src/front/Components/Video/utils.ts
@@ -1,5 +1,6 @@
 import type { UserSimplePeerInterface } from "../../WebRtc/SimplePeer";
 import { STUN_SERVER, TURN_PASSWORD, TURN_SERVER, TURN_USER } from "../../Enum/EnvironmentVariable";
+import adapter from "webrtc-adapter";
 
 export function getColorByString(str: string): string | null {
     let hash = 0;
@@ -63,4 +64,49 @@ export function getIceServersConfig(user: UserSimplePeerInterface): RTCIceServer
         });
     }
     return config;
+}
+
+export function getSdpTransform(videoBandwidth = 0) {
+    return (sdp: string) => {
+        sdp = updateBandwidthRestriction(sdp, videoBandwidth, "video");
+
+        return sdp;
+    };
+}
+
+function updateBandwidthRestriction(sdp: string, bandwidth: integer, mediaType: string): string {
+    if (bandwidth <= 0) {
+        return sdp;
+    }
+
+    let modifier = "AS";
+    // Firefox doesn't support "AS"
+    if (adapter.browserDetails.browser === "firefox") {
+        bandwidth = (bandwidth >>> 0) * 1000;
+        modifier = "TIAS";
+    }
+
+    for (
+        let targetMediaPos = sdp.indexOf(`m=${mediaType}`);
+        targetMediaPos !== -1;
+        targetMediaPos = sdp.indexOf(`m=${mediaType}`, targetMediaPos + 1)
+    ) {
+        const nextMediaPos = sdp.indexOf(`m=`, targetMediaPos + 1);
+        const nextBWPos = sdp.indexOf(`b=${modifier}:`, targetMediaPos + 1);
+
+        let mediaSlice = sdp.slice(targetMediaPos);
+        const mustCreateBWField = nextBWPos === -1 || (nextBWPos > nextMediaPos && nextMediaPos !== -1);
+        if (mustCreateBWField) {
+            // insert b= after c= line.
+            mediaSlice = mediaSlice.replace(/c=IN (.*)(\r?\n)/, `c=IN $1$2b=${modifier}:${bandwidth}$2`);
+        } else {
+            // update b= with new 'bandwidth'
+            mediaSlice = mediaSlice.replace(new RegExp(`b=${modifier}:.*(\r?\n)`), `b=${modifier}:${bandwidth}$1`);
+        }
+
+        // update the sdp
+        sdp = sdp.slice(0, targetMediaPos) + mediaSlice;
+    }
+
+    return sdp;
 }

--- a/play/src/front/Enum/EnvironmentVariable.ts
+++ b/play/src/front/Enum/EnvironmentVariable.ts
@@ -35,6 +35,8 @@ export const OPID_LOGOUT_REDIRECT_URL = env.OPID_LOGOUT_REDIRECT_URL;
 export const CHAT_URL = env.CHAT_URL;
 export const ENABLE_CHAT_UPLOAD = env.ENABLE_CHAT_UPLOAD;
 export const FALLBACK_LOCALE = env.FALLBACK_LOCALE;
+export const PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS = env.PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS;
+export const PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS = env.PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS;
 
 export const POSITION_DELAY = 200; // Wait 200ms between sending position events
 export const MAX_EXTRAPOLATION_TIME = 100; // Extrapolate a maximum of 250ms if no new movement is sent by the player

--- a/play/src/front/WebRtc/ScreenSharingPeer.ts
+++ b/play/src/front/WebRtc/ScreenSharingPeer.ts
@@ -4,11 +4,12 @@ import { MESSAGE_TYPE_CONSTRAINT } from "./VideoPeer";
 import type { UserSimplePeerInterface } from "./SimplePeer";
 import type { Readable, Writable } from "svelte/store";
 import { readable, writable } from "svelte/store";
-import { getIceServersConfig } from "../Components/Video/utils";
+import { getIceServersConfig, getSdpTransform } from "../Components/Video/utils";
 import { highlightedEmbedScreen } from "../Stores/EmbedScreensStore";
 import { isMediaBreakpointUp } from "../Utils/BreakpointsUtils";
 import Peer from "simple-peer/simplepeer.min.js";
 import { Buffer } from "buffer";
+import { PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS } from "../Enum/EnvironmentVariable";
 
 /**
  * A peer connection used to transmit video / audio signals between 2 peers.
@@ -37,6 +38,7 @@ export class ScreenSharingPeer extends Peer {
             config: {
                 iceServers: getIceServersConfig(user),
             },
+            sdpTransform: getSdpTransform(PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS),
         });
 
         this.userId = user.userId;

--- a/play/src/front/WebRtc/VideoPeer.ts
+++ b/play/src/front/WebRtc/VideoPeer.ts
@@ -14,12 +14,13 @@ import {
     newChatMessageWritingStatusSubject,
     writingStatusMessageStore,
 } from "../Stores/ChatStore";
-import { getIceServersConfig } from "../Components/Video/utils";
+import { getIceServersConfig, getSdpTransform } from "../Components/Video/utils";
 import { isMediaBreakpointUp } from "../Utils/BreakpointsUtils";
 import { SoundMeter } from "../Phaser/Components/SoundMeter";
 import Peer from "simple-peer/simplepeer.min.js";
 import { Buffer } from "buffer";
 import { gameManager } from "../Phaser/Game/GameManager";
+import { PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS } from "../Enum/EnvironmentVariable";
 
 export type PeerStatus = "connecting" | "connected" | "error" | "closed";
 
@@ -63,6 +64,7 @@ export class VideoPeer extends Peer {
             config: {
                 iceServers: getIceServersConfig(user),
             },
+            sdpTransform: getSdpTransform(PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS),
         });
 
         this.userId = user.userId;

--- a/play/src/pusher/enums/EnvironmentVariable.ts
+++ b/play/src/pusher/enums/EnvironmentVariable.ts
@@ -67,6 +67,8 @@ const EnvironmentVariables = z.object({
     POSTHOG_URL: z.string().url().optional().or(z.literal("")),
     FALLBACK_LOCALE: z.string().optional(),
     CHAT_URL: z.string().url(),
+    PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS: PositiveIntAsString.optional(),
+    PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS: PositiveIntAsString.optional(),
 });
 
 type EnvironmentVariables = z.infer<typeof EnvironmentVariables>;
@@ -172,4 +174,6 @@ export const FRONT_ENVIRONMENT_VARIABLES: FrontConfigurationInterface = {
     CHAT_URL: env.CHAT_URL,
     ENABLE_CHAT_UPLOAD: toBool(env.ENABLE_CHAT_UPLOAD, true),
     FALLBACK_LOCALE: env.FALLBACK_LOCALE,
+    PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS: toNumber(env.PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS, 0),
+    PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS: toNumber(env.PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS, 0),
 };

--- a/play/tests/front/Components/Video/UtilsTest.ts
+++ b/play/tests/front/Components/Video/UtilsTest.ts
@@ -1,0 +1,129 @@
+import "jasmine";
+
+import { getSdpTransform } from "../../../src/front/Components/Video/utils";
+
+describe("getSdpTransform()", () => {
+    it("should not do anything if bandwidth = 0", () => {
+        const bw = 0;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:22
+          m=application
+          c=IN IP4 0.0.0.0
+          b=AS:33`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(originalSdp);
+    });
+
+    it("should create the 'b' field of the video media if it doesn't exist", () => {
+        const bw = 55;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          m=application
+          c=IN IP4 0.0.0.0`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(expectedDefaultSdp(bw));
+    });
+
+    it("should update the 'b' field of the video media if it already exists", () => {
+        const bw = 66;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:22
+          m=application
+          c=IN IP4 0.0.0.0`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(expectedDefaultSdp(bw));
+    });
+
+    it("should create and update the 'b' field of each video media if one doesn't exist and the other does", () => {
+        const bw = 77;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          m=application
+          c=IN IP4 0.0.0.0`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(expectedDefaultSdp(bw));
+    });
+
+    it("should not change the 'b' field of other medias", () => {
+        const bw = 88;
+        const originalSdp = `
+          m=audio
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:22
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:33
+          m=application
+          c=IN IP4 0.0.0.0
+          b=AS:44`.replace(/^[\s]*/gm, "");
+
+        const modifiedSdp = getSdpTransform(bw)(originalSdp);
+        expect(modifiedSdp).toEqual(expectedFullBWSdp(bw));
+    });
+
+    // Expected sdp where the audio and application medias have no 'b' fields
+    // and the video medias should have 'b=AS:<bw>'.
+    const expectedDefaultSdp = (bw: integer) => {
+        return `
+          m=audio
+          c=IN IP4 0.0.0.0
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:${bw}
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:${bw}
+          m=application
+          c=IN IP4 0.0.0.0`.replace(/^[\s]*/gm, "");
+    };
+
+    // Expected sdp where the audio and application medias have a 'b' field
+    // and the video medias should have 'b=AS:<bw>'.
+    const expectedFullBWSdp = (bw: integer) => {
+        return `
+          m=audio
+          c=IN IP4 0.0.0.0
+          b=AS:11
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:${bw}
+          m=video
+          c=IN IP4 0.0.0.0
+          b=AS:${bw}
+          m=application
+          c=IN IP4 0.0.0.0
+          b=AS:44`.replace(/^[\s]*/gm, "");
+    };
+});

--- a/play/tests/front/Components/Video/UtilsTest.ts
+++ b/play/tests/front/Components/Video/UtilsTest.ts
@@ -1,6 +1,6 @@
-import "jasmine";
-
-import { getSdpTransform } from "../../../src/front/Components/Video/utils";
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { getSdpTransform } from "../../../../src/front/Components/Video/utils";
 
 describe("getSdpTransform()", () => {
     it("should not do anything if bandwidth = 0", () => {

--- a/play/yarn.lock
+++ b/play/yarn.lock
@@ -4489,6 +4489,11 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
+sdp@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sdp/-/sdp-3.0.3.tgz#669958d54663ea9f4a46cc66518c9d980c52c61e"
+  integrity sha512-8EkfckS+XZQaPLyChu4ey7PghrdcraCVNpJe2Gfdi2ON1ylQ7OasuKX+b37R9slnRChwIAiQgt+oj8xXGD8x+A==
+
 semver@^5.6.0, semver@^5.7.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -5307,6 +5312,13 @@ webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+webrtc-adapter@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-8.1.1.tgz#e4a4dfd1b5085d119da40c4efc0147f7d0961cba"
+  integrity sha512-1yXevP7TeZGmklEXkvQVrZp3fOSJlLeXNGCA7NovQokxgP3/e2T3EVGL0eKU87S9vKppWjvRWqnJeSANEspOBg==
+  dependencies:
+    sdp "^3.0.2"
 
 whatwg-encoding@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Add two new environment variables, `PEER_VIDEO_MAX_BANDWIDTH_KBITS_PS` and `PEER_SCREENSHARE_MAX_BANDWIDTH_KBITS_PS`, in order to limit bandwidth used by the P2P connection in the bubble. Leaving video and screenshare unlimited is problematic because it might take a lot of bandwidth and processing power, which leads to poor quality/experience.
We've been testing very successfully 600 kbps for video and 1000 kbps for screenshare.