### PR TITLE
Improving fluidity when navigating a map

### DIFF
--- a/docs/developer/map-scripting/events.md
+++ b/docs/developer/map-scripting/events.md
@@ -36,7 +36,7 @@ The payload can be any JSON-serializable value (including objects, arrays, strin
 
 ## Targeting a player
 
-If you are tracking users using the [players API](./api-players.md), you can target a specific player using the `RemotePlayer.sendEvent` method:
+If you are tracking users using the [players API](./references/api-players.md), you can target a specific player using the `RemotePlayer.sendEvent` method:
 
 Example: let's send an event only to players that have the `admin` tag:
 

--- a/play/src/front/Phaser/ECS/Entity.ts
+++ b/play/src/front/Phaser/ECS/Entity.ts
@@ -169,7 +169,7 @@ export class Entity extends Phaser.GameObjects.Image implements ActivatableInter
         this.outlineColorStore.characterFarAway();
     }
 
-    public getCurrentOutline(): { thickness: number; color?: number } {
+    private getCurrentOutline(): { thickness: number; color?: number } {
         return { thickness: 2, color: get(this.outlineColorStore) };
     }
 

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -31,7 +31,7 @@ const interactiveRadius = 35;
 
 export abstract class Character extends Container implements OutlineableInterface {
     private bubble: SpeechBubble | null = null;
-    private readonly playerNameText: Text;
+    private playerNameText: Text | undefined;
     private readonly talkIcon: TalkIcon;
     protected readonly statusDot: PlayerStatusDot;
     protected readonly speakerIcon: SpeakerIcon;
@@ -48,8 +48,9 @@ export abstract class Character extends Container implements OutlineableInterfac
     scene: GameScene;
     private readonly _pictureStore: Writable<string | undefined>;
     protected readonly outlineColorStore = createColorStore();
-    private readonly outlineColorStoreUnsubscribe: Unsubscriber;
+    private outlineColorStoreUnsubscribe: Unsubscriber | undefined;
     private texturePromise: CancelablePromise<string[] | void> | undefined;
+    private destroyed = false;
 
     /**
      * A deferred promise that resolves when the texture of the character is actually displayed.
@@ -125,22 +126,53 @@ export abstract class Character extends Container implements OutlineableInterfac
             this.addCompanion(companionTexturePromise);
         }
 
-        // Todo: Replace the font family with a better one
-        this.playerNameText = new Text(scene, 0, playerNameY, name, {
-            fontFamily: '"Press Start 2P"',
-            fontSize: "8px",
-            strokeThickness: 2,
-            stroke: "#14304C",
-            metrics: {
-                ascent: 20,
-                descent: 10,
-                fontSize: 35,
-            },
-        });
+        // We delay the assignment of the text because it can take up to 16ms.
+        // If we enter a zone with 100 people, that is a 1.6s freeze.
+        // requestAnimationFrame has the priority over setTimeout so the game will keep running smoothly.
+        setTimeout(() => {
+            if (this.destroyed) {
+                // The character has been destroyed before the timeout
+                return;
+            }
 
+            // Todo: Replace the font family with a better one
+            this.playerNameText = new Text(scene, 0, playerNameY, name, {
+                fontFamily: '"Press Start 2P"',
+                fontSize: "8px",
+                strokeThickness: 2,
+                stroke: "#14304C",
+                metrics: {
+                    ascent: 20,
+                    descent: 10,
+                    fontSize: 35,
+                },
+            });
+
+            this.playerNameText.setOrigin(0.5).setDepth(DEPTH_INGAME_TEXT_INDEX);
+            this.add([this.playerNameText]);
+
+            // Reposition status dot and megaphone icon
+            this.statusDot.x = (this.playerNameText.getLeftCenter().x ?? 0) - 6;
+            this.megaphoneIcon.x = this.playerNameText.width - 10;
+            this.statusDot.visible = true;
+            this.megaphoneIcon.visible = true;
+
+            scene.getOutlineManager().add(this.playerNameText, () => {
+                return this.getCurrentOutline();
+            });
+
+            this.outlineColorStoreUnsubscribe = this.outlineColorStore.subscribe((color) => {
+                this.setOutline(color);
+            });
+        }, 0);
+
+        this.statusDot = new PlayerStatusDot(scene, 0, playerNameY - 1);
+        this.megaphoneIcon = new MegaphoneIcon(scene, 0, playerNameY - 1);
+        this.statusDot.visible = false;
+        this.megaphoneIcon.visible = false;
         this.talkIcon = new TalkIcon(scene, 0, -45);
         this.speakerIcon = new SpeakerIcon(scene, 0, -45);
-        this.add([this.talkIcon, this.speakerIcon]);
+        this.add([this.talkIcon, this.speakerIcon, this.statusDot, this.megaphoneIcon]);
 
         if (isClickable) {
             this.setInteractive({
@@ -149,21 +181,10 @@ export abstract class Character extends Container implements OutlineableInterfac
                 useHandCursor: true,
             });
         }
-        this.playerNameText.setOrigin(0.5).setDepth(DEPTH_INGAME_TEXT_INDEX);
-        this.statusDot = new PlayerStatusDot(scene, (this.playerNameText.getLeftCenter().x ?? 0) - 6, playerNameY - 1);
-        this.megaphoneIcon = new MegaphoneIcon(scene, this.playerNameText.width - 10, playerNameY - 1);
-        this.add([this.playerNameText, this.statusDot, this.megaphoneIcon]);
 
         this.setClickable(isClickable);
 
-        this.outlineColorStoreUnsubscribe = this.outlineColorStore.subscribe((color) => {
-            this.setOutline(color);
-        });
-
         scene.add.existing(this);
-        scene.getOutlineManager().add(this.getObjectToOutline(), () => {
-            return this.getCurrentOutline();
-        });
 
         this.scene.physics.world.enableBody(this);
         this.getBody().setImmovable(true);
@@ -220,10 +241,6 @@ export abstract class Character extends Container implements OutlineableInterfac
                 return { x: this.x, y: this.y };
             }
         }
-    }
-
-    public getObjectToOutline(): Phaser.GameObjects.GameObject {
-        return this.playerNameText;
     }
 
     private async getSnapshot(): Promise<string> {
@@ -377,7 +394,8 @@ export abstract class Character extends Container implements OutlineableInterfac
         }
         this.texturePromise?.cancel();
         this.list.forEach((objectContaining) => objectContaining.destroy());
-        this.outlineColorStoreUnsubscribe();
+        this.outlineColorStoreUnsubscribe?.();
+        this.destroyed = true;
         super.destroy();
     }
 
@@ -442,6 +460,9 @@ export abstract class Character extends Container implements OutlineableInterfac
     }
 
     private setOutline(color: number | undefined) {
+        if (!this.playerNameText) {
+            throw new Error("Player name text is not defined when setOuline is called");
+        }
         if (color === undefined) {
             this.getOutlinePlugin()?.remove(this.playerNameText);
         } else {
@@ -464,7 +485,6 @@ export abstract class Character extends Container implements OutlineableInterfac
     private destroyEmote() {
         this.emote?.destroy();
         this.emote = null;
-        this.playerNameText.setVisible(true);
     }
 
     public get pictureStore(): PictureStore {
@@ -503,7 +523,7 @@ export abstract class Character extends Container implements OutlineableInterfac
         this.outlineColorStore.characterFarAway();
     }
 
-    public getCurrentOutline(): { thickness: number; color?: number } {
+    private getCurrentOutline(): { thickness: number; color?: number } {
         return { thickness: 2, color: get(this.outlineColorStore) };
     }
 

--- a/play/src/front/Phaser/Game/OutlineableInterface.ts
+++ b/play/src/front/Phaser/Game/OutlineableInterface.ts
@@ -7,5 +7,4 @@ export interface OutlineableInterface {
     pointerOutOutline(): void;
     characterCloseByOutline(color: number): void;
     characterFarAwayOutline(): void;
-    getCurrentOutline(): { thickness: number; color?: number };
 }

--- a/play/src/front/Phaser/Game/UI/OutlineManager.ts
+++ b/play/src/front/Phaser/Game/UI/OutlineManager.ts
@@ -4,6 +4,8 @@ import { DirtyScene } from "../DirtyScene";
 /**
  * Temporary solution to fix the issue with the postFX pipeline:
  * https://github.com/photonstorm/phaser/issues/6503
+ *
+ * TODO: delete this when we migrate to 3.60.1+
  */
 export class OutlineManager {
     private scene: DirtyScene;
@@ -18,7 +20,7 @@ export class OutlineManager {
             for (const [gameObject, getOutline] of this.gameObjects) {
                 this.getOutlinePlugin()?.remove(gameObject);
                 const outline = getOutline();
-                if (outline.color) {
+                if (outline.color !== undefined) {
                     this.getOutlinePlugin()?.add(gameObject, {
                         thickness: outline.thickness,
                         outlineColor: outline.color,


### PR DESCRIPTION
If there are 100 people packed at the same position in the map, when you move
next to the zone that contains those people, you will suddenly have to
create 100 character instances.

It turns out the creation of a "Text" Phaser object can take up to 16ms.
We are now building this Text object in a setTimeout. Because requestAnimationFrame has the precedence
over setTimeout, this will avoid having freezes. Instead, Wokas will be displayed
without a text for a few milliseconds and the text will be displayed just after, when it is ready.

Also, computing the snapshot of a character can take up to 16ms.
We delay this in a setTimeout to avoid freezing the game (RAF has precedence)

Closes #3570