### PR TITLE
Adding data: protocol to allowed font-src

### DIFF
--- a/play/index.html
+++ b/play/index.html
@@ -13,7 +13,7 @@
         />
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';" />
+            content="default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; font-src * data: ; frame-src *; style-src * 'unsafe-inline';" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
         <!-- TRACK CODE -->


### PR DESCRIPTION
In the Content-Security-Policy, we explicitly allow the "data:" protocol for fonts.

This should remove this warning:

![image](https://github.com/workadventure/workadventure/assets/1290952/f2e7589d-4a6a-48e8-a5a0-02b03f50a56a)
