### PR TITLE
Adding an error message when ending a stream because of timeout

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -299,6 +299,15 @@ const roomManager = {
                     ${JSON.stringify(room?.roomUrl)}`,
                     "debug"
                 );
+                call.write({
+                    message: {
+                        $case: "errorMessage",
+                        errorMessage: {
+                            message:
+                                "Connection lost with user. The user did not send a pong message in time. You should never see this message in the browser.",
+                        },
+                    },
+                });
                 closeConnection();
             }, PONG_TIMEOUT);
         }, PING_INTERVAL);


### PR DESCRIPTION
This error message should logically NEVER appear in the browser. If it does, we have an issue with the ping mechanism.