### PR TITLE
Adding new eslint svelte/no-ignored-unsubscribe rule to the project

### DIFF
--- a/chat/.eslintrc.js
+++ b/chat/.eslintrc.js
@@ -64,6 +64,7 @@ module.exports = {
 
         "svelte/require-each-key": "error",
         "svelte/valid-compile": [ "error", { 'ignoreWarnings': true } ],
+        "svelte/no-ignored-unsubscribe": "error",
     },
     "settings": {
         "typescript": true,

--- a/chat/package.json
+++ b/chat/package.json
@@ -22,7 +22,7 @@
     "eslint-import-resolver-typescript": "^3.5.3",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-rxjs": "^5.0.3",
-    "eslint-plugin-svelte": "^2.33.2",
+    "eslint-plugin-svelte": "^2.34.0",
     "jasmine": "^3.5.0",
     "lint-staged": "^12.3.7",
     "npm-run-all": "^4.1.5",

--- a/chat/src/IframeListener.ts
+++ b/chat/src/IframeListener.ts
@@ -285,7 +285,7 @@ export const iframeListener = new IframeListener();
 
 /* @deprecated with new service chat messagerie */
 //publish new message when user send message in chat timeline
-//eslint-disable-next-line rxjs/no-ignored-subscription
+//eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
 newChatMessageSubject.subscribe((message) => {
     window.parent.postMessage(
         {
@@ -296,7 +296,7 @@ newChatMessageSubject.subscribe((message) => {
     );
 });
 
-//eslint-disable-next-line rxjs/no-ignored-subscription
+//eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
 newChatMessageWritingStatusSubject.subscribe((status) => {
     window.parent.postMessage(
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,7 +207,7 @@
         "eslint-import-resolver-typescript": "^3.5.3",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-rxjs": "^5.0.3",
-        "eslint-plugin-svelte": "^2.33.2",
+        "eslint-plugin-svelte": "^2.34.0",
         "jasmine": "^3.5.0",
         "lint-staged": "^12.3.7",
         "npm-run-all": "^4.1.5",
@@ -12030,9 +12030,9 @@
       "dev": true
     },
     "node_modules/eslint-plugin-svelte": {
-      "version": "2.33.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.33.2.tgz",
-      "integrity": "sha512-knWmauax+E/jvQ9CmuX5dAhQKP9P4eGQZxWa5RMutEJVCcy0wFmiUvOeDND2jR4vUkbDlX4khKjaceY7QzbkYw==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.34.0.tgz",
+      "integrity": "sha512-4RYUgNai7wr0v+T/kljMiYSjC/oqwgq5i+cPppawryAayj4C7WK1ixFlWCGmNmBppnoKCl4iA4ZPzPtlHcb4CA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -24330,7 +24330,7 @@
         "eslint-import-resolver-typescript": "^3.5.3",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-rxjs": "^5.0.3",
-        "eslint-plugin-svelte": "^2.33.2",
+        "eslint-plugin-svelte": "^2.34.0",
         "jsdom": "^20.0.1",
         "lint-staged": "^12.3.7",
         "postcss": "^8.4.17",
@@ -33916,9 +33916,9 @@
       }
     },
     "eslint-plugin-svelte": {
-      "version": "2.33.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.33.2.tgz",
-      "integrity": "sha512-knWmauax+E/jvQ9CmuX5dAhQKP9P4eGQZxWa5RMutEJVCcy0wFmiUvOeDND2jR4vUkbDlX4khKjaceY7QzbkYw==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.34.0.tgz",
+      "integrity": "sha512-4RYUgNai7wr0v+T/kljMiYSjC/oqwgq5i+cPppawryAayj4C7WK1ixFlWCGmNmBppnoKCl4iA4ZPzPtlHcb4CA==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -43056,7 +43056,7 @@
         "eslint-import-resolver-typescript": "^3.5.3",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-rxjs": "^5.0.3",
-        "eslint-plugin-svelte": "^2.33.2",
+        "eslint-plugin-svelte": "^2.34.0",
         "fast-deep-equal": "^3.1.3",
         "google-protobuf": "^3.21.0",
         "hyper-express": "^6.4.11",
@@ -43311,7 +43311,7 @@
         "eslint-import-resolver-typescript": "^3.5.3",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-rxjs": "^5.0.3",
-        "eslint-plugin-svelte": "^2.33.2",
+        "eslint-plugin-svelte": "^2.34.0",
         "highlight-words": "^1.2.0",
         "jasmine": "^3.5.0",
         "lint-staged": "^12.3.7",

--- a/play/.eslintrc.js
+++ b/play/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
         "import/default": "off",
         "import/no-named-as-default": "off",
         "import/no-named-as-default-member": "off",
+        "svelte/no-ignored-unsubscribe": "error",
     },
     "settings": {
         /*"svelte3/typescript": () => require('typescript'),

--- a/play/package.json
+++ b/play/package.json
@@ -76,7 +76,7 @@
     "eslint-import-resolver-typescript": "^3.5.3",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-rxjs": "^5.0.3",
-    "eslint-plugin-svelte": "^2.33.2",
+    "eslint-plugin-svelte": "^2.34.0",
     "jsdom": "^20.0.1",
     "lint-staged": "^12.3.7",
     "postcss": "^8.4.17",

--- a/play/src/front/Administration/UserMessageManager.ts
+++ b/play/src/front/Administration/UserMessageManager.ts
@@ -9,7 +9,7 @@ class UserMessageManager {
 
     constructor() {
         // Not unsubscribing is ok, this is a singleton.
-        //eslint-disable-next-line rxjs/no-ignored-subscription
+        //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
         adminMessagesService.messageStream.subscribe((event) => {
             if (event.type === AdminMessageEventTypes.admin) {
                 textMessageStore.addMessage(event.text);

--- a/play/src/front/Api/Desktop/index.ts
+++ b/play/src/front/Api/Desktop/index.ts
@@ -36,6 +36,8 @@ class DesktopApi {
             }
         });
 
+        // Not unsubscribing is ok, this is a singleton.
+        //eslint-disable-next-line svelte/no-ignored-unsubscribe
         silentStore.subscribe((silent) => {
             this.isSilent = silent;
         });

--- a/play/src/front/Api/Iframe/AbstractState.ts
+++ b/play/src/front/Api/Iframe/AbstractState.ts
@@ -12,7 +12,7 @@ export abstract class AbstractWorkadventureStateCommands {
         //super();
 
         // Not unsubscribing is ok, this is two singletons never destroyed.
-        //eslint-disable-next-line rxjs/no-ignored-subscription
+        //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
         this.setVariableResolvers.subscribe((event) => {
             // const oldValue = this.variables.get(event.key);
             // If we are setting the same value, no need to do anything.

--- a/play/src/front/Components/Video/VideoOffBox.svelte
+++ b/play/src/front/Components/Video/VideoOffBox.svelte
@@ -17,7 +17,6 @@
     import BanReportBox from "./BanReportBox.svelte";
     import { srcObject } from "./utils";
 
-    let videoContainer: HTMLDivElement;
     let videoElement: HTMLVideoElement;
     export let peer: VideoPeer;
     export let clickable = false;
@@ -76,7 +75,6 @@
 
 <div
     class="video-container video-off"
-    bind:this={videoContainer}
     on:click={() => (clickable ? highlightedEmbedScreen.toggleHighlight(embedScreen) : null)}
 >
     <div

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -296,7 +296,7 @@ class ConnectionManager {
             });
 
             // The roomJoinedMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-            //eslint-disable-next-line rxjs/no-ignored-subscription
+            //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
             connection.connectionErrorStream.subscribe((event: CloseEvent) => {
                 console.info(
                     "An error occurred while connecting to socket server. Retrying => Event: ",
@@ -335,7 +335,7 @@ class ConnectionManager {
             });
 
             // The roomJoinedMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-            //eslint-disable-next-line rxjs/no-ignored-subscription
+            //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
             connection.roomJoinedMessageStream.subscribe((connect: OnConnectInterface) => {
                 resolve(connect);
             });

--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -1,6 +1,6 @@
 import { EntityData, EntityDataProperties, EntityPrefabRef, WAMEntityData } from "@workadventure/map-editor";
 import { Observable, Subject } from "rxjs";
-import { get } from "svelte/store";
+import { get, Unsubscriber } from "svelte/store";
 import { z } from "zod";
 import { actionsMenuStore } from "../../../Stores/ActionsMenuStore";
 import {
@@ -57,6 +57,7 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
     private activatableEntities: Entity[];
 
     private properties: Map<string, string | boolean | number>;
+    private actionsMenuStoreUnsubscriber: Unsubscriber;
 
     /**
      * Firing on map change, containing newest collision grid array
@@ -75,7 +76,7 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
         this.properties = new Map<string, string | boolean | number>();
 
         // clear properties immediately on every ActionsMenu change
-        actionsMenuStore.subscribe((data) => {
+        this.actionsMenuStoreUnsubscriber = actionsMenuStore.subscribe((data) => {
             this.clearProperties();
             this.gameMapFrontWrapper.handleEntityActionTrigger();
         });
@@ -409,5 +410,9 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
 
     public clearProperties(): void {
         this.properties.clear();
+    }
+
+    public close() {
+        this.actionsMenuStoreUnsubscriber();
     }
 }

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -1169,4 +1169,8 @@ export class GameMapFrontWrapper {
         }
         return properties;
     }
+
+    public close() {
+        this.entitiesManager.close();
+    }
 }

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -226,6 +226,7 @@ export class GameScene extends DirtyScene {
     private refreshPromptStoreStoreUnsubscriber!: Unsubscriber;
 
     private modalVisibilityStoreUnsubscriber!: Unsubscriber;
+    private unsubscribers: Unsubscriber[] = [];
 
     mapUrlFile!: string;
     wamUrlFile?: string;
@@ -950,7 +951,7 @@ export class GameScene extends DirtyScene {
                 userIsEditorStore.set(this.connection.hasTag("editor"));
 
                 // The userJoinedMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.userJoinedMessageStream.subscribe((message) => {
                     this.remotePlayersRepository.addPlayer(message);
 
@@ -969,7 +970,7 @@ export class GameScene extends DirtyScene {
                 });
 
                 // The userMovedMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.userMovedMessageStream.subscribe((message) => {
                     this.remotePlayersRepository.movePlayer(message);
                     const position = message.position;
@@ -986,7 +987,7 @@ export class GameScene extends DirtyScene {
                 });
 
                 // The userLeftMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.userLeftMessageStream.subscribe((message) => {
                     this.remotePlayersRepository.removePlayer(message.userId);
                     this.playersEventDispatcher.postMessage({
@@ -996,7 +997,7 @@ export class GameScene extends DirtyScene {
                 });
 
                 // The refreshRoomMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.refreshRoomMessageStream.subscribe((message) => {
                     refreshPromptStore.set({
                         timeToRefresh: message.timeToRefresh,
@@ -1004,7 +1005,7 @@ export class GameScene extends DirtyScene {
                 });
 
                 // The playerDetailsUpdatedMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.playerDetailsUpdatedMessageStream.subscribe((message) => {
                     // Is this message for me (exceptionally, we can use this stream to send messages to users
                     // who share the same UUID as us)
@@ -1017,7 +1018,7 @@ export class GameScene extends DirtyScene {
                 });
 
                 // The groupUpdateMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.groupUpdateMessageStream.subscribe(
                     (groupPositionMessage: GroupCreatedUpdatedMessageInterface) => {
                         this.shareGroupPosition(groupPositionMessage);
@@ -1025,7 +1026,7 @@ export class GameScene extends DirtyScene {
                 );
 
                 // The groupDeleteMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.groupDeleteMessageStream.subscribe((message) => {
                     try {
                         this.deleteGroup(message.groupId);
@@ -1043,7 +1044,7 @@ export class GameScene extends DirtyScene {
                 hideConnectionIssueMessage();
 
                 // The itemEventMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.itemEventMessageStream.subscribe((message) => {
                     const item = this.actionableItems.get(message.itemId);
                     if (item === undefined) {
@@ -1058,13 +1059,13 @@ export class GameScene extends DirtyScene {
                 });
 
                 // The groupUsersUpdateMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.groupUsersUpdateMessageStream.subscribe((message) => {
                     this.currentPlayerGroupId = message.groupId;
                 });
 
                 // The joinMucRoomMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.joinMucRoomMessageStream.subscribe((mucRoomDefinitionMessage) => {
                     iframeListener.sendJoinMucEventToChatIframe(
                         mucRoomDefinitionMessage.url,
@@ -1075,13 +1076,13 @@ export class GameScene extends DirtyScene {
                 });
 
                 // The leaveMucRoomMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.leaveMucRoomMessageStream.subscribe((leaveMucRoomMessage) => {
                     iframeListener.sendLeaveMucEventToChatIframe(leaveMucRoomMessage.url);
                 });
 
                 // The worldFullMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.messageSubscription = this.connection.worldFullMessageStream.subscribe((message) => {
                     this.showWorldFullError(message);
                 });
@@ -1153,7 +1154,7 @@ export class GameScene extends DirtyScene {
                 );
 
                 // The xmppSettingsMessageStream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.xmppSettingsMessageStream.subscribe((xmppSettingsMessage) => {
                     if (xmppSettingsMessage) {
                         iframeListener.sendXmppSettingsToChatIframe(xmppSettingsMessage);
@@ -1164,7 +1165,7 @@ export class GameScene extends DirtyScene {
                 this._broadcastService = broadcastService;
 
                 // The megaphoneSettingsMessageStream is completed in the RoomConnection. No need to unsubscribe.
-                //eslint-disable-next-line rxjs/no-ignored-subscription
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.megaphoneSettingsMessageStream.subscribe((megaphoneSettingsMessage) => {
                     if (megaphoneSettingsMessage) {
                         megaphoneCanBeUsedStore.set(megaphoneSettingsMessage.enabled);
@@ -1326,21 +1327,29 @@ export class GameScene extends DirtyScene {
             //this.reposition();
         });
 
-        requestedCameraState.subscribe((state) => {
-            this.connection?.emitCameraState(state);
-        });
+        this.unsubscribers.push(
+            requestedCameraState.subscribe((state) => {
+                this.connection?.emitCameraState(state);
+            })
+        );
 
-        requestedMicrophoneState.subscribe((state) => {
-            this.connection?.emitMicrophoneState(state);
-        });
+        this.unsubscribers.push(
+            requestedMicrophoneState.subscribe((state) => {
+                this.connection?.emitMicrophoneState(state);
+            })
+        );
 
-        requestedScreenSharingState.subscribe((state) => {
-            this.connection?.emitScreenSharingState(state);
-        });
+        this.unsubscribers.push(
+            requestedScreenSharingState.subscribe((state) => {
+                this.connection?.emitScreenSharingState(state);
+            })
+        );
 
-        megaphoneEnabledStore.subscribe((state) => {
-            this.connection?.emitMegaphoneState(state);
-        });
+        this.unsubscribers.push(
+            megaphoneEnabledStore.subscribe((state) => {
+                this.connection?.emitMegaphoneState(state);
+            })
+        );
 
         const talkIconVolumeTreshold = 10;
         let oldPeersNumber = 0;
@@ -2033,6 +2042,7 @@ ${escapedMessage}
                             for (const layer of this.Map.layers) {
                                 layer.tilemapLayer.destroy(false);
                             }
+                            this.gameMapFrontWrapper?.close();
                             //Create a new GameMap with the changed file
                             this.gameMapFrontWrapper = new GameMapFrontWrapper(
                                 this,
@@ -2322,11 +2332,16 @@ ${escapedMessage}
         this.emoteUnsubscriber?.();
         this.emoteMenuUnsubscriber?.();
         this.followUsersColorStoreUnsubscriber?.();
+        this.modalVisibilityStoreUnsubscriber?.();
         this.highlightedEmbedScreenUnsubscriber?.();
         this.embedScreenLayoutStoreUnsubscriber?.();
         this.userIsJitsiDominantSpeakerStoreUnsubscriber?.();
         this.jitsiParticipantsCountStoreUnsubscriber?.();
         this.availabilityStatusStoreUnsubscriber?.();
+        for (const unsubscriber of this.unsubscribers) {
+            unsubscriber();
+        }
+        this.unsubscribers = [];
         iframeListener.unregisterAnswerer("getState");
         iframeListener.unregisterAnswerer("loadTileset");
         iframeListener.unregisterAnswerer("getMapData");
@@ -2348,6 +2363,7 @@ ${escapedMessage}
         this.areaManager?.close();
         this.playersEventDispatcher.cleanup();
         this.playersMovementEventDispatcher.cleanup();
+        this.gameMapFrontWrapper?.close();
 
         //When we leave game, the camera is stop to be reopen after.
         // I think that we could keep camera status and the scene can manage camera setup

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -275,7 +275,7 @@ export class MapEditorModeManager {
     public subscribeToRoomConnection(connection: RoomConnection): void {
         const limit = pLimit(1);
         // The editMapCommandMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-        //eslint-disable-next-line rxjs/no-ignored-subscription
+        //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
         connection.editMapCommandMessageStream.subscribe((editMapCommandMessage) => {
             limit(async () => {
                 if (editMapCommandMessage.editMapMessage?.message?.$case === "errorCommandMessage") {

--- a/play/src/front/Phaser/Game/SharedVariablesManager.ts
+++ b/play/src/front/Phaser/Game/SharedVariablesManager.ts
@@ -43,7 +43,7 @@ export class SharedVariablesManager {
         }
 
         // The variableMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
-        //eslint-disable-next-line rxjs/no-ignored-subscription
+        //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
         roomConnection.variableMessageStream.subscribe(({ name, value }) => {
             if (JSON.stringify(value) === JSON.stringify(this._variables.get(name))) {
                 return;

--- a/play/src/front/Phaser/Game/UI/UIWebsiteManager.ts
+++ b/play/src/front/Phaser/Game/UI/UIWebsiteManager.ts
@@ -7,7 +7,7 @@ import { uiWebsitesStore } from "../../../Stores/UIWebsiteStore";
 class UIWebsiteManager {
     constructor() {
         // This is a singleton, so we subscribe to iframeListener only once and never unsubscribe.
-        //eslint-disable-next-line rxjs/no-ignored-subscription
+        //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
         iframeListener.modifyUIWebsiteStream.subscribe((websiteEvent: ModifyUIWebsiteEvent) => {
             const website = get(uiWebsitesStore).find((currentWebsite) => currentWebsite.id === websiteEvent.id);
             if (!website) {

--- a/play/src/front/Stores/AudioManagerStore.ts
+++ b/play/src/front/Stores/AudioManagerStore.ts
@@ -105,6 +105,8 @@ export const audioManagerVolumeStore = createAudioManagerVolumeStore();
 
 export const audioManagerFileStore = createAudioManagerFileStore();
 
+// Not unsubscribing is ok, this is a singleton.
+//eslint-disable-next-line svelte/no-ignored-unsubscribe
 peerStore.subscribe((peers) => {
     audioManagerVolumeStore.setTalking(peers.size > 0);
 });

--- a/play/src/front/Stores/EmoteStore.ts
+++ b/play/src/front/Stores/EmoteStore.ts
@@ -65,6 +65,8 @@ export const emoteDataStore = createEmoteDataStore();
 export const emoteDataStoreLoading = writable<boolean>(false);
 
 //subscribe to update localstorage favorite emoji
+// This is a singleton, so we don't need to unsubscribe.
+// eslint-disable-next-line svelte/no-ignored-unsubscribe
 emoteDataStore.subscribe((map: Map<number, Emoji>) => {
     localUserStore.setEmojiFavorite(map);
 });

--- a/play/src/front/Stores/GuestMenuStore.ts
+++ b/play/src/front/Stores/GuestMenuStore.ts
@@ -1,4 +1,4 @@
-import { writable } from "svelte/store";
+import { get, writable } from "svelte/store";
 import { gameManager } from "../Phaser/Game/GameManager";
 import { startLayerNamesStore } from "./StartLayerNamesStore";
 
@@ -15,19 +15,13 @@ export async function copyLink() {
 }
 
 export function getLink(): string {
-    let startLayerName: string[] = [];
-    startLayerNamesStore.subscribe((value) => {
-        startLayerName = value;
-    });
+    const startLayerName: string[] = get(startLayerNamesStore);
     const entryPoint: string | null = startLayerName.length > 0 ? startLayerName[0] : null;
     try {
         const currentPlayer = gameManager.getCurrentGameScene().CurrentPlayer;
         const playerPos = { x: Math.floor(currentPlayer.x), y: Math.floor(currentPlayer.y) };
 
-        let walkAutomatically = false;
-        walkAutomaticallyStore.subscribe((value) => {
-            walkAutomatically = value;
-        });
+        const walkAutomatically = get(walkAutomaticallyStore);
 
         return `${getRoomId()}${entryPoint ? `#${entryPoint}` : ""}${
             walkAutomatically ? `&moveTo=${playerPos.x},${playerPos.y}` : ""
@@ -40,13 +34,6 @@ export function getLink(): string {
 
 export function getRoomId(): string {
     return `${location.origin}${location.pathname}`;
-}
-
-export function updateInputFieldValue() {
-    const input = document.getElementById("input-share-link");
-    if (input && input instanceof HTMLInputElement) {
-        input.value = getLink();
-    }
 }
 
 export const canShare = navigator.share !== undefined;

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -529,6 +529,7 @@ export const localStreamStore = derived<Readable<MediaStreamConstraints>, LocalS
                         return stream;
                     })
                     .catch((e) => {
+                        console.error("BAAAAAAAAAAAAAAAAAAAA", e);
                         if (constraints.video !== false /* || constraints.audio !== false*/) {
                             console.info(
                                 "Error. Unable to get microphone and/or camera access. Trying audio only.",
@@ -778,6 +779,8 @@ function isConstrainDOMStringParameters(param: ConstrainDOMString): param is Con
 }
 
 // TODO: detect the new webcam and automatically switch on it.
+// It is ok to not unsubscribe to this store because it is a singleton.
+// eslint-disable-next-line svelte/no-ignored-unsubscribe
 cameraListStore.subscribe((devices) => {
     // Store not initialized yet
     if (devices === undefined) {
@@ -799,6 +802,8 @@ cameraListStore.subscribe((devices) => {
     }
 });
 
+// It is ok to not unsubscribe to this store because it is a singleton.
+// eslint-disable-next-line svelte/no-ignored-unsubscribe
 microphoneListStore.subscribe((devices) => {
     // Store not initialized yet
     if (devices === undefined) {
@@ -818,11 +823,14 @@ microphoneListStore.subscribe((devices) => {
     // If we cannot find the device ID, let's remove it.
     if (isConstrainDOMStringParameters(deviceId)) {
         if (!devices.find((device) => device.deviceId === deviceId.exact)) {
+            console.log("Microphone unplugged, removing constraint on deviceId");
             requestedMicrophoneDeviceIdStore.set(undefined);
         }
     }
 });
 
+// It is ok to not unsubscribe to this store because it is a singleton.
+// eslint-disable-next-line svelte/no-ignored-unsubscribe
 localStreamStore.subscribe((streamResult) => {
     if (streamResult.type === "error") {
         if (streamResult.error.name === BrowserTooOldError.NAME || streamResult.error.name === WebviewOnOldIOS.NAME) {
@@ -833,6 +841,8 @@ localStreamStore.subscribe((streamResult) => {
 
 // When the stream is initialized, the new sound constraint is recreated and the first speaker is set.
 // If the user did not select the new speaker, the first new speaker cannot be selected automatically.
+// It is ok to not unsubscribe to this store because it is a singleton.
+// eslint-disable-next-line svelte/no-ignored-unsubscribe
 speakerSelectedStore.subscribe((speaker) => {
     const oldValue = localUserStore.getSpeakerDeviceId();
     const currentValue = speaker;

--- a/play/src/front/Stores/MenuStore.ts
+++ b/play/src/front/Stores/MenuStore.ts
@@ -110,6 +110,8 @@ function createSubMenusStore() {
     ]);
     const { subscribe, update } = store;
 
+    // It is ok to not unsubscribe to this store because the function is called only once
+    // eslint-disable-next-line svelte/no-ignored-unsubscribe
     inviteUserActivated.subscribe((value) => {
         //update menu tab
         update((valuesSubMenusStore) => {
@@ -318,6 +320,9 @@ function createAdditionalButtonsMenu() {
 export const additionnalButtonsMenu = createAdditionalButtonsMenu();
 export const addClassicButtonActionBarEvent = writable<AddClassicButtonActionBarEvent[]>([]);
 export const addActionButtonActionBarEvent = writable<AddActionButtonActionBarEvent[]>([]);
+
+// It is ok to not unsubscribe to this store because it is a singleton.
+// eslint-disable-next-line svelte/no-ignored-unsubscribe
 additionnalButtonsMenu.subscribe((map) => {
     addClassicButtonActionBarEvent.set(
         [...map.values()].filter((c) => c.type === "button") as AddClassicButtonActionBarEvent[]

--- a/play/src/front/Stores/PlayersStore.ts
+++ b/play/src/front/Stores/PlayersStore.ts
@@ -21,7 +21,7 @@ function createPlayersStore() {
             players = new Map<number, PlayerInterface>();
             set(players);
             // The userJoinedMessageStream and userLeftMessageStream streams are completed in the RoomConnection. No need to unsubscribe.
-            //eslint-disable-next-line rxjs/no-ignored-subscription
+            //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
             roomConnection.userJoinedMessageStream.subscribe((message) => {
                 update((users) => {
                     users.set(message.userId, {
@@ -39,7 +39,7 @@ function createPlayersStore() {
                     return users;
                 });
             });
-            //eslint-disable-next-line rxjs/no-ignored-subscription
+            //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
             roomConnection.userLeftMessageStream.subscribe((message) => {
                 update((users) => {
                     users.delete(message.userId);

--- a/play/src/front/Stores/PrivacyShutdownStore.ts
+++ b/play/src/front/Stores/PrivacyShutdownStore.ts
@@ -10,6 +10,8 @@ function createPrivacyShutdownStore() {
 
     const { subscribe, set } = writable(privacyEnabled);
 
+    // It is ok to not unsubscribe to this store because it is a singleton.
+    // eslint-disable-next-line svelte/no-ignored-unsubscribe
     visibilityStore.subscribe((isVisible) => {
         if (!isVisible && get(peerStore).size === 0) {
             privacyEnabled = true;
@@ -21,6 +23,8 @@ function createPrivacyShutdownStore() {
         }
     });
 
+    // It is ok to not unsubscribe to this store because it is a singleton.
+    // eslint-disable-next-line svelte/no-ignored-unsubscribe
     peerStore.subscribe((peers) => {
         if (peers.size === 0 && get(visibilityStore) === false) {
             privacyEnabled = true;

--- a/play/src/front/Stores/VideoFocusStore.ts
+++ b/play/src/front/Stores/VideoFocusStore.ts
@@ -30,6 +30,8 @@ function createVideoFocusStore() {
 
 export const videoFocusStore = createVideoFocusStore();
 
+// It is ok to not unsubscribe to this store because it is a singleton.
+// eslint-disable-next-line svelte/no-ignored-unsubscribe
 peerStore.subscribe((peers) => {
     const focusedMedia: Streamable | null = get(videoFocusStore);
     if (focusedMedia instanceof JitsiTrackStreamWrapper) {

--- a/play/src/front/WebRtc/CoWebsiteManager.ts
+++ b/play/src/front/WebRtc/CoWebsiteManager.ts
@@ -1,5 +1,5 @@
 import { Subject } from "rxjs";
-import type { Readable, Writable } from "svelte/store";
+import type { Readable, Unsubscriber, Writable } from "svelte/store";
 import { get, writable } from "svelte/store";
 import type CancelablePromise from "cancelable-promise";
 import { randomDelay } from "@workadventure/shared-utils/src/RandomDelay/RandomDelay";
@@ -71,6 +71,9 @@ class CoWebsiteManager {
         }
     });
 
+    private mainCoWebsiteUnsubscriber: Unsubscriber;
+    private highlightedEmbedScreenUnsubscriber: Unsubscriber;
+
     public getMainState() {
         return get(this.openedMain);
     }
@@ -135,7 +138,7 @@ class CoWebsiteManager {
             trails: undefined,
         };
 
-        mainCoWebsite.subscribe((coWebsite) => {
+        this.mainCoWebsiteUnsubscriber = mainCoWebsite.subscribe((coWebsite) => {
             this.buttonCloseCoWebsite.hidden = !coWebsite?.isClosable() ?? false;
         });
 
@@ -172,7 +175,7 @@ class CoWebsiteManager {
 
         const buttonSwipe = HtmlUtils.getElementByIdOrFail(cowebsiteSwipeButtonId);
 
-        highlightedEmbedScreen.subscribe((value) => {
+        this.highlightedEmbedScreenUnsubscriber = highlightedEmbedScreen.subscribe((value) => {
             if (!value || value.type !== "cowebsite") {
                 buttonSwipe.style.display = "none";
                 return;
@@ -200,6 +203,8 @@ class CoWebsiteManager {
 
     public cleanup(): void {
         this.closeCoWebsites();
+        this.mainCoWebsiteUnsubscriber();
+        this.highlightedEmbedScreenUnsubscriber();
     }
 
     public getCoWebsiteBuffer(): HTMLDivElement {

--- a/play/src/front/WebRtc/MediaManager.ts
+++ b/play/src/front/WebRtc/MediaManager.ts
@@ -40,6 +40,8 @@ export class MediaManager {
                 throw new Error("Cannot load locale on media manager");
             })
             .finally(() => {
+                // It is ok to not unsubscribe to this store because it is a singleton.
+                // eslint-disable-next-line svelte/no-ignored-unsubscribe
                 localStreamStore.subscribe((result) => {
                     if (result.type === "error") {
                         if (result.error.name !== MediaStreamConstraintsError.NAME && get(myCameraStore)) {
@@ -61,6 +63,8 @@ export class MediaManager {
                     }
                 });
 
+                // It is ok to not unsubscribe to this store because it is a singleton.
+                // eslint-disable-next-line svelte/no-ignored-unsubscribe
                 screenSharingLocalStreamStore.subscribe((result) => {
                     if (result.type === "error") {
                         console.error(result.error);

--- a/play/src/svelte.ts
+++ b/play/src/svelte.ts
@@ -177,7 +177,7 @@ window.addEventListener("resize", function () {
 });
 
 // coWebsiteManager.onResize is a singleton. No need to unsubscribe.
-//eslint-disable-next-line rxjs/no-ignored-subscription
+//eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
 coWebsiteManager.onResize.subscribe(() => {
     waScaleManager.applyNewSize();
     waScaleManager.refreshFocusOnTarget();

--- a/play/tests/front/Stores/Utils/ForwardableStore.test.ts
+++ b/play/tests/front/Stores/Utils/ForwardableStore.test.ts
@@ -8,7 +8,7 @@ describe("Forwardable store", () => {
 
         let value = "";
 
-        forwardableStore.subscribe((val) => {
+        const unsubscribe = forwardableStore.subscribe((val) => {
             value = val;
         });
 
@@ -27,5 +27,7 @@ describe("Forwardable store", () => {
         expect(value).toBe("bar");
         stringStore2.set("baz");
         expect(value).toBe("baz");
+
+        unsubscribe();
     });
 });

--- a/play/tests/front/Stores/Utils/MapStore.test.ts
+++ b/play/tests/front/Stores/Utils/MapStore.test.ts
@@ -9,7 +9,7 @@ describe("Main store", () => {
 
         let triggered = false;
 
-        mapStore.subscribe((map) => {
+        const unsubscribe = mapStore.subscribe((map) => {
             triggered = true;
             expect(map).toBe(mapStore);
         });
@@ -31,6 +31,7 @@ describe("Main store", () => {
         triggered = false;
         mapStore.clear();
         expect(triggered).toBe(true);
+        unsubscribe();
     });
 
     it("generates stores for keys with getStore", () => {
@@ -41,7 +42,7 @@ describe("Main store", () => {
 
         mapStore.set("foo", "someValue");
 
-        mapStore.getStore("foo").subscribe((value) => {
+        const unsubscribe = mapStore.getStore("foo").subscribe((value) => {
             valueReceivedInStoreForFoo = value;
         });
         const unsubscribeBar = mapStore.getStore("bar").subscribe((value) => {
@@ -61,6 +62,7 @@ describe("Main store", () => {
         unsubscribeBar();
         mapStore.set("bar", "fiz");
         expect(valueReceivedInStoreForBar).toBe(undefined);
+        unsubscribe();
     });
 
     it("generates stores with getStoreByAccessor", () => {
@@ -121,7 +123,7 @@ describe("Main store", () => {
 
         let value: number | undefined;
 
-        sumStore.subscribe((val) => {
+        const unsubscribe = sumStore.subscribe((val) => {
             value = val;
         });
 
@@ -146,5 +148,7 @@ describe("Main store", () => {
         mapStore.delete("baz");
 
         expect(value).toBe(48);
+
+        unsubscribe();
     });
 });


### PR DESCRIPTION
This new rule (that [we contributed to the eslint-plugin-svelte package](https://github.com/sveltejs/eslint-plugin-svelte/pull/592#event-10548114549)) detects ignored `subscribe()` calls.

As a result, this commit fixes 10 memory leaks in the project. :tada: 

Closes https://github.com/workadventure/workadventure/issues/3530