### PR TITLE
Display correct error message on collection of images tilesets

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -48,7 +48,7 @@
     "@sentry/node": "^7.48.0",
     "@workadventure/messages": "1.0.0",
     "@workadventure/shared-utils": "1.0.0",
-    "@workadventure/tiled-map-type-guard": "^2.1.0",
+    "@workadventure/tiled-map-type-guard": "^2.1.2",
     "axios": "^1.3.2",
     "bigbluebutton-js": "^0.1.1",
     "busboy": "^1.6.0",

--- a/libs/map-editor/package.json
+++ b/libs/map-editor/package.json
@@ -23,7 +23,7 @@
     "@types/uuid": "^8.3.4",
     "@workadventure/math-utils": "1.0.0",
     "@workadventure/messages": "1.0.0",
-    "@workadventure/tiled-map-type-guard": "^2.1.0",
+    "@workadventure/tiled-map-type-guard": "^2.1.2",
     "axios": "^1.3.2",
     "ipaddr.js": "^2.0.1",
     "lodash": "^4.17.21",

--- a/libs/map-editor/src/GameMap/MapValidator.ts
+++ b/libs/map-editor/src/GameMap/MapValidator.ts
@@ -402,6 +402,16 @@ export class MapValidator {
                 tilesetTsx.push(tileset.source);
                 continue;
             }
+
+            if (!("image" in tileset)) {
+                errors.push({
+                    type: "error",
+                    message: `The tileset "${tileset.name}" is a collection of images. Collection of images are not supported.`,
+                    details: "",
+                });
+                continue;
+            }
+
             //test of tileset image existence : ERRORS
             //TODO: optimize this by removing the await in the loop
             //eslint-disable-next-line no-await-in-loop

--- a/libs/shared-utils/package.json
+++ b/libs/shared-utils/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "@workadventure/map-editor": "1.0.0",
-    "@workadventure/tiled-map-type-guard": "^2.1.0",
+    "@workadventure/tiled-map-type-guard": "^2.1.2",
     "@grpc/grpc-js": "^1.8.12",
     "axios": "^1.3.2",
     "zod": "^3.19.1",

--- a/map-storage/package.json
+++ b/map-storage/package.json
@@ -55,7 +55,7 @@
     "@workadventure/map-editor": "1.0.0",
     "@workadventure/messages": "1.0.0",
     "@workadventure/shared-utils": "1.0.0",
-    "@workadventure/tiled-map-type-guard": "^2.1.0",
+    "@workadventure/tiled-map-type-guard": "^2.1.2",
     "archiver": "^5.3.1",
     "axios": "^1.3.5",
     "body-parser": "^1.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@sentry/node": "^7.48.0",
         "@workadventure/messages": "1.0.0",
         "@workadventure/shared-utils": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "axios": "^1.3.2",
         "bigbluebutton-js": "^0.1.1",
         "busboy": "^1.6.0",
@@ -292,7 +292,7 @@
         "@types/uuid": "^8.3.4",
         "@workadventure/math-utils": "1.0.0",
         "@workadventure/messages": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "axios": "^1.3.2",
         "ipaddr.js": "^2.0.1",
         "lodash": "^4.17.21",
@@ -665,7 +665,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.8.12",
         "@workadventure/map-editor": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "axios": "^1.3.2",
         "debug": "^4.3.4",
         "zod": "^3.19.1"
@@ -906,7 +906,7 @@
         "@workadventure/map-editor": "1.0.0",
         "@workadventure/messages": "1.0.0",
         "@workadventure/shared-utils": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "archiver": "^5.3.1",
         "axios": "^1.3.5",
         "body-parser": "^1.20.1",
@@ -7201,9 +7201,9 @@
       "link": true
     },
     "node_modules/@workadventure/tiled-map-type-guard": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.1.0.tgz",
-      "integrity": "sha512-VA9xYMfA1wsY7KpE2xUXMfMHaFZHoVHf2tHwQ1XpGN6V0jdACrIqxA8cfDJwccr6CsbApCF7FddbrDkDYtkScQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.1.2.tgz",
+      "integrity": "sha512-CNGTBeg8nfvBxyZSr+5IFUGBUTF1nzxDRX9njCab4Cd02iQNYDL8S8nOvHj6Aur4c631JdcgJm8heIcIQDCwHg==",
       "dependencies": {
         "zod": "^3.17.3"
       }
@@ -24245,7 +24245,7 @@
         "@workadventure/shared-utils": "1.0.0",
         "@workadventure/store-utils": "1.0.0",
         "@workadventure/tailwind": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "@xmpp/client": "^0.13.1",
         "@xmpp/component": "^0.13.1",
         "@xmpp/debug": "^0.13.0",
@@ -29925,7 +29925,7 @@
         "@vitest/coverage-c8": "^0.30.1",
         "@workadventure/math-utils": "1.0.0",
         "@workadventure/messages": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "axios": "^1.3.2",
         "eslint": "^8.31.0",
         "eslint-config-prettier": "^8.6.0",
@@ -30181,7 +30181,7 @@
         "@typescript-eslint/eslint-plugin": "^5.48.1",
         "@typescript-eslint/parser": "^5.48.1",
         "@workadventure/map-editor": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "axios": "^1.3.2",
         "debug": "^4.3.4",
         "eslint": "^8.31.0",
@@ -30350,9 +30350,9 @@
       }
     },
     "@workadventure/tiled-map-type-guard": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.1.0.tgz",
-      "integrity": "sha512-VA9xYMfA1wsY7KpE2xUXMfMHaFZHoVHf2tHwQ1XpGN6V0jdACrIqxA8cfDJwccr6CsbApCF7FddbrDkDYtkScQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.1.2.tgz",
+      "integrity": "sha512-CNGTBeg8nfvBxyZSr+5IFUGBUTF1nzxDRX9njCab4Cd02iQNYDL8S8nOvHj6Aur4c631JdcgJm8heIcIQDCwHg==",
       "requires": {
         "zod": "^3.17.3"
       }
@@ -37226,7 +37226,7 @@
         "@workadventure/map-editor": "1.0.0",
         "@workadventure/messages": "1.0.0",
         "@workadventure/shared-utils": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "archiver": "^5.3.1",
         "axios": "^1.3.5",
         "body-parser": "^1.20.1",
@@ -43034,7 +43034,7 @@
         "@workadventure/shared-utils": "1.0.0",
         "@workadventure/store-utils": "1.0.0",
         "@workadventure/tailwind": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "@xmpp/client": "^0.13.1",
         "@xmpp/component": "^0.13.1",
         "@xmpp/debug": "^0.13.0",
@@ -43244,7 +43244,7 @@
         "@vitest/coverage-c8": "^0.29.1",
         "@workadventure/messages": "1.0.0",
         "@workadventure/shared-utils": "1.0.0",
-        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.2",
         "axios": "^1.3.2",
         "bigbluebutton-js": "^0.1.1",
         "busboy": "^1.6.0",

--- a/play/package.json
+++ b/play/package.json
@@ -114,7 +114,7 @@
     "@workadventure/shared-utils": "1.0.0",
     "@workadventure/store-utils": "1.0.0",
     "@workadventure/tailwind": "1.0.0",
-    "@workadventure/tiled-map-type-guard": "^2.1.0",
+    "@workadventure/tiled-map-type-guard": "^2.1.2",
     "@xmpp/client": "^0.13.1",
     "@xmpp/component": "^0.13.1",
     "@xmpp/debug": "^0.13.0",

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -505,7 +505,7 @@ export class GameScene extends DirtyScene {
                     `Tilesets must be embedded in a map. The tileset "${tileset.source}" must be embedded in the Tiled map "${this.mapUrlFile}".`
                 );
             }
-            if (typeof tileset.name === "undefined" || typeof tileset.image === "undefined") {
+            if (typeof tileset.name === "undefined" || !("image" in tileset)) {
                 console.warn("Don't know how to handle tileset ", tileset);
                 return;
             }
@@ -631,6 +631,11 @@ export class GameScene extends DirtyScene {
             if ("source" in tileset) {
                 throw new Error(
                     `Tilesets must be embedded in a map. The tileset "${tileset.source}" must be embedded in the Tiled map "${this.mapUrlFile}".`
+                );
+            }
+            if (!("image" in tileset)) {
+                throw new Error(
+                    `Tilesets made of a collection of images are not supported in WorkAdventure in the Tiled map "${this.mapUrlFile}".`
                 );
             }
             const tilesetImage = this.Map.addTilesetImage(


### PR DESCRIPTION
In Tiled, collection of images tilesets can be created. They are not supported in WA.
This displays a correct error in the log if we see such tilesets.

Closes #3180