### PR TITLE
Improving the layout of the title of object popup if the name is very…

### DIFF
--- a/play/src/front/Components/ActionsMenu/ActionsMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/ActionsMenu.svelte
@@ -81,6 +81,7 @@
         height: max-content !important;
         max-height: 50vh;
         margin-top: 200px;
+        overflow-y: auto;
         z-index: 425;
 
         pointer-events: auto;
@@ -105,8 +106,9 @@
         }
 
         .name {
-            max-height: 15vh;
+            max-height: 25vh;
             margin: 20px 20px 0 20px;
+            overflow-y: auto;
         }
 
         .actions::-webkit-scrollbar {


### PR DESCRIPTION
… very very long

In case it is really too long, a scrollbar will now appear (instead of the text overflowing below the popup).

Closes #3457