### PR TITLE
Setting a white background in iframes

### DIFF
--- a/play/src/front/WebRtc/CoWebsite/SimpleCoWebsite.ts
+++ b/play/src/front/WebRtc/CoWebsite/SimpleCoWebsite.ts
@@ -76,6 +76,7 @@ export class SimpleCoWebsite implements CoWebsite {
             }
 
             this.iframe.classList.add("pixel");
+            this.iframe.style.backgroundColor = "white";
 
             const onloadPromise = new Promise<void>((resolve) => {
                 if (this.iframe) {


### PR DESCRIPTION
HTML page loaded as Iframes that don't provide a body background are transparent by default. But users expect them to have white background instead (because this is how the pages look when loaded in the browser).

Here, we apply a white background to all iframes.

Before:

![image](https://github.com/workadventure/workadventure/assets/1290952/17812a30-790d-49ec-a944-d550c3229c0b)


After:

![image](https://github.com/workadventure/workadventure/assets/1290952/fb686217-bb2c-4b6e-9101-a2b5c552e4ea)
