### PR TITLE
Gracefully shutting down websocket connection.

### DIFF
--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -149,7 +149,7 @@ export class IoSocketController {
                                 },
                             })
                         );
-                        ws.close();
+                        ws.end(1007, "Invalid message received!");
                         return;
                     }
 
@@ -170,7 +170,7 @@ export class IoSocketController {
                                 },
                             })
                         );
-                        ws.close();
+                        ws.end(1008, "Access refused");
                         return;
                     }
 
@@ -195,7 +195,7 @@ export class IoSocketController {
                                     },
                                 })
                             );
-                            ws.close();
+                            ws.end(1008, "Access refused");
                             return;
                         }
 
@@ -658,7 +658,7 @@ export class IoSocketController {
                         } else {
                             socketManager.emitConnectionErrorMessage(ws, ws.message);
                         }
-                        setTimeout(() => ws.close(), 0);
+                        ws.end(1000, "Error message sent");
                         return;
                     }
 


### PR DESCRIPTION
Using `.end()` instead of `.close()` to close websocket connections.

Also, calling end just after sending the error message.

We hope this will fix a crash seen on this stacktrace:

```
workadventure-saas-play-1  | Error: Invalid answer received from the admin for the /api/room/access endpoint. Received: {"email":"fa696813-2228-4bb3-9ada-053656ef949c","userUuid":"fa696813-2228-4bb3-9ada-053656ef949c","tags":[],"messages":[],"textures":[],"visitCardUrl":null,"jabberId":null,"jabberPassword":null,"mucRooms":[{"name":"Connected users","url":"http://play.workadventure.test/@/wa/workadventure-premium/","type":"default","subscribe":false},{"name":"Welcome","type":"forum","url":"http://play.workadventure.test/@/wa/workadventure-premium/forum/welcome","subscribe":false}],"activatedInviteUser":true,"applications":[{"name":"Test onboarding","script":"http://extra.workadventure.localhost/tutorialv1Script.html"}],"username":null}
workadventure-saas-play-1  |     at AdminApi.fetchMemberDataByUuid (/usr/src/play/src/pusher/services/AdminApi.ts:373:15)
workadventure-saas-play-1  |     at processTicksAndRejections (node:internal/process/task_queues:95:5)
workadventure-saas-play-1  |     at async /usr/src/play/src/pusher/controllers/IoSocketController.ts:391:44
workadventure-saas-play-1  | Error: User cannot access this world
workadventure-saas-play-1  |     at /usr/src/play/src/pusher/controllers/IoSocketController.ts:465:35
workadventure-saas-play-1  |     at processTicksAndRejections (node:internal/process/task_queues:95:5)
workadventure-saas-play-1  | Could not find the GameRoom the user is leaving!
```