### PR TITLE
Making Jitsi and Cowebsites closable by default

### DIFF
--- a/play/src/front/Components/MapEditor/AreaPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/AreaPropertiesEditor.svelte
@@ -54,6 +54,7 @@
                 return {
                     id,
                     type,
+                    closable: true,
                     jitsiRoomConfig: {},
                     hideButtonLabel: true,
                     roomName: "JITSI ROOM",
@@ -62,6 +63,7 @@
                 return {
                     id,
                     type,
+                    closable: true,
                     link: "https://workadventu.re",
                     newTab: false,
                     hideButtonLabel: true,

--- a/play/src/front/Components/MapEditor/EntityPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/EntityPropertiesEditor.svelte
@@ -50,6 +50,7 @@
                     id,
                     type,
                     jitsiRoomConfig: {},
+                    closable: true,
                     roomName: "JITSI ROOM",
                     buttonLabel: "Connect to Jitsi",
                 };
@@ -57,6 +58,7 @@
                 return {
                     id,
                     type,
+                    closable: true,
                     buttonLabel: "Open Website",
                     link: "https://workadventu.re",
                     newTab: false,


### PR DESCRIPTION
Making Jitsi and Cowebsites closable by default in the map editor (on areas and on entities)