### PR TITLE
Adding an exception for pingMessages

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -101,7 +101,7 @@ const roomManager = {
                                     Sentry.captureException(`message handleJoinRoom error: ${JSON.stringify(e)}`);
                                     emitError(call, e);
                                 });
-                        } else {
+                        } else if (message.message.$case !== "pingMessage") {
                             throw new Error("The first message sent MUST be of type JoinRoomMessage");
                         }
                     } else {


### PR DESCRIPTION
If a pingMessage arrives BEFORE a joinedRoomMessage, let's not throw an error. Something is definitely wrong (the joinedRoomMessage should not be that long to arrive). But the ping issue should not be put in front instead of the underlying issue.