### PR TITLE
Making areas defined in Tiled editable from the scripting API

### DIFF
--- a/play/src/front/Phaser/Game/StartPositionCalculator.ts
+++ b/play/src/front/Phaser/Game/StartPositionCalculator.ts
@@ -37,19 +37,14 @@ export class StartPositionCalculator {
             }
         }
 
-        for (const tiledArea of this.gameMapFrontWrapper.getTiledAreas()) {
-            if (tiledArea.name === "start") {
-                names.push(tiledArea.name);
+        for (const dynamicArea of this.gameMapFrontWrapper.dynamicAreas.values()) {
+            if (dynamicArea.name === "start") {
+                names.push(dynamicArea.name);
                 continue;
             }
-            const properties = tiledArea.properties;
-            if (properties) {
-                for (const property of properties) {
-                    if (property.name === GameMapProperties.START && property.value === true) {
-                        names.push(tiledArea.name);
-                        break;
-                    }
-                }
+            const properties = dynamicArea.properties;
+            if (properties && properties[GameMapProperties.START] === true) {
+                names.push(dynamicArea.name);
             }
         }
 
@@ -105,14 +100,14 @@ export class StartPositionCalculator {
     }
 
     private initPositionFromTiledArea(startPositionName: string, needStartProperty = false): boolean {
-        const tiledAreas = this.gameMapFrontWrapper.getTiledAreas();
-        for (const tiledArea of tiledAreas) {
-            if (!tiledArea || tiledArea.name !== startPositionName) {
+        const tiledAreas = this.gameMapFrontWrapper.dynamicAreas;
+        for (const [name, tiledArea] of tiledAreas.entries()) {
+            if (!tiledArea || name !== startPositionName) {
                 continue;
             }
             const properties = tiledArea.properties;
             if (needStartProperty && properties) {
-                if (!properties.find((property) => property.name === "start")) {
+                if (!properties["start"]) {
                     return false;
                 }
             }


### PR DESCRIPTION
Making areas defined in Tiled editable (again) from the scripting API. Now that areas in Tiled cannot be edited in the map editor (we have special areas in WAM files for that), Tiled areas should be editable from the map editor again.

TODO:

- [ ] Remove dead code
- [ ] End to end test