### PR TITLE
[WIP] Turns on noise suppression by default in Jitsi

### DIFF
--- a/play/src/front/WebRtc/JitsiFactory.ts
+++ b/play/src/front/WebRtc/JitsiFactory.ts
@@ -189,6 +189,12 @@ class JitsiFactory {
 
                 this.jitsiApi.addListener("videoConferenceJoined", () => {
                     this.jitsiApi?.executeCommand("displayName", playerName);
+
+                    // Enable Noise suppression by default.
+                    this.jitsiApi?.executeCommand("setNoiseSuppressionEnabled", {
+                        enabled: true,
+                    });
+
                     this.updateParticipantsCountStore();
                 });
 


### PR DESCRIPTION
This turns on the "noise suppression" feature of Jitsi when someone enters a Jitsi meeting.

The solution is not perfect because it displays an error message on Firefox (due to stereo recording not being supported)

- [ ] Check this message on Jitsi forum: https://community.jitsi.org/t/disable-stereo-microphone/124563