### PR TITLE
Migrating Docker build images to GHCR

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -62,20 +62,26 @@ jobs:
             "SENTRY_PROJECT=play"
             "SENTRY_RELEASE=${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}"
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build test image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: play/Dockerfile
           platforms: linux/amd64
-          push: false
-          tags: thecodingmachine/workadventure-play:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          push: true
+          tags: ghcr.io/workadventure/play:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
           cache-from: |
             type=registry,ref=thecodingmachine/workadventure-play:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
             type=registry,ref=thecodingmachine/workadventure-play:develop
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/play.tar
 
       - name: Sentry push source maps
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
@@ -94,17 +100,6 @@ jobs:
             thecodingmachine/workadventure-play:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }} \
             /bin/sh -c 'npm install --dev && npm run push-sentry-sourcemaps'
       
-
-      - name: Zip image
-        run: gzip play.tar
-        working-directory: /tmp
-
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: play
-          path: /tmp/play.tar.gz
-
   build-chat:
     runs-on: ubuntu-latest
 
@@ -154,30 +149,26 @@ jobs:
             "SENTRY_PROJECT=chat"
             "SENTRY_RELEASE=${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}"
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build test image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: chat/Dockerfile
           platforms: linux/amd64
-          push: false
-          tags: thecodingmachine/workadventure-chat:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          push: true
+          tags: ghcr.io/workadventure/chat:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
           cache-from: |
             type=registry,ref=thecodingmachine/workadventure-chat:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
             type=registry,ref=thecodingmachine/workadventure-chat:develop
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/chat.tar
-
-      - name: Zip image
-        run: gzip chat.tar
-        working-directory: /tmp
-
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: chat
-          path: /tmp/chat.tar.gz
 
   build-back:
     runs-on: ubuntu-latest
@@ -229,20 +220,26 @@ jobs:
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build test image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: back/Dockerfile
           platforms: linux/amd64
-          push: false
-          tags: thecodingmachine/workadventure-back:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          push: true
+          tags: ghcr.io/workadventure/back:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
           cache-from: |
             type=registry,ref=thecodingmachine/workadventure-back:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
             type=registry,ref=thecodingmachine/workadventure-back:develop
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/back.tar
 
       - name: Sentry push source maps
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
@@ -260,17 +257,6 @@ jobs:
               -e SENTRY_RELEASE \
               thecodingmachine/workadventure-back:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }} \
               /bin/sh -c 'npm install --dev && npm run push-sentry-sourcemaps'
-
-
-      - name: Zip image
-        run: gzip back.tar
-        working-directory: /tmp
-
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: back
-          path: /tmp/back.tar.gz
 
   build-uploader:
     runs-on: ubuntu-latest
@@ -310,28 +296,24 @@ jobs:
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build test image
         uses: docker/build-push-action@v3
         with:
           file: uploader/Dockerfile
-          push: false
-          tags: thecodingmachine/workadventure-uploader:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          push: true
+          tags: ghcr.io/workadventure/uploader:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
           cache-from: |
             type=registry,ref=thecodingmachine/workadventure-uploader:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
             type=registry,ref=thecodingmachine/workadventure-uploader:develop
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/uploader.tar
-
-      - name: Zip image
-        run: gzip uploader.tar
-        working-directory: /tmp
-
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: uploader
-          path: /tmp/uploader.tar.gz
 
   build-maps:
     runs-on: ubuntu-latest
@@ -375,29 +357,25 @@ jobs:
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build test image
         uses: docker/build-push-action@v3
         with:
           context: maps/
           file: maps/Dockerfile
-          push: false
-          tags: thecodingmachine/workadventure-maps:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          push: true
+          tags: ghcr.io/workadventure/maps:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
           cache-from: |
             type=registry,ref=thecodingmachine/workadventure-maps:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
             type=registry,ref=thecodingmachine/workadventure-maps:develop
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/maps.tar
-
-      - name: Zip image
-        run: gzip maps.tar
-        working-directory: /tmp
-
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: maps
-          path: /tmp/maps.tar.gz
 
   build-map-storage:
     runs-on: ubuntu-latest
@@ -443,20 +421,26 @@ jobs:
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build test image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: map-storage/Dockerfile
           platforms: linux/amd64
-          push: false
-          tags: thecodingmachine/workadventure-map-storage:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          push: true
+          tags: ghcr.io/workadventure/map-storage:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
           cache-from: |
             type=registry,ref=thecodingmachine/workadventure-map-storage:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
             type=registry,ref=thecodingmachine/workadventure-map-storage:develop
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/map-storage.tar
 
       - name: Sentry push source maps
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
@@ -474,16 +458,6 @@ jobs:
             -e SENTRY_RELEASE \
             thecodingmachine/workadventure-map-storage:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }} \
             /bin/sh -c 'cd /usr/src && npm ci -w map-storage && cd /usr/src/map-storage && npm run push-sentry-sourcemaps'
-
-      - name: Zip image
-        run: gzip map-storage.tar
-        working-directory: /tmp
-
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: map-storage
-          path: /tmp/map-storage.tar.gz
 
   build-ejabberd:
     runs-on: ubuntu-latest
@@ -528,29 +502,25 @@ jobs:
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build test image
         uses: docker/build-push-action@v3
         with:
           context: xmpp/
           platforms: linux/amd64
-          push: false
-          tags: thecodingmachine/workadventure-ejabberd:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          push: true
+          tags: ghcr.io/workadventure/ejabberd:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
           cache-from: |
             type=registry,ref=thecodingmachine/workadventure-ejabberd:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
             type=registry,ref=thecodingmachine/workadventure-ejabberd:develop
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/ejabberd.tar
-
-      - name: Zip image
-        run: gzip ejabberd.tar
-        working-directory: /tmp
-
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ejabberd
-          path: /tmp/ejabberd.tar.gz
 
   end-to-end-tests:
     name: "End to end tests with ${{ matrix.browser }} (${{ matrix.shard }}/${{ matrix.nbShards }})"
@@ -620,59 +590,18 @@ jobs:
         run: |
           sed -i "s/ROOM_API_SECRET_KEY=/ROOM_API_SECRET_KEY=MYAWESOMEKEY/g" .env
 
-      -
-        name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v2
         with:
-          name: play
-          path: /tmp
-      -
-        name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: chat
-          path: /tmp
-      -
-        name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: back
-          path: /tmp
-      -
-        name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: maps
-          path: /tmp
-      -
-        name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: map-storage
-          path: /tmp
-      -
-        name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: uploader
-          path: /tmp
-      -
-        name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: ejabberd
-          path: /tmp
-      -
-        name: Load image
-        run: |
-          docker load --input /tmp/play.tar.gz
-          docker load --input /tmp/chat.tar.gz
-          docker load --input /tmp/back.tar.gz
-          docker load --input /tmp/maps.tar.gz
-          docker load --input /tmp/map-storage.tar.gz
-          docker load --input /tmp/uploader.tar.gz
-          docker load --input /tmp/ejabberd.tar.gz
-          docker image ls -a
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull images
+        run: docker-compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml pull
+        env:
+          DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+
       - name: Start WorkAdventure
         run: docker-compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml up -d
         env:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -11,12 +11,12 @@ services:
         condition: service_healthy
 
   play:
-    image: thecodingmachine/workadventure-play:${DOCKER_TAG:-develop}
+    image: ghcr.io/workadventure/play:${DOCKER_TAG:-develop}
     build:
       context: ./
       dockerfile: play/Dockerfile
       cache_from:
-        - thecodingmachine/workadventure-play:${DOCKER_TAG:-develop}
+        - ghcr.io/workadventure/play:${DOCKER_TAG:-develop}
       args:
         BUILDKIT_INLINE_CACHE: 1
     working_dir: /usr/src/play
@@ -38,12 +38,12 @@ services:
       - "traefik.http.services.play.loadbalancer.server.port=3000"
 
   chat:
-    image: thecodingmachine/workadventure-chat:${DOCKER_TAG:-develop}
+    image: ghcr.io/workadventure/chat:${DOCKER_TAG:-develop}
     build:
       context: ./
       dockerfile: chat/Dockerfile
       cache_from:
-        - thecodingmachine/workadventure-chat:${DOCKER_TAG:-develop}
+        - ghcr.io/workadventure/chat:${DOCKER_TAG:-develop}
       args:
         BUILDKIT_INLINE_CACHE: 1
     command: /start_nginx.sh
@@ -59,12 +59,12 @@ services:
       - "traefik.http.services.chat.loadbalancer.server.port=80"
 
   back:
-    image: thecodingmachine/workadventure-back:${DOCKER_TAG:-develop}
+    image: ghcr.io/workadventure/back:${DOCKER_TAG:-develop}
     build:
       context: ./
       dockerfile: back/Dockerfile
       cache_from:
-        - thecodingmachine/workadventure-back:${DOCKER_TAG:-develop}
+        - ghcr.io/workadventure/back:${DOCKER_TAG:-develop}
       args:
         BUILDKIT_INLINE_CACHE: 1
     command: npm run runprod
@@ -77,12 +77,12 @@ services:
       STARTUP_COMMAND_2: ""
 
   map-storage:
-    image: thecodingmachine/workadventure-map-storage:${DOCKER_TAG:-develop}
+    image: ghcr.io/workadventure/map-storage:${DOCKER_TAG:-develop}
     build:
       context: ./
       dockerfile: map-storage/Dockerfile
       cache_from:
-        - thecodingmachine/workadventure-map-storage:${DOCKER_TAG:-develop}
+        - ghcr.io/workadventure/map-storage:${DOCKER_TAG:-develop}
       args:
         BUILDKIT_INLINE_CACHE: 1
     working_dir: /usr/src/map-storage
@@ -93,11 +93,11 @@ services:
       STARTUP_COMMAND_2: ""
 
   maps:
-    image: thecodingmachine/workadventure-maps:${DOCKER_TAG:-develop}
+    image: ghcr.io/workadventure/maps:${DOCKER_TAG:-develop}
     build:
       context: maps/
       cache_from:
-        - thecodingmachine/workadventure-maps:${DOCKER_TAG:-develop}
+        - ghcr.io/workadventure/maps:${DOCKER_TAG:-develop}
       args:
         BUILDKIT_INLINE_CACHE: 1
     volumes: []
@@ -106,12 +106,12 @@ services:
       STARTUP_COMMAND_1: ""
 
   uploader:
-    image: thecodingmachine/workadventure-uploader:${DOCKER_TAG:-develop}
+    image: ghcr.io/workadventure/uploader:${DOCKER_TAG:-develop}
     build:
       context: ./
       dockerfile: uploader/Dockerfile
       cache_from:
-        - thecodingmachine/workadventure-uploader:${DOCKER_TAG:-develop}
+        - ghcr.io/workadventure/uploader:${DOCKER_TAG:-develop}
       args:
         BUILDKIT_INLINE_CACHE: 1
     working_dir: /usr/src/uploader
@@ -122,11 +122,11 @@ services:
       STARTUP_COMMAND_1: ""
 
   ejabberd:
-    image: thecodingmachine/workadventure-ejabberd:${DOCKER_TAG:-develop}
+    image: ghcr.io/workadventure/ejabberd:${DOCKER_TAG:-develop}
     build:
       context: ./xmpp
       cache_from:
-        - thecodingmachine/workadventure-ejabberd:${DOCKER_TAG:-develop}
+        - ghcr.io/workadventure/ejabberd:${DOCKER_TAG:-develop}
       args:
         BUILDKIT_INLINE_CACHE: 1
     volumes: []


### PR DESCRIPTION
Previously, build images (used by the E2E tests) were stored as artifacts. Storing a 800MB artifact can take 2 to 3 minutes.

Using Docker images instead can be beneficial as only the modified layers need to be stored.