### PR TITLE
Configuring a full domain name for PUSHER_URL in single-domain deployment

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -36,7 +36,7 @@ services:
       - JITSI_PRIVATE_MODE
       - ENABLE_MAP_EDITOR
       - MAP_EDITOR_ALLOWED_USERS
-      - PUSHER_URL=/
+      - PUSHER_URL=https://${DOMAIN}/
       - ICON_URL=/icon
       - TURN_SERVER
       - TURN_USER


### PR DESCRIPTION
This should make a good default for a OIDC setup.

Closes #3513 