### PR TITLE
Switching the Jitsi room prefix by default

### DIFF
--- a/libs/shared-utils/src/Jitsi/slugify.ts
+++ b/libs/shared-utils/src/Jitsi/slugify.ts
@@ -12,7 +12,7 @@ export const slugify = (...args: (string | number)[]): string => {
         .replace(/\s+/g, "-"); // separator
 };
 
-function slugifyJitsiRoomName(roomName: string, roomId: string, noPrefix = true): string {
+function slugifyJitsiRoomName(roomName: string, roomId: string, noPrefix = false): string {
     return slugify((noPrefix ? "" : shortHash(roomId) + "-") + roomName);
 }
 

--- a/play/src/i18n/de-DE/mapEditor.ts
+++ b/play/src/i18n/de-DE/mapEditor.ts
@@ -39,7 +39,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             triggerOnClick: "Als minimiert in der unteren Leiste starten",
             triggerOnAction: "Aktionstoast mit Nachricht anzeigen",
             closable: "Kann geschlossen werden",
-            noPrefix: "Kein Jitsi-Raumnamenpräfix",
+            noPrefix: "Mit anderen Räumen teilen",
             jitsiRoomConfig: {
                 addConfig: "Option hinzufügen",
                 startWithAudioMuted: "Mit deaktiviertem Mikrofon starten",

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -42,7 +42,7 @@ const mapEditor: BaseTranslation = {
             triggerOnClick: "Start as minimized in bottom bar",
             triggerOnAction: "Show action toast with message",
             closable: "Can be closed",
-            noPrefix: "No Jitsi room name prefix",
+            noPrefix: "Share with other rooms",
             jitsiRoomConfig: {
                 addConfig: "Add an option",
                 startWithAudioMuted: "Start with microphone muted",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -40,7 +40,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             triggerOnClick: "Démarrer en mode réduit dans la barre inférieure",
             triggerOnAction: "Afficher un message d'information avec le message",
             closable: "Peut être fermé",
-            noPrefix: "Pas de préfixe de nom de salle Jitsi",
+            noPrefix: "Partager avec d'autres salles",
             jitsiRoomConfig: {
                 addConfig: "Ajouter une option",
                 startWithAudioMuted: "Démarrer avec le microphone coupé",


### PR DESCRIPTION
In the map editor, the default value for disabling Jitsi prefix was true instead of false.