### PR TITLE
Making URLs more permissive in map editor

### DIFF
--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -61,7 +61,7 @@ const mapEditor: BaseTranslation = {
         },
         linkProperties: {
             label: "Open Link",
-            description: "Open website within Workadventure or as a new tab.",
+            description: "Open website within WorkAdventure or as a new tab.",
             linkLabel: "Link URL",
             newTabLabel: "Open in new tab",
             trigger: "Interaction",
@@ -78,6 +78,7 @@ const mapEditor: BaseTranslation = {
             policyPlaceholder: "fullscreen",
             errorEmbeddableLink: "The link is not embeddable",
             warningEmbeddableLink: "The link is not embeddable. It will open in a new tab",
+            errorInvalidUrl: 'Please enter a valid URL (starting with "https://")',
             findOutMoreHere: "Find out more here",
         },
         advancedOptions: "Advanced Options",


### PR DESCRIPTION
Now, if a URL is invalid, it is not immediately replaced by the oldValue. Instead, we display the error message but keep the invalid value active.

This can be useful because some URLs are invalid from the point of view of the server, but maybe valid from the browser. For instance: URLs pointing to internal material in a company.

Closes #3406 