### PR TITLE
Adding a WA.ui.getMenuCommand method

### DIFF
--- a/docs/maps/api-ui.md
+++ b/docs/maps/api-ui.md
@@ -75,6 +75,7 @@ Add a custom menu item containing the text `commandDescriptor` in the navbar of 
 `options` attribute accepts an object with three properties :
 - `callback : (commandDescriptor: string) => void` : A click on the custom menu will trigger the `callback`.
 - `iframe: string` : A click on the custom menu will open the `iframe` inside the menu.
+- `key?: string` : A unique identifier for your menu item.
 - `allowApi?: boolean` : Allow the iframe of the custom menu to use the Scripting API.
 
 Important : `options` accepts only `callback` or `iframe` not both.
@@ -124,7 +125,23 @@ class Menu {
 }
 ```
 
+## Fetching a custom menu
 
+```
+WA.ui.getMenuCommand(key: string): Promise<Menu>
+```
+
+You can retrieve a menu by its key using `WA.ui.getMenuCommand`.
+You can also access the list of default menu items provided by WA.
+
+Here is the full list of pre-registered keys: "settings", "profile", "invite", "credit", "globalMessages", "contact", "report".
+
+Example: open the "invite" page from a script:
+
+```ts
+const menu = await WA.ui.getMenuCommand("invite");
+menu.open();
+```
 
 ### Awaiting User Confirmation (with space bar)
 

--- a/play/src/front/Api/Events/Ui/MenuEvents.ts
+++ b/play/src/front/Api/Events/Ui/MenuEvents.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
  * A message sent from a script to the game to remove a custom menu from the menu
  */
 export const isUnregisterMenuEvent = z.object({
-    name: z.string(),
+    key: z.string(),
 });
 
 export type UnregisterMenuEvent = z.infer<typeof isUnregisterMenuEvent>;
@@ -19,6 +19,7 @@ export const isMenuRegisterOptions = z.object({
 export const isMenuRegisterEvent = z.object({
     name: z.string(),
     iframe: z.optional(z.string()),
+    key: z.string(),
     options: isMenuRegisterOptions,
 });
 
@@ -28,7 +29,7 @@ export type MenuRegisterEvent = z.infer<typeof isMenuRegisterEvent>;
  * A message sent from a script to the game to open a menu
  */
 export const isOpenMenuEvent = z.object({
-    name: z.string(),
+    key: z.string(),
 });
 
 export type OpenMenuEvent = z.infer<typeof isOpenMenuEvent>;

--- a/play/src/front/Api/Iframe/Ui/Menu.ts
+++ b/play/src/front/Api/Iframe/Ui/Menu.ts
@@ -1,8 +1,7 @@
 import { sendToWorkadventure } from "../IframeApiContribution";
-import { MenuOptions } from "../ui";
 
 export class Menu {
-    constructor(private menuName: string, private options: MenuOptions) {}
+    constructor(private key: string) {}
 
     /**
      * remove the menu
@@ -11,25 +10,20 @@ export class Menu {
         sendToWorkadventure({
             type: "unregisterMenu",
             data: {
-                name: this.menuName,
+                key: this.key,
             },
         });
     }
 
     /**
-     * Programmatically open the menu
+     * Programmatically open the menu (only works if the menu has been defined with the "iframe" property)
      */
     public open(): void {
-        if (this.options.callback) {
-            this.options.callback(this.menuName);
-        }
-        if (this.options.iframe) {
-            sendToWorkadventure({
-                type: "openMenu",
-                data: {
-                    name: this.menuName,
-                },
-            });
-        }
+        sendToWorkadventure({
+            type: "openMenu",
+            data: {
+                key: this.key,
+            },
+        });
     }
 }

--- a/play/src/front/Api/Iframe/Ui/MenuItem.ts
+++ b/play/src/front/Api/Iframe/Ui/MenuItem.ts
@@ -1,11 +1,11 @@
 import type { MenuItemClickedEvent } from "../../Events/Ui/MenuItemClickedEvent";
 import { iframeListener } from "../../IframeListener";
 
-export function sendMenuClickedEvent(menuItem: string) {
+export function sendMenuClickedEvent(menuItemKey: string) {
     iframeListener.postMessage({
         type: "menuItemClicked",
         data: {
-            menuItem: menuItem,
+            menuItem: menuItemKey,
         } as MenuItemClickedEvent,
     });
 }

--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -412,13 +412,14 @@ class IframeListener {
                         handleMenuRegistrationEvent(
                             iframeEvent.data.name,
                             iframeEvent.data.iframe,
+                            iframeEvent.data.key,
                             foundSrc,
                             iframeEvent.data.options
                         );
                     } else if (iframeEvent.type == "unregisterMenu") {
-                        handleMenuUnregisterEvent(iframeEvent.data.name);
+                        handleMenuUnregisterEvent(iframeEvent.data.key);
                     } else if (iframeEvent.type == "openMenu") {
-                        handleOpenMenuEvent(iframeEvent.data.name);
+                        handleOpenMenuEvent(iframeEvent.data.key);
                     } else if (iframeEvent.type == "askPosition") {
                         this._askPositionStream.next(iframeEvent.data);
                     } else if (iframeEvent.type == "openInviteMenu") {

--- a/play/src/front/Components/Menu/Menu.svelte
+++ b/play/src/front/Components/Menu/Menu.svelte
@@ -92,13 +92,13 @@
                     break;
             }
         } else {
-            const customMenu = customMenuIframe.get(menu.label);
+            const customMenu = customMenuIframe.get(menu.key);
             if (customMenu !== undefined) {
                 activeSubMenu = menu;
                 props = { url: customMenu.url, allowApi: customMenu.allowApi };
                 activeComponent = CustomSubMenu;
             } else {
-                sendMenuClickedEvent(menu.label);
+                sendMenuClickedEvent(menu.key);
                 menuVisiblilityStore.set(false);
             }
         }

--- a/tests/tests/iframe_script.spec.ts
+++ b/tests/tests/iframe_script.spec.ts
@@ -64,5 +64,17 @@ test.describe('Iframe API', () => {
         .frameLocator('.menu-submenu-container iframe')
         .locator('p');
     await expect(iframeParagraph2).toHaveText('This is an iframe in a custom menu.');
+
+    await Menu.closeMenu(page);
+
+    // Now, let's test that we can open a default menu:
+    await evaluateScript(page, async () => {
+      await WA.onInit();
+
+      const menu = await WA.ui.getMenuCommand('invite');
+      await menu.open();
+    });
+
+    await expect(page.locator('.menu-container')).toContainText("Share the link of the room");
   });
 });

--- a/tests/tests/utils/menu.ts
+++ b/tests/tests/utils/menu.ts
@@ -20,7 +20,7 @@ class Menu {
     }
 
     async closeMenu(page: Page) {
-        await page.getByRole('button', { name: '×' }).click();
+        await page.locator('.menu-container').getByRole('button', { name: '×' }).click();
         await expect(await page.locator('#menuIcon')).not.toHaveClass(/border-top-light/);
     }
 


### PR DESCRIPTION
This new method allows to fetch a menu by its key. Useful to access default system menus OR menus that are created by another frame.

Also, this commit refactors the code internally in order to use "keys" instead of "labels" as an identifier for custom menu items.