### PR TITLE
Adding a default start position notion in the map editor

### DIFF
--- a/docs/schema/1.0/wam.json
+++ b/docs/schema/1.0/wam.json
@@ -272,6 +272,9 @@
                         "type": {
                           "type": "string",
                           "const": "start"
+                        },
+                        "isDefault": {
+                          "type": "boolean"
                         }
                       },
                       "required": [

--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -36,6 +36,7 @@ export const SilentPropertyData = PropertyBase.extend({
 
 export const StartPropertyData = PropertyBase.extend({
     type: z.literal("start"),
+    isDefault: z.boolean().optional(),
 });
 
 export const ExitPropertyData = PropertyBase.extend({

--- a/play/src/front/Components/MapEditor/AreaPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/AreaPropertiesEditor.svelte
@@ -485,6 +485,7 @@
                     />
                 {:else if property.type === "start"}
                     <StartPropertyEditor
+                        {property}
                         on:close={() => {
                             onDeleteProperty(property.id);
                         }}

--- a/play/src/front/Components/MapEditor/AreaPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/AreaPropertiesEditor.svelte
@@ -61,6 +61,7 @@
                 return {
                     id,
                     type,
+                    isDefault: true,
                 };
             case "silent":
                 return {

--- a/play/src/front/Components/MapEditor/PropertyEditor/StartPropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/StartPropertyEditor.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
     import { createEventDispatcher } from "svelte";
+    import { StartPropertyData } from "@workadventure/map-editor";
     import { LL } from "../../../../i18n/i18n-svelte";
     import PropertyEditorBase from "./PropertyEditorBase.svelte";
     const dispatch = createEventDispatcher();
+    export let property: StartPropertyData;
+
+    function onValueChange() {
+        dispatch("change");
+    }
 </script>
 
 <PropertyEditorBase
@@ -17,5 +23,22 @@
             alt={$LL.mapEditor.properties.startProperties.description()}
         />
         {$LL.mapEditor.properties.startProperties.label()}
+    </span>
+
+    <span slot="content">
+        <div>
+            <label for="startTypeSelector">{$LL.mapEditor.properties.startProperties.type()}</label>
+            <select
+                id="startTypeSelector"
+                class="tw-w-full"
+                bind:value={property.isDefault}
+                on:change={() => {
+                    onValueChange();
+                }}
+            >
+                <option value={true}>{$LL.mapEditor.properties.startProperties.defaultMenuItem()}</option>
+                <option value={false}>{$LL.mapEditor.properties.startProperties.hashMenuItem()}</option>
+            </select>
+        </div>
     </span>
 </PropertyEditorBase>

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -101,6 +101,9 @@ const mapEditor: BaseTranslation = {
             description: "Where people can start in the map.",
             nameLabel: "Start name",
             namePlaceholder: "Enter1",
+            type: "Start position type",
+            defaultMenuItem: "Use by default",
+            hashMenuItem: "Use if URL contains #[area name]",
         },
         exitProperties: {
             label: "Exit area",


### PR DESCRIPTION
A new dropdown can be used in the map editor on the start layers to say if the layer should be used as a default start layer or not.