### PR TITLE
Modifying start layer precedence order

### DIFF
--- a/docs/maps/editor/property/entry-exit.md
+++ b/docs/maps/editor/property/entry-exit.md
@@ -23,6 +23,10 @@ To do that, you must follow those instructions :
 {.alert.alert-info}
 **Pro tip**: if you expect many people to connect to your map at the same time (for instance, if you are organizing a big event), consider making a large start area. This way, users will not all appear at the same position and will not pop randomly in a chat with someone connecting at the same moment.
 
+:::info
+If your map already has start positions defined in Tiled, areas defined in the map editor will take precedence. 
+:::
+
 ## Create an exit area
 In order to let user leave your map in a defined area you will need to create an exit area.
 To do that, you must follow those instructions :

--- a/tests/tests/utils/map-editor/entityEditor.ts
+++ b/tests/tests/utils/map-editor/entityEditor.ts
@@ -18,6 +18,9 @@ class EntityEditor {
     async quitEntitySelector(page: Page){
         await page.locator('.map-editor .item-picker .item-variations img[alt="Unselect object picked"]').click();
         await expect(page.locator('.map-editor .item-picker .item-variations img[alt="Unselect object picked"]')).toHaveCount(0);
+        // That's bad, but we need to wait a bit for the canvas to put the object.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(200);
     }
 
     async addProperty(page: Page, property: string) {


### PR DESCRIPTION
Start layer is now looked into map editor areas first, then Tiled areas, then tiles / layers. Also, Tiled areas named "start" are now considered for a start position.