### PR TITLE
Allowing relative URLs to be passed to WA.ui.modal.openModal

### DIFF
--- a/play/src/front/Components/Modal/Modal.svelte
+++ b/play/src/front/Components/Modal/Modal.svelte
@@ -4,6 +4,7 @@
     import { iframeListener } from "../../Api/IframeListener";
     import { modalIframeStore, modalVisibilityStore } from "../../Stores/ModalStore";
     import { isMediaBreakpointUp } from "../../Utils/BreakpointsUtils";
+    import { gameManager } from "../../Phaser/Game/GameManager";
 
     let modalIframe: HTMLIFrameElement;
     let mainModal: HTMLDivElement;
@@ -34,6 +35,10 @@
         }
     });
 
+    let modalUrl = $modalIframeStore
+        ? new URL($modalIframeStore.src, gameManager.currentStartedRoom.mapUrl).toString()
+        : undefined;
+
     let isMobile = isMediaBreakpointUp("md");
     const resizeObserver = new ResizeObserver(() => {
         isMobile = isMediaBreakpointUp("md");
@@ -45,7 +50,7 @@
 <div class="menu-container {isMobile ? 'mobile' : $modalIframeStore?.position}" bind:this={mainModal}>
     <div class="tw-w-full tw-bg-dark-purple/95 tw-rounded" transition:fly={{ x: 1000, duration: 500 }}>
         <button type="button" class="close-window" on:click={close}>&times</button>
-        {#if $modalIframeStore?.src != undefined}
+        {#if modalUrl != undefined}
             <iframe
                 id="modalIframe"
                 bind:this={modalIframe}
@@ -53,7 +58,7 @@
                 width="100%"
                 allow={$modalIframeStore?.allow}
                 title={$modalIframeStore?.title}
-                src={$modalIframeStore?.src}
+                src={modalUrl}
                 class="tw-border-0"
             />
         {/if}

--- a/tests/tests/modal_script.spec.ts
+++ b/tests/tests/modal_script.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import {expect, test} from '@playwright/test';
 import { login } from './utils/roles';
 import {evaluateScript} from "./utils/scripting";
 import {expectInViewport} from "./utils/viewport";
@@ -18,6 +18,25 @@ test.describe('Modal', () => {
 
         // Check the component of the Webpage
         await expectInViewport("#modalIframe", page);
+
+        await evaluateScript(page, async () => {
+            WA.ui.modal.closeModal();
+        });
+
+        // Let's expect #modalIframe to not be displayed
+        await expect(page.locator('#modalIframe')).toBeVisible({
+            visible: false
+        });
+
+        // Opening a modal with a relative path
+        await evaluateScript(page, async () => {
+            return WA.ui.modal.openModal({
+                src: "../index.html"
+            });
+        });
+
+        // Check the modal is loaded
+        await expect(page.frameLocator('#modalIframe').locator("body")).toContainText("WorkAdventure test cases");
 
         //TODO fix me
         //await timeout(3000);


### PR DESCRIPTION
`WA.ui.modal.openModal` now accepts relative URLs. URLs are relative to the Tiled map path (the json/tmj file path)

Closes #3465