### PR TITLE
Fixing teleport in scripting API + chat stability

### DIFF
--- a/chat/src/IframeListener.ts
+++ b/chat/src/IframeListener.ts
@@ -39,144 +39,146 @@ const debug = Debug("chat");
 class IframeListener {
     init() {
         window.addEventListener("message", (message: MessageEvent): void => {
-            const payload = message.data;
-            const lookingLikeEvent = isLookingLikeIframeEventWrapper.safeParse(payload);
-            if (lookingLikeEvent.success) {
-                const iframeEventGuarded = isIframeEventWrapper.safeParse(lookingLikeEvent.data);
-                if (iframeEventGuarded.success) {
-                    debug(`iFrameListener => message received => ${JSON.stringify(iframeEventGuarded.data)}`);
-                    const iframeEvent = iframeEventGuarded.data;
-                    switch (iframeEvent.type) {
-                        case "settings": {
-                            chatSoundsStore.set(iframeEvent.data.chatSounds);
-                            chatNotificationsStore.set(iframeEvent.data.notification);
-                            enableChat.set(iframeEvent.data.enableChat);
-                            enableChatUpload.set(iframeEvent.data.enableChatUpload);
-                            enableChatOnlineListStore.set(iframeEvent.data.enableChatOnlineList);
-                            enableChatDisconnectedListStore.set(iframeEvent.data.enableChatDisconnectedList);
-                            break;
-                        }
-                        case "xmppSettingsMessage": {
-                            chatConnectionManager.initXmppSettings(iframeEvent.data);
-                            break;
-                        }
-                        case "userData": {
-                            iframeEvent.data.name = iframeEvent.data.name.replace(emojiRegex, "");
-                            userStore.set(iframeEvent.data);
-                            chatConnectionManager.initUser(
-                                iframeEvent.data.playUri,
-                                iframeEvent.data.uuid,
-                                iframeEvent.data.klaxoonToolActivated,
-                                iframeEvent.data.youtubeToolActivated,
-                                iframeEvent.data.googleDocsToolActivated,
-                                iframeEvent.data.googleSheetsToolActivated,
-                                iframeEvent.data.googleSlidesToolActivated,
-                                iframeEvent.data.eraserToolActivated,
-                                iframeEvent.data.authToken,
-                                iframeEvent.data.klaxoonToolClientId
-                            );
-                            if (chatConnectionManager.connection) {
-                                mucRoomsStore.sendUserInfos();
-                            }
-                            break;
-                        }
-                        case "setLocale": {
-                            setCurrentLocale(iframeEvent.data.locale as Locales).catch((err) => console.error(err));
-                            break;
-                        }
-                        case "joinMuc": {
-                            if (!get(enableChat)) {
-                                return;
-                            }
-                            chatConnectionManager.connectionOrFail?.joinMuc(
-                                iframeEvent.data.name,
-                                iframeEvent.data.url,
-                                iframeEvent.data.type,
-                                iframeEvent.data.subscribe
-                            );
-                            break;
-                        }
-                        case "leaveMuc": {
-                            if (!get(enableChat)) {
-                                return;
-                            }
-                            chatConnectionManager.connectionOrFail?.leaveMuc(iframeEvent.data.url);
-                            break;
-                        }
-                        case "updateWritingStatusChatList": {
-                            writingStatusMessageStore.set(iframeEvent.data);
-                            break;
-                        }
-                        case "addChatMessage": {
-                            if (iframeEvent.data.text == undefined) {
+            (async () => {
+                const payload = message.data;
+                const lookingLikeEvent = isLookingLikeIframeEventWrapper.safeParse(payload);
+                if (lookingLikeEvent.success) {
+                    const iframeEventGuarded = isIframeEventWrapper.safeParse(lookingLikeEvent.data);
+                    if (iframeEventGuarded.success) {
+                        debug(`iFrameListener => message received => ${JSON.stringify(iframeEventGuarded.data)}`);
+                        const iframeEvent = iframeEventGuarded.data;
+                        switch (iframeEvent.type) {
+                            case "settings": {
+                                chatSoundsStore.set(iframeEvent.data.chatSounds);
+                                chatNotificationsStore.set(iframeEvent.data.notification);
+                                enableChat.set(iframeEvent.data.enableChat);
+                                enableChatUpload.set(iframeEvent.data.enableChatUpload);
+                                enableChatOnlineListStore.set(iframeEvent.data.enableChatOnlineList);
+                                enableChatDisconnectedListStore.set(iframeEvent.data.enableChatDisconnectedList);
                                 break;
                             }
-                            const mucRoomDefault = mucRoomsStore.getDefaultRoom();
-                            let userData = undefined;
-                            if (mucRoomDefault && iframeEvent.data.author.jid !== "fake") {
-                                try {
-                                    userData = mucRoomDefault.getUserByJid(iframeEvent.data.author.jid);
-                                } catch (e) {
-                                    console.warn("Can't fetch user data from Ejabberd", e);
+                            case "xmppSettingsMessage": {
+                                chatConnectionManager.initXmppSettings(iframeEvent.data);
+                                break;
+                            }
+                            case "userData": {
+                                iframeEvent.data.name = iframeEvent.data.name.replace(emojiRegex, "");
+                                userStore.set(iframeEvent.data);
+                                chatConnectionManager.initUser(
+                                    iframeEvent.data.playUri,
+                                    iframeEvent.data.uuid,
+                                    iframeEvent.data.klaxoonToolActivated,
+                                    iframeEvent.data.youtubeToolActivated,
+                                    iframeEvent.data.googleDocsToolActivated,
+                                    iframeEvent.data.googleSheetsToolActivated,
+                                    iframeEvent.data.googleSlidesToolActivated,
+                                    iframeEvent.data.eraserToolActivated,
+                                    iframeEvent.data.authToken,
+                                    iframeEvent.data.klaxoonToolClientId
+                                );
+                                if (chatConnectionManager.connection) {
+                                    mucRoomsStore.sendUserInfos();
+                                }
+                                break;
+                            }
+                            case "setLocale": {
+                                setCurrentLocale(iframeEvent.data.locale as Locales).catch((err) => console.error(err));
+                                break;
+                            }
+                            case "joinMuc": {
+                                if (!get(enableChat)) {
+                                    return;
+                                }
+                                (await chatConnectionManager.connectionPromise).joinMuc(
+                                    iframeEvent.data.name,
+                                    iframeEvent.data.url,
+                                    iframeEvent.data.type,
+                                    iframeEvent.data.subscribe
+                                );
+                                break;
+                            }
+                            case "leaveMuc": {
+                                if (!get(enableChat)) {
+                                    return;
+                                }
+                                (await chatConnectionManager.connectionPromise).leaveMuc(iframeEvent.data.url);
+                                break;
+                            }
+                            case "updateWritingStatusChatList": {
+                                writingStatusMessageStore.set(iframeEvent.data);
+                                break;
+                            }
+                            case "addChatMessage": {
+                                if (iframeEvent.data.text == undefined) {
+                                    break;
+                                }
+                                const mucRoomDefault = mucRoomsStore.getDefaultRoom();
+                                let userData = undefined;
+                                if (mucRoomDefault && iframeEvent.data.author.jid !== "fake") {
+                                    try {
+                                        userData = mucRoomDefault.getUserByJid(iframeEvent.data.author.jid);
+                                    } catch (e) {
+                                        console.warn("Can't fetch user data from Ejabberd", e);
+                                        userData = iframeEvent.data.author;
+                                    }
+                                } else {
                                     userData = iframeEvent.data.author;
                                 }
-                            } else {
-                                userData = iframeEvent.data.author;
+                                for (const chatMessageText of iframeEvent.data.text) {
+                                    chatMessagesStore.addExternalMessage(userData, chatMessageText, userData.name);
+                                }
+                                break;
                             }
-                            for (const chatMessageText of iframeEvent.data.text) {
-                                chatMessagesStore.addExternalMessage(userData, chatMessageText, userData.name);
+                            case "comingUser": {
+                                const mucRoomDefault = mucRoomsStore.getDefaultRoom();
+                                let userData = undefined;
+                                if (mucRoomDefault && iframeEvent.data.author.jid !== "fake") {
+                                    userData = mucRoomDefault.getUserByJid(iframeEvent.data.author.jid);
+                                } else {
+                                    userData = iframeEvent.data.author;
+                                }
+                                if (ChatMessageTypes.userIncoming === iframeEvent.data.type) {
+                                    chatMessagesStore.addIncomingUser(userData);
+                                }
+                                if (ChatMessageTypes.userOutcoming === iframeEvent.data.type) {
+                                    chatMessagesStore.addOutcomingUser(userData);
+                                }
+                                break;
                             }
-                            break;
+                            case "peerConnectionStatus": {
+                                chatPeerConnectionInProgress.set(iframeEvent.data);
+                                if (iframeEvent.data) {
+                                    showTimelineStore.set(true);
+                                }
+                                break;
+                            }
+                            case "chatVisibility": {
+                                chatVisibilityStore.set(iframeEvent.data.visibility);
+                                if (!iframeEvent.data.visibility) {
+                                    activeThreadStore.reset();
+                                } else if (get(chatPeerConnectionInProgress) || get(timelineMessagesToSee) > 0) {
+                                    timelineActiveStore.set(true);
+                                } else if (mucRoomsStore.getChatZones()) {
+                                    activeThreadStore.set(mucRoomsStore.getChatZones());
+                                }
+                                break;
+                            }
+                            case "availabilityStatus": {
+                                availabilityStatusStore.set(iframeEvent.data);
+                                break;
+                            }
+                            case KLAXOON_ACTIVITY_PICKER_EVENT: {
+                                // @ts-ignore
+                                const event = new MessageEvent("AcitivityPickerFromWorkAdventure", message);
+                                window.dispatchEvent(event);
+                                break;
+                            }
                         }
-                        case "comingUser": {
-                            const mucRoomDefault = mucRoomsStore.getDefaultRoom();
-                            let userData = undefined;
-                            if (mucRoomDefault && iframeEvent.data.author.jid !== "fake") {
-                                userData = mucRoomDefault.getUserByJid(iframeEvent.data.author.jid);
-                            } else {
-                                userData = iframeEvent.data.author;
-                            }
-                            if (ChatMessageTypes.userIncoming === iframeEvent.data.type) {
-                                chatMessagesStore.addIncomingUser(userData);
-                            }
-                            if (ChatMessageTypes.userOutcoming === iframeEvent.data.type) {
-                                chatMessagesStore.addOutcomingUser(userData);
-                            }
-                            break;
-                        }
-                        case "peerConnectionStatus": {
-                            chatPeerConnectionInProgress.set(iframeEvent.data);
-                            if (iframeEvent.data) {
-                                showTimelineStore.set(true);
-                            }
-                            break;
-                        }
-                        case "chatVisibility": {
-                            chatVisibilityStore.set(iframeEvent.data.visibility);
-                            if (!iframeEvent.data.visibility) {
-                                activeThreadStore.reset();
-                            } else if (get(chatPeerConnectionInProgress) || get(timelineMessagesToSee) > 0) {
-                                timelineActiveStore.set(true);
-                            } else if (mucRoomsStore.getChatZones()) {
-                                activeThreadStore.set(mucRoomsStore.getChatZones());
-                            }
-                            break;
-                        }
-                        case "availabilityStatus": {
-                            availabilityStatusStore.set(iframeEvent.data);
-                            break;
-                        }
-                        case KLAXOON_ACTIVITY_PICKER_EVENT: {
-                            // @ts-ignore
-                            const event = new MessageEvent("AcitivityPickerFromWorkAdventure", message);
-                            window.dispatchEvent(event);
-                            break;
-                        }
+                    } else {
+                        console.error("Message structure not conform", lookingLikeEvent.data, iframeEventGuarded);
                     }
-                } else {
-                    console.error("Message structure not conform", lookingLikeEvent.data, iframeEventGuarded);
                 }
-            }
+            })().catch((e) => console.error(e));
         });
     }
 

--- a/chat/src/Xmpp/MucRoom.ts
+++ b/chat/src/Xmpp/MucRoom.ts
@@ -60,10 +60,12 @@ export class MucRoom extends AbstractRoom {
         return this.roomJid.bare;
     }
 
-    public getUserByJid(jid: string): User {
+    public getUserByJid(jid: string): User | undefined {
         const user = this.presenceStore.get(jid);
         if (!user) {
-            throw new Error("No user found for this JID");
+            //throw new Error("No user found for this JID");
+            console.error("No user found for this JID");
+            return undefined;
         }
         return get(user);
     }

--- a/chat/src/Xmpp/XmppClient.ts
+++ b/chat/src/Xmpp/XmppClient.ts
@@ -369,6 +369,12 @@ export class XmppClient {
         }));
     }
 
+    public get readyPromise(): Promise<void> {
+        return this.clientPromise.then(() => {
+            return;
+        });
+    }
+
     private xmlRestrictionsToEjabberd(element: string): void {
         // TODO IMPLEMENT RESTRICTIONS
         // Test body message length

--- a/maps/tests/E2E/livezone.json
+++ b/maps/tests/E2E/livezone.json
@@ -50,7 +50,6 @@
          "name":"floorLayer",
          "objects":[
                 {
-                 "class":"",
                  "height":116.924156284309,
                  "id":1,
                  "name":"Tests",
@@ -62,13 +61,13 @@
                      "text":"An empty map dedicated to run tests about the chat in E2E Playwright environment.",
                      "wrap":true
                     },
+                 "type":"",
                  "visible":true,
                  "width":158.381128664136,
                  "x":85.1946075358359,
                  "y":5.93109324900794
                 }, 
                 {
-                 "class":"area",
                  "height":320,
                  "id":3,
                  "name":"LiveZone",
@@ -84,10 +83,79 @@
                          "value":"liveZone"
                         }],
                  "rotation":0,
+                 "type":"area",
                  "visible":true,
                  "width":126.363636363636,
                  "x":321.818181818182,
                  "y":0
+                }, 
+                {
+                 "height":44,
+                 "id":4,
+                 "name":"LiveZone_a",
+                 "properties":[
+                        {
+                         "name":"start",
+                         "type":"bool",
+                         "value":true
+                        }],
+                 "rotation":0,
+                 "type":"area",
+                 "visible":true,
+                 "width":55,
+                 "x":361,
+                 "y":30
+                }, 
+                {
+                 "height":44,
+                 "id":6,
+                 "name":"Out_LiveZone_b",
+                 "properties":[
+                        {
+                         "name":"start",
+                         "type":"bool",
+                         "value":true
+                        }],
+                 "rotation":0,
+                 "type":"area",
+                 "visible":true,
+                 "width":55,
+                 "x":202.5,
+                 "y":237.5
+                }, 
+                {
+                 "height":44,
+                 "id":7,
+                 "name":"Out_LiveZone_a",
+                 "properties":[
+                        {
+                         "name":"start",
+                         "type":"bool",
+                         "value":true
+                        }],
+                 "rotation":0,
+                 "type":"area",
+                 "visible":true,
+                 "width":55,
+                 "x":203.5,
+                 "y":29
+                }, 
+                {
+                 "height":44,
+                 "id":8,
+                 "name":"LiveZone_b",
+                 "properties":[
+                        {
+                         "name":"start",
+                         "type":"bool",
+                         "value":true
+                        }],
+                 "rotation":0,
+                 "type":"area",
+                 "visible":true,
+                 "width":55,
+                 "x":355.5,
+                 "y":236
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -96,7 +164,7 @@
          "y":0
         }],
  "nextlayerid":9,
- "nextobjectid":4,
+ "nextobjectid":9,
  "orientation":"orthogonal",
  "properties":[
         {
@@ -110,7 +178,7 @@
          "value":true
         }],
  "renderorder":"right-down",
- "tiledversion":"1.9.1",
+ "tiledversion":"1.10.2",
  "tileheight":32,
  "tilesets":[
         {
@@ -636,6 +704,6 @@
         }],
  "tilewidth":32,
  "type":"map",
- "version":"1.9",
+ "version":"1.10",
  "width":14
 }

--- a/play/src/front/Components/App.svelte
+++ b/play/src/front/Components/App.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { afterUpdate } from "svelte";
     import type { Game } from "../Phaser/Game/Game";
     import { errorStore } from "../Stores/ErrorStore";
     import { errorScreenStore } from "../Stores/ErrorScreenStore";
@@ -13,6 +12,7 @@
     import { gameSceneIsLoadedStore } from "../Stores/GameSceneStore";
     import { mapEditorModeStore } from "../Stores/MapEditorStore";
     import { refreshPromptStore } from "../Stores/RefreshPromptStore";
+    import { forceRefreshChatStore } from "../Stores/ChatStore";
     import EnableCameraScene from "./EnableCamera/EnableCameraScene.svelte";
     import LoginScene from "./Login/LoginScene.svelte";
     import MainLayout from "./MainLayout.svelte";
@@ -28,13 +28,9 @@
 
     /**
      * When changing map from an exit on the current map, the Chat and the MainLayout are not really destroyed
-     * due to an internal issue of Svelte, this is a work-around to force the component to be reloaded
+     * due to an internal issue of Svelte, we use a #key directive to force the destruction of the components.
      * https://github.com/sveltejs/svelte/issues/5268
      */
-    let unique = {};
-    afterUpdate(() => {
-        unique = {};
-    });
 </script>
 
 {#if $errorScreenStore !== undefined}
@@ -65,7 +61,7 @@
     {#if $refreshPromptStore}
         <RefreshPrompt />
     {/if}
-    {#key unique}
+    {#key $forceRefreshChatStore}
         <Chat />
         {#if $mapEditorModeStore}
             <MapEditor />

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -38,7 +38,7 @@ export abstract class Character extends Container implements OutlineableInterfac
     protected readonly megaphoneIcon: MegaphoneIcon;
     public playerName: string;
     public sprites: Map<string, Sprite>;
-    protected lastDirection: PositionMessage_Direction = PositionMessage_Direction.DOWN;
+    protected _lastDirection: PositionMessage_Direction = PositionMessage_Direction.DOWN;
     //private teleportation: Sprite;
     private invisible: boolean;
     private clickable: boolean;
@@ -203,7 +203,7 @@ export abstract class Character extends Container implements OutlineableInterfac
      * @param shift How far from player should the point of interest be.
      */
     public getDirectionalActivationPosition(shift: number): { x: number; y: number } {
-        switch (this.lastDirection) {
+        switch (this._lastDirection) {
             case PositionMessage_Direction.DOWN: {
                 return { x: this.x, y: this.y + shift };
             }
@@ -331,29 +331,29 @@ export abstract class Character extends Container implements OutlineableInterfac
 
         if (Math.abs(body.velocity.x) > Math.abs(body.velocity.y)) {
             if (body.velocity.x < 0) {
-                this.lastDirection = PositionMessage_Direction.LEFT;
+                this._lastDirection = PositionMessage_Direction.LEFT;
             } else if (body.velocity.x > 0) {
-                this.lastDirection = PositionMessage_Direction.RIGHT;
+                this._lastDirection = PositionMessage_Direction.RIGHT;
             }
         } else {
             if (body.velocity.y < 0) {
-                this.lastDirection = PositionMessage_Direction.UP;
+                this._lastDirection = PositionMessage_Direction.UP;
             } else if (body.velocity.y > 0) {
-                this.lastDirection = PositionMessage_Direction.DOWN;
+                this._lastDirection = PositionMessage_Direction.DOWN;
             }
         }
-        this.playAnimation(this.lastDirection, true);
+        this.playAnimation(this._lastDirection, true);
 
         this.setDepth(this.y + 16);
 
         if (this.companion) {
-            this.companion.setTarget(this.x, this.y, this.lastDirection);
+            this.companion.setTarget(this.x, this.y, this._lastDirection);
         }
     }
 
     stop() {
         this.getBody().setVelocity(0, 0);
-        this.playAnimation(this.lastDirection, false);
+        this.playAnimation(this._lastDirection, false);
     }
 
     say(text: string) {
@@ -512,5 +512,9 @@ export abstract class Character extends Container implements OutlineableInterfac
      */
     public getTextureLoadedPromise(): PromiseLike<void> {
         return this.textureLoadedDeferred.promise;
+    }
+
+    public get lastDirection(): PositionMessage_Direction {
+        return this._lastDirection;
     }
 }

--- a/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
@@ -27,7 +27,6 @@ import {
     requestedMicrophoneState,
     isSpeakerStore,
 } from "../../Stores/MediaStore";
-import { urlManager } from "../../Url/UrlManager";
 import { chatZoneLiveStore } from "../../Stores/ChatStore";
 import { connectionManager } from "../../Connection/ConnectionManager";
 import { currentMegaphoneNameStore, requestedMegaphoneStore } from "../../Stores/MegaphoneStore";
@@ -299,7 +298,7 @@ export class GameMapPropertiesListener {
                 return;
             }
 
-            const playUri = urlManager.getPlayUri() + "/";
+            const playUri = this.scene.roomUrl + "/";
 
             if (oldValue !== undefined) {
                 iframeListener.sendLeaveMucEventToChatIframe(playUri + oldValue);

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -111,6 +111,7 @@ import {
     chatVisibilityStore,
     _newChatMessageSubject,
     _newChatMessageWritingStatusSubject,
+    forceRefreshChatStore,
 } from "../../Stores/ChatStore";
 import type { HasPlayerMovedInterface } from "../../Api/Events/HasPlayerMovedInterface";
 import { gameSceneIsLoadedStore, gameSceneStore } from "../../Stores/GameSceneStore";
@@ -2204,6 +2205,7 @@ ${escapedMessage}
             this.scene.stop();
             this.scene.start(targetRoom.key);
             this.scene.remove(this.scene.key);
+            forceRefreshChatStore.forceRefresh();
         } else {
             //if the exit points to the current map, we simply teleport the user back to the startLayer
             this.startPositionCalculator.initStartXAndStartY(urlManager.getStartPositionNameFromUrl());
@@ -2213,6 +2215,16 @@ ${escapedMessage}
             // clear properties in case we are moved on the same layer / area in order to trigger them
             this.gameMapFrontWrapper.clearCurrentProperties();
             this.gameMapFrontWrapper.setPosition(this.CurrentPlayer.x, this.CurrentPlayer.y);
+
+            // TODO: we should have a "teleport" parameter to explicitly say the user teleports and should not be moved in 200ms to the new place.
+            this.handleCurrentPlayerHasMovedEvent({
+                x: this.CurrentPlayer.x,
+                y: this.CurrentPlayer.y,
+                direction: this.CurrentPlayer.lastDirection,
+                moving: false,
+            });
+
+            this.markDirty();
             setTimeout(() => (this.mapTransitioning = false), 500);
         }
     }

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -487,12 +487,7 @@ export class AreasPropertiesListener {
     }
 
     private handleJoinMucRoom(name: string, type: string) {
-        iframeListener.sendJoinMucEventToChatIframe(
-            `${this.scene.roomUrl}/${slugify(name)}`,
-            name,
-            type,
-            false
-        );
+        iframeListener.sendJoinMucEventToChatIframe(`${this.scene.roomUrl}/${slugify(name)}`, name, type, false);
         chatZoneLiveStore.set(true);
     }
 

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -457,7 +457,7 @@ export class AreasPropertiesListener {
     private handleListenerMegaphonePropertyOnEnter(property: ListenerMegaphonePropertyData): void {
         if (property.speakerZoneName !== undefined) {
             const speakerZoneName = getSpeakerMegaphoneAreaName(
-                gameManager.getCurrentGameScene().getGameMap().getGameMapAreas()?.getAreas(),
+                this.scene.getGameMap().getGameMapAreas()?.getAreas(),
                 property.speakerZoneName
             );
             if (speakerZoneName) {
@@ -473,7 +473,7 @@ export class AreasPropertiesListener {
     private handleListenerMegaphonePropertyOnLeave(property: ListenerMegaphonePropertyData): void {
         if (property.speakerZoneName !== undefined) {
             const speakerZoneName = getSpeakerMegaphoneAreaName(
-                gameManager.getCurrentGameScene().getGameMap().getGameMapAreas()?.getAreas(),
+                this.scene.getGameMap().getGameMapAreas()?.getAreas(),
                 property.speakerZoneName
             );
             if (speakerZoneName) {
@@ -488,7 +488,7 @@ export class AreasPropertiesListener {
 
     private handleJoinMucRoom(name: string, type: string) {
         iframeListener.sendJoinMucEventToChatIframe(
-            `${gameManager.getCurrentGameScene().roomUrl}/${slugify(name)}`,
+            `${this.scene.roomUrl}/${slugify(name)}`,
             name,
             type,
             false
@@ -497,7 +497,7 @@ export class AreasPropertiesListener {
     }
 
     private handleLeaveMucRoom(name: string) {
-        iframeListener.sendLeaveMucEventToChatIframe(`${gameManager.getCurrentGameScene().roomUrl}/${slugify(name)}`);
+        iframeListener.sendLeaveMucEventToChatIframe(`${this.scene.roomUrl}/${slugify(name)}`);
         chatZoneLiveStore.set(false);
     }
 

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -69,15 +69,15 @@ export class Player extends Character {
     }
 
     public rotate(): void {
-        const direction = (this.lastDirection + 1) % (PositionMessage_Direction.LEFT + 1);
+        const direction = (this._lastDirection + 1) % (PositionMessage_Direction.LEFT + 1);
         this.emit(hasMovedEventName, {
             moving: false,
-            direction: (this.lastDirection + 1) % (PositionMessage_Direction.LEFT + 1),
+            direction: (this._lastDirection + 1) % (PositionMessage_Direction.LEFT + 1),
             x: this.x,
             y: this.y,
         });
-        this.lastDirection = direction;
-        this.playAnimation(this.lastDirection, false);
+        this._lastDirection = direction;
+        this.playAnimation(this._lastDirection, false);
     }
 
     public sendFollowRequest() {
@@ -154,7 +154,7 @@ export class Player extends Character {
         const moving = x !== 0 || y !== 0 || joystickMovement;
 
         // Compute direction
-        let direction = this.lastDirection;
+        let direction = this._lastDirection;
         if (moving && !joystickMovement) {
             if (Math.abs(x) > Math.abs(y)) {
                 direction = x < 0 ? PositionMessage_Direction.LEFT : PositionMessage_Direction.RIGHT;

--- a/play/src/front/Stores/ChatStore.ts
+++ b/play/src/front/Stores/ChatStore.ts
@@ -18,6 +18,20 @@ export const newChatMessageSubject = _newChatMessageSubject.asObservable();
 export const _newChatMessageWritingStatusSubject = new Subject<number>();
 export const newChatMessageWritingStatusSubject = _newChatMessageWritingStatusSubject.asObservable();
 
+// Call "forceRefresh" to force the refresh of the chat iframe.
+function createForceRefreshChatStore() {
+    const { subscribe, update } = writable({});
+    return {
+        subscribe,
+        forceRefresh() {
+            update((list) => {
+                return {};
+            });
+        },
+    };
+}
+export const forceRefreshChatStore = createForceRefreshChatStore();
+
 function getAuthor(authorId: number): PlayerInterface {
     const author = playersStore.getPlayerById(authorId);
     if (!author) {

--- a/play/src/front/Url/UrlManager.ts
+++ b/play/src/front/Url/UrlManager.ts
@@ -89,10 +89,6 @@ class UrlManager {
             history.pushState("", document.title, window.location.pathname + window.location.search);
         }
     }
-
-    getPlayUri(): string {
-        return document.location.toString();
-    }
 }
 
 export const urlManager = new UrlManager();

--- a/tests/tests/chat.spec.ts
+++ b/tests/tests/chat.spec.ts
@@ -60,12 +60,12 @@ test.describe('Chat', () => {
       // Enter in liveZone
       await Chat.slideToChat(page);
       await page.locator('#game canvas').click();
-      await Map.walkToPosition(page, 12*32, 1*32);
+      await Map.goToRoom(page, '#LiveZone_a');
       await Chat.chatZoneExist(page, 'liveZone');
 
       await Chat.slideToChat(page2);
       await page2.locator('#game canvas').click();
-      await Map.walkToPosition(page2, 12*32, 7*32);
+      await Map.goToRoom(page2, '#LiveZone_b');
       await Chat.chatZoneExist(page2, 'liveZone');
 
 
@@ -78,6 +78,7 @@ test.describe('Chat', () => {
       await Chat.AT_sendMessage(page, 'Hello, how are you ?');
       await Chat.AT_checkLastMessageSent(page);
       // Receive the message
+      await page2.pause();
       await Chat.AT_lastMessageContain(page2, 'Hello, how are you ?');
 
 
@@ -155,11 +156,11 @@ test.describe('Chat', () => {
 
       // Exit of liveZone
       await page.locator('#game canvas').click();
-      await Map.walkToPosition(page, 5*32, 1*32);
+      await Map.goToRoom(page, '#Out_LiveZone_a');
       await Chat.slideToChat(page);
       await Chat.noChatZone(page);
       await page2.locator('#game canvas').click();
-      await Map.walkToPosition(page2, 5*32, 7*32);
+      await Map.goToRoom(page2, '#Out_LiveZone_b');
       await Chat.slideToChat(page2);
       await Chat.noChatZone(page2);
     });

--- a/tests/tests/utils/map-editor/entityEditor.ts
+++ b/tests/tests/utils/map-editor/entityEditor.ts
@@ -20,7 +20,7 @@ class EntityEditor {
         await expect(page.locator('.map-editor .item-picker .item-variations img[alt="Unselect object picked"]')).toHaveCount(0);
         // That's bad, but we need to wait a bit for the canvas to put the object.
         // eslint-disable-next-line playwright/no-wait-for-timeout
-        await page.waitForTimeout(200);
+        await page.waitForTimeout(500);
     }
 
     async addProperty(page: Page, property: string) {

--- a/tests/tests/utils/map.ts
+++ b/tests/tests/utils/map.ts
@@ -19,6 +19,14 @@ class Map {
             y,
         });
     }
+
+    async goToRoom(page: Page, room: string){
+        await evaluateScript(page, async ({ room }) => {
+            WA.nav.goToRoom(room);
+        }, {
+            room,
+        });
+    }
 }
 
 export default new Map();


### PR DESCRIPTION
Now, a teleport does not trigger a full chat reload anymore. Nor opening the map editor.

In addition, the teleport fix made apparent a bug in the liveZones + maps with hash URLs and another issue where the chat was reloaded when the map editor was opened.