### PR TITLE
Deploy Develop -> Master 03/07/23

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -34,7 +34,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
 
       - name: Docker meta
         id: meta
@@ -57,11 +57,12 @@ jobs:
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
+            "SENTRY_URL=${{ secrets.SENTRY_URL }}"
             "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}"
             "SENTRY_ORG=${{ secrets.SENTRY_ORG }}"
             "SENTRY_PROJECT=play"
-            "SENTRY_ENVIRONMENT=${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF == 'master' && 'staging' || 'testing' }}"
-            "SENTRY_RELEASE=${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}"
+            "SENTRY_ENVIRONMENT=${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF_SLUG == 'master' && 'staging' || 'testing' }}"
+            "SENTRY_RELEASE=${{ github.event_name == 'release' && env.GITHUB_HEAD_REF_SLUG || format('{0}@{1}', env.GITHUB_HEAD_REF_SLUG, env.GITHUB_SHA_SHORT) }}"
 
       - name: Build test image
         uses: docker/build-push-action@v3
@@ -84,15 +85,18 @@ jobs:
 
       - name: Sentry push source maps
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
+        continue-on-error: true
         env:
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: play
-          SENTRY_ENVIRONMENT: ${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF == 'master' && 'staging' || 'testing' }}
-          SENTRY_RELEASE: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          SENTRY_ENVIRONMENT: ${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF_SLUG == 'master' && 'staging' || 'testing' }}
+          SENTRY_RELEASE: ${{ github.event_name == 'release' && env.GITHUB_HEAD_REF_SLUG || format('{0}@{1}', env.GITHUB_HEAD_REF_SLUG, env.GITHUB_SHA_SHORT) }}
         run: |
           docker run --rm \
             --user 0       \
+            -e SENTRY_URL \
             -e SENTRY_AUTH_TOKEN \
             -e SENTRY_ORG \
             -e SENTRY_PROJECT \
@@ -133,7 +137,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
 
       - name: Docker meta
         id: meta
@@ -156,11 +160,12 @@ jobs:
           cache-to: type=inline
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
+            "SENTRY_URL=${{ secrets.SENTRY_URL }}"
             "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}"
             "SENTRY_ORG=${{ secrets.SENTRY_ORG }}"
             "SENTRY_PROJECT=chat"
-            "SENTRY_ENVIRONMENT=${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF == 'master' && 'staging' || 'testing' }}"
-            "SENTRY_RELEASE=${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}"
+            "SENTRY_ENVIRONMENT=${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF_SLUG == 'master' && 'staging' || 'testing' }}"
+            "SENTRY_RELEASE=${{ github.event_name == 'release' && env.GITHUB_HEAD_REF_SLUG || format('{0}@{1}', env.GITHUB_HEAD_REF_SLUG, env.GITHUB_SHA_SHORT) }}"
 
       - name: Build test image
         uses: docker/build-push-action@v3
@@ -208,7 +213,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
 
       - name: Docker meta
         id: meta
@@ -259,14 +264,16 @@ jobs:
       - name: Sentry push source maps
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
         env:
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: back
-          SENTRY_ENVIRONMENT: ${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF == 'master' && 'staging' || 'testing' }}
-          SENTRY_RELEASE: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          SENTRY_ENVIRONMENT: ${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF_SLUG == 'master' && 'staging' || 'testing' }}
+          SENTRY_RELEASE: ${{ github.event_name == 'release' && env.GITHUB_HEAD_REF_SLUG || format('{0}@{1}', env.GITHUB_HEAD_REF_SLUG, env.GITHUB_SHA_SHORT) }}
         run: |
             docker run --rm \
               --user 0       \
+              -e SENTRY_URL \
               -e SENTRY_AUTH_TOKEN \
               -e SENTRY_ORG \
               -e SENTRY_PROJECT \
@@ -303,7 +310,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
 
       - name: Docker meta
         id: meta
@@ -367,7 +374,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
 
       - name: Docker meta
         id: meta
@@ -434,7 +441,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
 
       - name: Docker meta
         id: meta
@@ -479,14 +486,16 @@ jobs:
       - name: Sentry push source maps
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
         env:
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: map-storage
-          SENTRY_ENVIRONMENT: ${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF == 'master' && 'staging' || 'testing' }}
-          SENTRY_RELEASE: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          SENTRY_ENVIRONMENT: ${{ github.event_name == 'release' && 'production' || env.GITHUB_HEAD_REF_SLUG == 'master' && 'staging' || 'testing' }}
+          SENTRY_RELEASE: ${{ github.event_name == 'release' && env.GITHUB_HEAD_REF_SLUG || format('{0}@{1}', env.GITHUB_HEAD_REF_SLUG, env.GITHUB_SHA_SHORT) }}
         run: |
           docker run --rm \
             --user 0       \
+            -e SENTRY_URL \
             -e SENTRY_AUTH_TOKEN \
             -e SENTRY_ORG \
             -e SENTRY_PROJECT \
@@ -526,7 +535,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
 
       - name: Docker meta
         id: meta
@@ -622,7 +631,7 @@ jobs:
         working-directory: tests
       - name: 'Setup .env file'
         run: cp .env.template .env
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
       - name: Display pulled version
         run: echo "Pulling images with tag ${DOCKER_TAG}"
         env:
@@ -765,7 +774,7 @@ jobs:
       - name: 'Setup .env file'
         run: cp .env.prod.template .env
         working-directory: contrib/docker
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
 
       - name: "Install Room Api client dependencies"
         run: npm ci
@@ -849,7 +858,7 @@ jobs:
         uses: actions/checkout@v2
 
       # Create a slugified value of the branch
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@4.2.3
 
       - name: Set ADMIN_URL if "deploy-connect-to-admin" label is set
         run: echo "ADMIN_API_URL=https://${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}.test.workadventu.re" >> $GITHUB_ENV

--- a/chat/Dockerfile
+++ b/chat/Dockerfile
@@ -29,18 +29,20 @@ COPY chat ./chat
 
 # upgrade RAM available to 6G
 RUN --mount=type=secret,id=SENTRY_RELEASE \
+    --mount=type=secret,id=SENTRY_URL \
     --mount=type=secret,id=SENTRY_AUTH_TOKEN \
     --mount=type=secret,id=SENTRY_ORG \
     --mount=type=secret,id=SENTRY_PROJECT \
     --mount=type=secret,id=SENTRY_ENVIRONMENT \
     export SENTRY_RELEASE=$(cat /run/secrets/SENTRY_RELEASE) && \
+    export SENTRY_URL=$(cat /run/secrets/SENTRY_URL) && \
     export SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) && \
     export SENTRY_ORG=$(cat /run/secrets/SENTRY_ORG) && \
     export SENTRY_PROJECT=$(cat /run/secrets/SENTRY_PROJECT) && \
     export SENTRY_ENVIRONMENT=$(cat /run/secrets/SENTRY_ENVIRONMENT) && \
     cd chat && \
     npm run typesafe-i18n && \
-    SENTRY_RELEASE=$SENTRY_RELEASE SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_ORG=$SENTRY_ORG SENTRY_PROJECT=$SENTRY_PROJECT SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT NODE_OPTIONS="--max-old-space-size=6144" npm run build
+    SENTRY_RELEASE=$SENTRY_RELEASE SENTRY_URL=$SENTRY_URL SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_ORG=$SENTRY_ORG SENTRY_PROJECT=$SENTRY_PROJECT SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT NODE_OPTIONS="--max-old-space-size=6144" npm run build
 
 RUN mv /usr/src/chat/dist/index.html /usr/src/chat/dist/index.tpl.html
 # Bypassing a bug in envconfig generation that does not take into account relative base.

--- a/chat/vite.config.ts
+++ b/chat/vite.config.ts
@@ -84,8 +84,10 @@ export default defineConfig(({ mode }) => {
     };
 
     if (env.SENTRY_ORG && env.SENTRY_PROJECT && env.SENTRY_AUTH_TOKEN && env.SENTRY_RELEASE && env.SENTRY_ENVIRONMENT) {
+        console.info("Sentry plugin enabled");
         config.plugins.push(
             sentryVitePlugin({
+                url: env.SENTRY_URL || "https://sentry.io/",
                 org: env.SENTRY_ORG,
                 project: env.SENTRY_PROJECT,
                 // Specify the directory containing build artifacts
@@ -98,8 +100,11 @@ export default defineConfig(({ mode }) => {
                 deploy: {
                     env: env.SENTRY_ENVIRONMENT,
                 },
+                uploadSourceMaps: true,
             })
         );
+    } else {
+        console.info("Sentry plugin disabled");
     }
     return config;
 });

--- a/play/Dockerfile
+++ b/play/Dockerfile
@@ -28,11 +28,13 @@ COPY --from=proto-builder /usr/src/generated play/src/messages/generated
 ENV NODE_ENV=production
 # upgrade RAM available to 6G
 RUN --mount=type=secret,id=SENTRY_RELEASE \
+    --mount=type=secret,id=SENTRY_URL \
     --mount=type=secret,id=SENTRY_AUTH_TOKEN \
     --mount=type=secret,id=SENTRY_ORG \
     --mount=type=secret,id=SENTRY_PROJECT \
     --mount=type=secret,id=SENTRY_ENVIRONMENT \
     export SENTRY_RELEASE=$(cat /run/secrets/SENTRY_RELEASE) && \
+    export SENTRY_URL=$(cat /run/secrets/SENTRY_URL) && \
     export SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) && \
     export SENTRY_ORG=$(cat /run/secrets/SENTRY_ORG) && \
     export SENTRY_PROJECT=$(cat /run/secrets/SENTRY_PROJECT) && \
@@ -40,7 +42,7 @@ RUN --mount=type=secret,id=SENTRY_RELEASE \
     cd play && \
     npm run typesafe-i18n && \
     npm run build-iframe-api && \
-    SENTRY_RELEASE=$SENTRY_RELEASE SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_ORG=$SENTRY_ORG SENTRY_PROJECT=$SENTRY_PROJECT SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT NODE_OPTIONS="--max-old-space-size=6144" npm run build
+    SENTRY_RELEASE=$SENTRY_RELEASE SENTRY_URL=$SENTRY_URL SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_ORG=$SENTRY_ORG SENTRY_PROJECT=$SENTRY_PROJECT SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT NODE_OPTIONS="--max-old-space-size=6144" npm run build
 
 # final production image
 FROM node:18.12.1-buster-slim@sha256:62798b0191c85e2fc5f06897e345a6c9e8902ea3beedcb8e07463c665c37526d

--- a/play/package.json
+++ b/play/package.json
@@ -20,7 +20,7 @@
     "build": "cross-env vite build",
     "typecheck": "cross-env tsc --noEmit",
     "profile": "tsc && node --prof ./dist/server.js",
-    "push-sentry-sourcemaps": "tsc --project tsconfig-pusher.json && sentry-cli releases new $SENTRY_RELEASE && sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps dist && sentry-cli releases finalize $SENTRY_RELEASE",
+    "push-sentry-sourcemaps": "tsc --project tsconfig-pusher.json && sentry-cli releases new $SENTRY_RELEASE && sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps dist --log-level debug && sentry-cli releases finalize $SENTRY_RELEASE",
     "build-iframe-api": "vite --config iframe-api.vite.config.ts build",
     "watch-iframe-api": "npm run build-iframe-api -- --watch",
     "build-typings": "cross-env tsc --project tsconfig-for-iframe-api-typings.json",

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -149,7 +149,7 @@ export class IoSocketController {
                                 },
                             })
                         );
-                        ws.close();
+                        ws.end(1007, "Invalid message received!");
                         return;
                     }
 
@@ -170,7 +170,7 @@ export class IoSocketController {
                                 },
                             })
                         );
-                        ws.close();
+                        ws.end(1008, "Access refused");
                         return;
                     }
 
@@ -195,7 +195,7 @@ export class IoSocketController {
                                     },
                                 })
                             );
-                            ws.close();
+                            ws.end(1008, "Access refused");
                             return;
                         }
 
@@ -658,7 +658,7 @@ export class IoSocketController {
                         } else {
                             socketManager.emitConnectionErrorMessage(ws, ws.message);
                         }
-                        setTimeout(() => ws.close(), 0);
+                        ws.end(1000, "Error message sent");
                         return;
                     }
 

--- a/play/vite.config.ts
+++ b/play/vite.config.ts
@@ -27,12 +27,7 @@ export default defineConfig(({ mode }) => {
         },
         plugins: [
             svelte({
-                preprocess: sveltePreprocess({
-                    sourceMap: true,
-                }),
-                compilerOptions: {
-                    enableSourcemap: true,
-                },
+                preprocess: sveltePreprocess(),
                 onwarn(warning, defaultHandler) {
                     // don't warn on:
                     if (warning.code === "a11y-click-events-have-key-events") return;
@@ -58,6 +53,7 @@ export default defineConfig(({ mode }) => {
         console.info("Sentry plugin enabled");
         config.plugins.push(
             sentryVitePlugin({
+                url: env.SENTRY_URL || "https://sentry.io/",
                 org: env.SENTRY_ORG,
                 project: env.SENTRY_PROJECT,
                 // Specify the directory containing build artifacts


### PR DESCRIPTION
* Gracefully shutting down websocket connection.

Using `.end()` instead of `.close()` to close websocket connections.

Also, calling end just after sending the error message.

We hope this will fix a crash seen on this stacktrace:

```
workadventure-saas-play-1  | Error: Invalid answer received from the admin for the /api/room/access endpoint. Received: {"email":"fa696813-2228-4bb3-9ada-053656ef949c","userUuid":"fa696813-2228-4bb3-9ada-053656ef949c","tags":[],"messages":[],"textures":[],"visitCardUrl":null,"jabberId":null,"jabberPassword":null,"mucRooms":[{"name":"Connected users","url":"http://play.workadventure.test/@/wa/workadventure-premium/","type":"default","subscribe":false},{"name":"Welcome","type":"forum","url":"http://play.workadventure.test/@/wa/workadventure-premium/forum/welcome","subscribe":false}],"activatedInviteUser":true,"applications":[{"name":"Test onboarding","script":"http://extra.workadventure.localhost/tutorialv1Script.html"}],"username":null}
workadventure-saas-play-1  |     at AdminApi.fetchMemberDataByUuid (/usr/src/play/src/pusher/services/AdminApi.ts:373:15)
workadventure-saas-play-1  |     at processTicksAndRejections (node:internal/process/task_queues:95:5)
workadventure-saas-play-1  |     at async /usr/src/play/src/pusher/controllers/IoSocketController.ts:391:44
workadventure-saas-play-1  | Error: User cannot access this world
workadventure-saas-play-1  |     at /usr/src/play/src/pusher/controllers/IoSocketController.ts:465:35
workadventure-saas-play-1  |     at processTicksAndRejections (node:internal/process/task_queues:95:5)
workadventure-saas-play-1  | Could not find the GameRoom the user is leaving!
```

* Upgrade github-slug-action

Upgrading rlespinasse/github-slug-action to latest 4.2.3 version. Trying to solve an issue with Docker hub tagging of 1.16.0

* Add Sentry URL

---------