### PR TITLE
Sending healthcheck on /ping endpoint

### DIFF
--- a/play/Dockerfile
+++ b/play/Dockerfile
@@ -64,7 +64,7 @@ COPY --from=builder /usr/src/libs /usr/src/libs
 COPY --from=builder --chown=node:node /usr/src/play /usr/src/play
 WORKDIR /usr/src/play
 
-HEALTHCHECK --interval=10s --timeout=7s --start-period=10s --retries=15 CMD curl -f http://localhost:3000 || exit 1
+HEALTHCHECK --interval=10s --timeout=7s --start-period=10s --retries=15 CMD curl -f http://localhost:3000/ping || exit 1
 
 USER node
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
In play container, we send the healthcheck on the /ping endpoint. This will avoid triggering a request to the admin on every healthcheck.

Closes #3472 