### PR TITLE
More resilient cache generation in map-storage

### DIFF
--- a/map-storage/src/Services/MapListService.ts
+++ b/map-storage/src/Services/MapListService.ts
@@ -48,8 +48,12 @@ export class MapListService {
                     vendor: wamFile.vendor,
                 };
             } catch (err) {
-                console.log(`Parsing error for ${wamFilePath}`);
-                throw err;
+                Sentry.captureException(
+                    `Error while trying to read a WAM file to generate cache: ${JSON.stringify(
+                        err
+                    )}. Skipping this file for cache generation.`
+                );
+                console.log(`Parsing error for ${wamFilePath}. Skipping this file for cache generation.`);
             }
         }
 

--- a/map-storage/src/Upload/UploadController.ts
+++ b/map-storage/src/Upload/UploadController.ts
@@ -367,7 +367,11 @@ export class UploadController {
                     if (limiter.activeCount === 0 && limiter.pendingCount === 0) {
                         this.uploadLimiter.delete(virtualPath);
                     }
-                })().catch((e) => next(e));
+                })().catch((e) => {
+                    console.error(e);
+                    Sentry.captureException(e);
+                    next(e);
+                });
             }
         );
     }
@@ -451,7 +455,11 @@ export class UploadController {
                 if (limiter.activeCount === 0 && limiter.pendingCount === 0) {
                     this.uploadLimiter.delete(virtualPath);
                 }
-            })().catch((e) => next(e));
+            })().catch((e) => {
+                console.error(e);
+                Sentry.captureException(e);
+                next(e);
+            });
         });
     }
 
@@ -546,7 +554,11 @@ export class UploadController {
                 await this.fileSystem.archiveDirectory(archive, virtualDirectory);
 
                 await archive.finalize();
-            })().catch((e) => next(e));
+            })().catch((e) => {
+                console.error(e);
+                Sentry.captureException(e);
+                next(e);
+            });
         });
     }
 
@@ -571,7 +583,11 @@ export class UploadController {
                 await this.mapListService.generateCacheFile(req.hostname);
 
                 res.sendStatus(204);
-            })().catch((e) => next(e));
+            })().catch((e) => {
+                console.error(e);
+                Sentry.captureException(e);
+                next(e);
+            });
         });
     }
 
@@ -599,7 +615,11 @@ export class UploadController {
                 }
 
                 res.sendStatus(204);
-            })().catch((e) => next(e));
+            })().catch((e) => {
+                console.error(e);
+                Sentry.captureException(e);
+                next(e);
+            });
         });
     }
 
@@ -641,7 +661,11 @@ export class UploadController {
                 await this.fileSystem.move(virtualPath, newVirtualPath);
                 await this.mapListService.generateCacheFile(req.hostname);
                 res.sendStatus(200);
-            })().catch((e) => next(e));
+            })().catch((e) => {
+                console.error(e);
+                Sentry.captureException(e);
+                next(e);
+            });
         });
     }
 
@@ -679,7 +703,11 @@ export class UploadController {
                 await this.fileSystem.copy(virtualPath, newVirtualPath);
                 await this.mapListService.generateCacheFile(req.hostname);
                 res.sendStatus(201);
-            })().catch((e) => next(e));
+            })().catch((e) => {
+                console.error(e);
+                Sentry.captureException(e);
+                next(e);
+            });
         });
     }
 
@@ -701,7 +729,11 @@ export class UploadController {
                     }
                     throw e;
                 }
-            })().catch((e) => next(e));
+            })().catch((e) => {
+                console.error(e);
+                Sentry.captureException(e);
+                next(e);
+            });
         });
     }
 }


### PR DESCRIPTION
If a WAM file is invalid, cache generation will continue without it.
Also, adding logs and Sentry to HTTP 500 errors.