### PR TITLE
Adding Posthog analytics on the status of Turn server

### DIFF
--- a/play/src/front/Administration/AnalyticsClient.ts
+++ b/play/src/front/Administration/AnalyticsClient.ts
@@ -532,5 +532,29 @@ class AnalyticsClient {
             })
             .catch((e) => console.error(e));
     }
+
+    turnTestSuccess(protocol: string | null): void {
+        this.posthogPromise
+            ?.then((posthog) => {
+                posthog.capture(`wa_turn_test_success`, { protocol });
+            })
+            .catch((e) => console.error(e));
+    }
+
+    turnTestFailure(): void {
+        this.posthogPromise
+            ?.then((posthog) => {
+                posthog.capture(`wa_turn_test_failure`);
+            })
+            .catch((e) => console.error(e));
+    }
+
+    turnTestTimeout(): void {
+        this.posthogPromise
+            ?.then((posthog) => {
+                posthog.capture(`wa_turn_test_timeout`);
+            })
+            .catch((e) => console.error(e));
+    }
 }
 export const analyticsClient = new AnalyticsClient();


### PR DESCRIPTION
This could be useful to detect potential wide scale problems with the turn servers. If analytics show everybody has an issue with Turn, it is our problem. If the analytics show only one person has a problem, it is a network problem.