### PR TITLE
Fallback in case of Overconstrained deviceId

### DIFF
--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -529,8 +529,15 @@ export const localStreamStore = derived<Readable<MediaStreamConstraints>, LocalS
                         return stream;
                     })
                     .catch((e) => {
-                        console.error("BAAAAAAAAAAAAAAAAAAAA", e);
-                        if (constraints.video !== false /* || constraints.audio !== false*/) {
+                        if (e instanceof OverconstrainedError && e.constraint === "deviceId") {
+                            console.info(
+                                "Could not access the requested microphone or webcam. Falling back to default microphone and webcam",
+                                constraints,
+                                e
+                            );
+                            requestedCameraDeviceIdStore.set(undefined);
+                            requestedMicrophoneDeviceIdStore.set(undefined);
+                        } else if (constraints.video !== false /* || constraints.audio !== false*/) {
                             console.info(
                                 "Error. Unable to get microphone and/or camera access. Trying audio only.",
                                 constraints,


### PR DESCRIPTION
If a specific camera or microphone cannot be fetched, we now automatically fallback trying to get the default camera or microphone.

Note: this was already the case somehow because the device list is checked and we never request a device not part of the device list. Yet, in some specific cases (I have a hard time understanding), the device list would always be empty.

This should fix the issue.