### PR TITLE
Centering the Woka again when a MediaBox is removed

### DIFF
--- a/play/src/front/Components/Video/MediaBox.svelte
+++ b/play/src/front/Components/Video/MediaBox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { fly } from "svelte/transition";
     import type { Readable } from "svelte/store";
-    import { onMount } from "svelte";
+    import { onMount, onDestroy } from "svelte";
     import { PeerStatus, VideoPeer } from "../../WebRtc/VideoPeer";
     import { ScreenSharingPeer } from "../../WebRtc/ScreenSharingPeer";
     import type { Streamable } from "../../Stores/StreamableCollectionStore";
@@ -33,6 +33,10 @@
     const gameScene = gameManager.getCurrentGameScene();
 
     onMount(() => {
+        gameScene.reposition();
+    });
+
+    onDestroy(() => {
         gameScene.reposition();
     });
 </script>


### PR DESCRIPTION
We moved the centering of the Woka when a MediaBox was created but forget to move it back when the MediaBox was closed. This is now fixed.

Closes https://github.com/workadventure/workadventure/issues/3331