### PR TITLE
[scripting] Adding a way to open custom menus programmatically

### DIFF
--- a/docs/maps/api-ui.md
+++ b/docs/maps/api-ui.md
@@ -105,14 +105,22 @@ menu.remove();
 
 Please note that `registerMenuCommand` returns an object of the `Menu` class.
 
-The `Menu` class contains a single method: `remove(): void`. This will obviously remove the menu when called.
+The `Menu` class contains two methods: `remove(): void` and `open(): void`.
+
+`remove` will remove the menu when called.
+`open` will programmatically open the menu.
 
 ```ts
 class Menu {
-	/**
-	* Remove the menu
-	*/
-	remove() {};
+  /**
+   * Remove the menu
+   */
+  public remove(): void {/*...*/};
+
+  /**
+   * Programmatically open the menu
+   */
+  public open(): void {/*...*/};
 }
 ```
 

--- a/play/src/front/Api/Events/IframeEvent.ts
+++ b/play/src/front/Api/Events/IframeEvent.ts
@@ -18,7 +18,7 @@ import { isSetVariableEvent } from "./SetVariableEvent";
 import { isCreateEmbeddedWebsiteEvent, isEmbeddedWebsiteEvent } from "./EmbeddedWebsiteEvent";
 import { isLoadTilesetEvent } from "./LoadTilesetEvent";
 import { isMessageReferenceEvent, isTriggerActionMessageEvent } from "./Ui/TriggerActionMessageEvent";
-import { isMenuRegisterEvent, isUnregisterMenuEvent } from "./Ui/MenuRegisterEvent";
+import { isMenuRegisterEvent, isOpenMenuEvent, isUnregisterMenuEvent } from "./Ui/MenuEvents";
 import { isPlayerPosition } from "./PlayerPosition";
 import { isCameraSetEvent } from "./CameraSetEvent";
 import { isCameraFollowPlayerEvent } from "./CameraFollowPlayerEvent";
@@ -213,6 +213,10 @@ export const isIframeEventWrapper = z.union([
     z.object({
         type: z.literal("unregisterMenu"),
         data: isUnregisterMenuEvent,
+    }),
+    z.object({
+        type: z.literal("openMenu"),
+        data: isOpenMenuEvent,
     }),
     z.object({
         type: z.literal("setTiles"),

--- a/play/src/front/Api/Events/Ui/MenuEvents.ts
+++ b/play/src/front/Api/Events/Ui/MenuEvents.ts
@@ -23,3 +23,12 @@ export const isMenuRegisterEvent = z.object({
 });
 
 export type MenuRegisterEvent = z.infer<typeof isMenuRegisterEvent>;
+
+/**
+ * A message sent from a script to the game to open a menu
+ */
+export const isOpenMenuEvent = z.object({
+    name: z.string(),
+});
+
+export type OpenMenuEvent = z.infer<typeof isOpenMenuEvent>;

--- a/play/src/front/Api/Iframe/Ui/Menu.ts
+++ b/play/src/front/Api/Iframe/Ui/Menu.ts
@@ -1,17 +1,35 @@
 import { sendToWorkadventure } from "../IframeApiContribution";
+import { MenuOptions } from "../ui";
 
 export class Menu {
-    constructor(private menuName: string) {}
+    constructor(private menuName: string, private options: MenuOptions) {}
 
     /**
      * remove the menu
      */
-    public remove() {
+    public remove(): void {
         sendToWorkadventure({
             type: "unregisterMenu",
             data: {
                 name: this.menuName,
             },
         });
+    }
+
+    /**
+     * Programmatically open the menu
+     */
+    public open(): void {
+        if (this.options.callback) {
+            this.options.callback(this.menuName);
+        }
+        if (this.options.iframe) {
+            sendToWorkadventure({
+                type: "openMenu",
+                data: {
+                    name: this.menuName,
+                },
+            });
+        }
     }
 }

--- a/play/src/front/Api/Iframe/ui.ts
+++ b/play/src/front/Api/Iframe/ui.ts
@@ -182,50 +182,44 @@ export class WorkAdventureUiCommands extends IframeApiContribution<WorkAdventure
         commandDescriptor: string,
         options: MenuOptions | ((commandDescriptor: string) => void)
     ): Menu {
-        const menu = new Menu(commandDescriptor);
-
         if (typeof options === "function") {
-            menuCallbacks.set(commandDescriptor, options);
+            options = {
+                callback: options,
+            };
+        }
+
+        const menu = new Menu(commandDescriptor, options);
+
+        options.allowApi = options.allowApi === undefined ? options.iframe !== undefined : options.allowApi;
+
+        if (options.iframe !== undefined) {
+            sendToWorkadventure({
+                type: "registerMenu",
+                data: {
+                    name: commandDescriptor,
+                    iframe: options.iframe,
+                    options: {
+                        allowApi: options.allowApi,
+                    },
+                },
+            });
+        } else if (options.callback !== undefined) {
+            menuCallbacks.set(commandDescriptor, options.callback);
             sendToWorkadventure({
                 type: "registerMenu",
                 data: {
                     name: commandDescriptor,
                     options: {
-                        allowApi: false,
+                        allowApi: options.allowApi,
                     },
                 },
             });
         } else {
-            options.allowApi = options.allowApi === undefined ? options.iframe !== undefined : options.allowApi;
-
-            if (options.iframe !== undefined) {
-                sendToWorkadventure({
-                    type: "registerMenu",
-                    data: {
-                        name: commandDescriptor,
-                        iframe: options.iframe,
-                        options: {
-                            allowApi: options.allowApi,
-                        },
-                    },
-                });
-            } else if (options.callback !== undefined) {
-                menuCallbacks.set(commandDescriptor, options.callback);
-                sendToWorkadventure({
-                    type: "registerMenu",
-                    data: {
-                        name: commandDescriptor,
-                        options: {
-                            allowApi: options.allowApi,
-                        },
-                    },
-                });
-            } else {
-                throw new Error(
-                    "When adding a menu with WA.ui.registerMenuCommand, you must pass either an iframe or a callback"
-                );
-            }
+            throw new Error(
+                "When adding a menu with WA.ui.registerMenuCommand, you must pass either an iframe or a callback"
+            );
         }
+
         menus.set(commandDescriptor, menu);
         return menu;
     }

--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -5,6 +5,7 @@ import {
     additionnalButtonsMenu,
     handleMenuRegistrationEvent,
     handleMenuUnregisterEvent,
+    handleOpenMenuEvent,
     warningContainerStore,
 } from "../Stores/MenuStore";
 import type { PlayerInterface } from "../Phaser/Game/PlayerInterface";
@@ -416,6 +417,8 @@ class IframeListener {
                         );
                     } else if (iframeEvent.type == "unregisterMenu") {
                         handleMenuUnregisterEvent(iframeEvent.data.name);
+                    } else if (iframeEvent.type == "openMenu") {
+                        handleOpenMenuEvent(iframeEvent.data.name);
                     } else if (iframeEvent.type == "askPosition") {
                         this._askPositionStream.next(iframeEvent.data);
                     } else if (iframeEvent.type == "openInviteMenu") {

--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -52,7 +52,6 @@
         myCameraStore,
         myMicrophoneStore,
     } from "../../Stores/MyMediaStore";
-    import type { MenuItem, TranslatedMenu } from "../../Stores/MenuStore";
     import {
         activeSubMenuStore,
         menuVisiblilityStore,
@@ -159,7 +158,7 @@
     function toggleChat() {
         if (!$chatVisibilityStore) {
             menuVisiblilityStore.set(false);
-            activeSubMenuStore.set(0);
+            activeSubMenuStore.activateByIndex(0);
         }
         chatVisibilityStore.set(!$chatVisibilityStore);
     }
@@ -268,19 +267,13 @@
     function showInvite() {
         modalVisibilityStore.set(false);
 
-        const indexInviteMenu = $subMenusStore.findIndex(
-            (menu: MenuItem) => (menu as TranslatedMenu).key === SubMenusInterface.invite
-        );
-        if (indexInviteMenu === -1) {
-            console.error(`Menu key: ${SubMenusInterface.invite} was not founded in subMenusStore: `, $subMenusStore);
-            return;
-        }
-        if ($menuVisiblilityStore && $activeSubMenuStore === indexInviteMenu) {
+        const inviteMenu = subMenusStore.findByKey(SubMenusInterface.invite);
+        if ($menuVisiblilityStore && activeSubMenuStore.isActive(inviteMenu)) {
             menuVisiblilityStore.set(false);
-            activeSubMenuStore.set(0);
+            activeSubMenuStore.activateByIndex(0);
             return;
         }
-        activeSubMenuStore.set(indexInviteMenu);
+        activeSubMenuStore.activateByMenuItem(inviteMenu);
         menuVisiblilityStore.set(true);
 
         resetChatVisibility();
@@ -288,19 +281,13 @@
     }
 
     function showMenu() {
-        const indexInviteMenu = $subMenusStore.findIndex(
-            (menu: MenuItem) => (menu as TranslatedMenu).key === SubMenusInterface.profile
-        );
-        if (indexInviteMenu === -1) {
-            console.error(`Menu key: ${SubMenusInterface.profile} was not founded in subMenusStore: `, $subMenusStore);
-            return;
-        }
-        if ($menuVisiblilityStore && $activeSubMenuStore === indexInviteMenu) {
+        const profileMenu = subMenusStore.findByKey(SubMenusInterface.profile);
+        if ($menuVisiblilityStore && activeSubMenuStore.isActive(profileMenu)) {
             menuVisiblilityStore.set(false);
-            activeSubMenuStore.set(0);
+            activeSubMenuStore.activateByIndex(0);
             return;
         }
-        activeSubMenuStore.set(indexInviteMenu);
+        activeSubMenuStore.activateByMenuItem(profileMenu);
         menuVisiblilityStore.set(true);
 
         resetChatVisibility();

--- a/play/src/front/Components/Menu/Menu.svelte
+++ b/play/src/front/Components/Menu/Menu.svelte
@@ -3,7 +3,7 @@
     import { onDestroy, onMount } from "svelte";
     import type { Unsubscriber } from "svelte/store";
     import chevronImg from "../images/chevron.svg";
-    import type { TranslatedMenu, MenuItem } from "../../Stores/MenuStore";
+    import type { MenuItem } from "../../Stores/MenuStore";
     import {
         activeSubMenuStore,
         checkSubMenuToShow,
@@ -60,14 +60,7 @@
     async function switchMenu(menu: MenuItem) {
         if (menu.type === "translated") {
             activeSubMenu = menu;
-            const indexMenuSearch = $subMenusStore.findIndex(
-                (menuSearch) => (menuSearch as TranslatedMenu).key === menu.key
-            );
-            if (indexMenuSearch === -1) {
-                console.error(`Sub menu was not founded for key: ${menu.key} in the array: `, $activeSubMenuStore);
-                return;
-            }
-            activeSubMenuStore.set(indexMenuSearch);
+            activeSubMenuStore.activateByMenuItem(menu);
             switch (menu.key) {
                 case SubMenusInterface.profile:
                     activeComponent = ProfileSubMenu;
@@ -112,7 +105,7 @@
     }
 
     function closeMenu() {
-        activeSubMenuStore.set(0);
+        activeSubMenuStore.activateByIndex(0);
         menuVisiblilityStore.set(false);
     }
 

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -70,7 +70,6 @@ import {
     userIsEditorStore,
     userIsJitsiDominantSpeakerStore,
 } from "../../Stores/GameStore";
-import type { MenuItem, TranslatedMenu } from "../../Stores/MenuStore";
 import {
     activeSubMenuStore,
     contactPageStore,
@@ -1680,22 +1679,13 @@ ${escapedMessage}
 
         this.iframeSubscriptionList.push(
             iframeListener.openInviteMenuStream.subscribe(() => {
-                const indexInviteMenu = get(subMenusStore).findIndex(
-                    (menu: MenuItem) => (menu as TranslatedMenu).key === SubMenusInterface.invite
-                );
-                if (indexInviteMenu === -1) {
-                    console.error(
-                        `Menu key: ${SubMenusInterface.invite} was not founded in subMenusStore: `,
-                        get(subMenusStore)
-                    );
-                    return;
-                }
-                if (get(menuVisiblilityStore) && get(activeSubMenuStore) === indexInviteMenu) {
+                const inviteMenu = subMenusStore.findByKey(SubMenusInterface.invite);
+                if (get(menuVisiblilityStore) && activeSubMenuStore.isActive(inviteMenu)) {
                     menuVisiblilityStore.set(false);
-                    activeSubMenuStore.set(0);
+                    activeSubMenuStore.activateByIndex(0);
                     return;
                 }
-                activeSubMenuStore.set(indexInviteMenu);
+                activeSubMenuStore.activateByMenuItem(inviteMenu);
                 menuVisiblilityStore.set(true);
             })
         );

--- a/tests/tests/iframe_script.spec.ts
+++ b/tests/tests/iframe_script.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { login } from './utils/roles';
+import Menu from "./utils/menu";
+import {evaluateScript} from "./utils/scripting";
 
 test.describe('Iframe API', () => {
   test('can be called from an iframe loading a script', async ({
@@ -19,12 +21,22 @@ test.describe('Iframe API', () => {
                                                                  page,
                                                                }) => {
     await page.goto(
-        'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Metadata/customMenu.json'
+        'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json'
     );
 
     await login(page);
 
-    await page.click('#menuIcon img:first-child');
+    await evaluateScript(page, async () => {
+      await WA.onInit();
+
+      WA.ui.registerMenuCommand('custom callback menu', () => {
+        WA.chat.sendChatMessage('Custom menu clicked', 'Mr Robot');
+      })
+
+      WA.ui.registerMenuCommand('custom iframe menu', {iframe: '../Metadata/customIframeMenu.html'});
+    });
+
+    await Menu.openMenu(page);
 
     await page.click('button:has-text("custom iframe menu")');
 
@@ -33,8 +45,24 @@ test.describe('Iframe API', () => {
         .locator('p');
     await expect(iframeParagraph).toHaveText('This is an iframe in a custom menu.');
 
-    // FIXME e2e test related to chat
-    //await page.click('button:has-text("custom callback menu")');
-    //await expect(page.locator('p.other-text')).toHaveText('Custom menu clicked', {useInnerText: true});
+    await page.click('button:has-text("custom callback menu")');
+    await expect(
+        page.frameLocator('iframe#chatWorkAdventure')
+            .locator('aside.chatWindow')
+            .locator(".wa-message-body")
+    ).toContainText('Custom menu clicked');
+
+    // Now, let's add a menu item and open an iframe
+    await evaluateScript(page, async () => {
+      await WA.onInit();
+
+      const menu = WA.ui.registerMenuCommand('autoopen iframe menu', {iframe: '../Metadata/customIframeMenu.html'});
+      await menu.open();
+    });
+
+    const iframeParagraph2 = page
+        .frameLocator('.menu-submenu-container iframe')
+        .locator('p');
+    await expect(iframeParagraph2).toHaveText('This is an iframe in a custom menu.');
   });
 });

--- a/tests/tests/utils/menu.ts
+++ b/tests/tests/utils/menu.ts
@@ -14,6 +14,16 @@ class Menu {
         await expect(await page.getByRole('button', {name: 'toggle-map-editor'}).first()).toHaveClass(/border-top-light/);
     }
 
+    async openMenu(page: Page) {
+        await page.click('#menuIcon img:first-child');
+        await expect(await page.locator('#menuIcon')).toHaveClass(/border-top-light/);
+    }
+
+    async closeMenu(page: Page) {
+        await page.getByRole('button', { name: '×' }).click();
+        await expect(await page.locator('#menuIcon')).not.toHaveClass(/border-top-light/);
+    }
+
     async closeMapEditor(page: Page) {
         await page.getByRole('button', {name: 'toggle-map-editor'}).click();
         await expect(await page.getByRole('button', {name: 'toggle-map-editor'}).first()).not.toHaveClass(/border-top-light/);


### PR DESCRIPTION
A new `open()` method on the `Menu` object of the scripting API is now available. Using this method, we can force opening the menu in the custom iframe programmatically.

Example usage:

```js
const menu = WA.ui.registerMenuCommand('My menu', {iframe: 'my_iframe.html'});
await menu.open();
```