### PR TITLE
Remove hash on exit

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2170,9 +2170,7 @@ ${escapedMessage}
             return;
         }
 
-        if (roomUrl.hash) {
-            urlManager.pushStartLayerNameToUrl(roomUrl.hash);
-        }
+        urlManager.pushStartLayerNameToUrl(roomUrl.hash);
 
         if (!targetRoom.isEqual(this.room)) {
             if (this.scene.get(targetRoom.key) === null) {

--- a/play/src/front/Url/UrlManager.ts
+++ b/play/src/front/Url/UrlManager.ts
@@ -82,7 +82,12 @@ class UrlManager {
     }
 
     pushStartLayerNameToUrl(startLayerName: string): void {
-        window.location.hash = startLayerName;
+        if (startLayerName) {
+            window.location.hash = startLayerName;
+        } else {
+            // Remove the hash
+            history.pushState("", document.title, window.location.pathname + window.location.search);
+        }
     }
 
     getPlayUri(): string {


### PR DESCRIPTION
When we take an exit that has no hash in the URL, we now remove the hash from the current page.

Closes #3451