### PR TITLE
Fixes few things on Map Editor

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -54,7 +54,7 @@ import { GameRoom } from "../Model/GameRoom";
 import { User, UserSocket } from "../Model/User";
 import { ProtobufUtils } from "../Model/Websocket/ProtobufUtils";
 import { Group } from "../Model/Group";
-import { GROUP_RADIUS, MINIMUM_DISTANCE, TURN_STATIC_AUTH_SECRET } from "../Enum/EnvironmentVariable";
+import { GROUP_RADIUS, MINIMUM_DISTANCE, PLAY_URL, TURN_STATIC_AUTH_SECRET } from "../Enum/EnvironmentVariable";
 import { Movable } from "../Model/Movable";
 import { PositionInterface } from "../Model/PositionInterface";
 import { EventSocket, RoomSocket, VariableSocket, ZoneSocket } from "../RoomManager";
@@ -130,7 +130,9 @@ export class SocketManager {
                 );
             });
         } else {
-            emitError(user.socket, "WAM file url is undefined. Cannot edit map without WAM file.");
+            if (!room.roomUrl.match(`#${PLAY_URL}/_/.*#`)) {
+                emitError(user.socket, "WAM file url is undefined. Cannot edit map without WAM file.");
+            }
         }
 
         if (!socket.writable) {

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -54,7 +54,7 @@ import { GameRoom } from "../Model/GameRoom";
 import { User, UserSocket } from "../Model/User";
 import { ProtobufUtils } from "../Model/Websocket/ProtobufUtils";
 import { Group } from "../Model/Group";
-import { GROUP_RADIUS, MINIMUM_DISTANCE, PLAY_URL, TURN_STATIC_AUTH_SECRET } from "../Enum/EnvironmentVariable";
+import { GROUP_RADIUS, MINIMUM_DISTANCE, TURN_STATIC_AUTH_SECRET } from "../Enum/EnvironmentVariable";
 import { Movable } from "../Model/Movable";
 import { PositionInterface } from "../Model/PositionInterface";
 import { EventSocket, RoomSocket, VariableSocket, ZoneSocket } from "../RoomManager";
@@ -129,10 +129,6 @@ export class SocketManager {
                     }
                 );
             });
-        } else {
-            if (!room.roomUrl.match(`#${PLAY_URL}/_/.*#`)) {
-                emitError(user.socket, "WAM file url is undefined. Cannot edit map without WAM file.");
-            }
         }
 
         if (!socket.writable) {

--- a/docs/schema/1.0/wam.json
+++ b/docs/schema/1.0/wam.json
@@ -240,9 +240,6 @@
           "items": {
             "type": "object",
             "properties": {
-              "id": {
-                "type": "string"
-              },
               "x": {
                 "type": "number"
               },
@@ -254,6 +251,9 @@
               },
               "height": {
                 "type": "number"
+              },
+              "id": {
+                "type": "string"
               },
               "visible": {
                 "type": "boolean"
@@ -447,11 +447,11 @@
               }
             },
             "required": [
-              "id",
               "x",
               "y",
               "width",
               "height",
+              "id",
               "visible",
               "name",
               "properties"

--- a/libs/map-editor/src/Commands/Area/UpdateAreaCommand.ts
+++ b/libs/map-editor/src/Commands/Area/UpdateAreaCommand.ts
@@ -37,7 +37,7 @@ export class UpdateAreaCommand extends Command {
     }
 
     public execute(): Promise<void> {
-        if (!this.gameMap.getGameMapAreas()?.updateArea(this.newConfig.id, this.newConfig)) {
+        if (!this.gameMap.getGameMapAreas()?.updateArea(this.newConfig)) {
             throw new Error(`MapEditorError: Could not execute UpdateArea Command. Area ID: ${this.newConfig.id}`);
         }
         return Promise.resolve();

--- a/libs/map-editor/src/GameMap/GameMap.ts
+++ b/libs/map-editor/src/GameMap/GameMap.ts
@@ -7,7 +7,7 @@ import {
     upgradeMapToNewest,
 } from "@workadventure/tiled-map-type-guard";
 import { WAMFileFormat, GameMapProperties } from "../types";
-import type { AreaChangeCallback } from "./GameMapAreas";
+import type { AreaChangeCallback, AreaUpdateCallback } from "./GameMapAreas";
 import { GameMapAreas } from "./GameMapAreas";
 import { flattenGroupLayersMap } from "./LayersFlattener";
 import { GameMapEntities } from "./GameMapEntities";
@@ -180,10 +180,10 @@ export class GameMap {
     }
 
     /**
-     * Registers a callback called when the user moves outside another area.
+     * Registers a callback called when an area is updated.
      */
-    public onLeaveArea(callback: AreaChangeCallback) {
-        this.gameMapAreas?.onLeaveArea(callback);
+    public onUpdateArea(callback: AreaUpdateCallback) {
+        this.gameMapAreas?.onUpdateArea(callback);
     }
 
     public getTileProperty(index: number): Array<ITiledMapProperty> {

--- a/libs/map-editor/src/GameMap/GameMapAreas.ts
+++ b/libs/map-editor/src/GameMap/GameMapAreas.ts
@@ -7,10 +7,17 @@ export type AreaChangeCallback = (
     allAreasOnNewPosition: Array<AreaData>
 ) => void;
 
+export type AreaUpdateCallback = (
+    area: AreaData,
+    oldProperties: AreaDataProperties | undefined,
+    newProperties: AreaDataProperties | undefined
+) => void;
+
 export class GameMapAreas {
     private wam: WAMFileFormat;
 
     private enterAreaCallbacks = Array<AreaChangeCallback>();
+    private updateAreaCallbacks = Array<AreaUpdateCallback>();
     private leaveAreaCallbacks = Array<AreaChangeCallback>();
 
     /**
@@ -169,6 +176,13 @@ export class GameMapAreas {
     }
 
     /**
+     * Registers a callback called when an area is update.
+     */
+    public onUpdateArea(callback: AreaUpdateCallback) {
+        this.updateAreaCallbacks.push(callback);
+    }
+
+    /**
      * Registers a callback called when the user moves outside another area.
      */
     public onLeaveArea(callback: AreaChangeCallback) {
@@ -178,6 +192,16 @@ export class GameMapAreas {
     public triggerSpecificAreaOnEnter(area: AreaData): void {
         for (const callback of this.enterAreaCallbacks) {
             callback([area], []);
+        }
+    }
+
+    public triggerSpecificAreaOnUpdate(
+        area: AreaData,
+        oldProperties: AreaDataProperties | undefined,
+        newProperties: AreaDataProperties | undefined
+    ): void {
+        for (const callback of this.updateAreaCallbacks) {
+            callback(area, oldProperties, newProperties);
         }
     }
 

--- a/libs/map-editor/src/GameMap/GameMapAreas.ts
+++ b/libs/map-editor/src/GameMap/GameMapAreas.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash";
 import { MathUtils } from "@workadventure/math-utils";
-import { AreaData, AreaDataProperties, GameMapProperties, WAMFileFormat } from "../types";
+import { AreaData, AreaDataProperties, AtLeast, GameMapProperties, WAMFileFormat } from "../types";
 
 export type AreaChangeCallback = (
     areasChangedByAction: Array<AreaData>,
@@ -96,16 +96,19 @@ export class GameMapAreas {
         );
     }
 
-    public updateArea(id: string, config: Partial<AreaData>): AreaData | undefined {
-        const area = this.areas.get(id);
+    public updateArea(newConfig: AtLeast<AreaData, "id">): AreaData | undefined {
+        const area = this.areas.get(newConfig.id);
         if (!area) {
             throw new Error(`Area to update does not exist!`);
         }
-        _.merge(area, config);
+
+        _.merge(area, newConfig);
         // TODO: Find a way to update it without need of using conditions
-        if (config.properties !== undefined) {
-            area.properties = config.properties;
+
+        if (newConfig.properties !== undefined) {
+            area.properties = newConfig.properties;
         }
+
         this.updateAreaWAM(area);
         return area;
     }

--- a/libs/map-editor/src/GameMap/GameMapAreas.ts
+++ b/libs/map-editor/src/GameMap/GameMapAreas.ts
@@ -113,15 +113,7 @@ export class GameMapAreas {
         return area;
     }
 
-    public deleteArea(id: string, playerPosition?: { x: number; y: number }): boolean {
-        if (playerPosition) {
-            const area = this.getAreasOnPosition(playerPosition, this.areasPositionOffsetY).find(
-                (area) => area.id === id
-            );
-            if (area) {
-                this.triggerSpecificAreaOnLeave(area);
-            }
-        }
+    public deleteArea(id: string): boolean {
         const deleted = this.areas.delete(id);
         if (deleted) {
             return this.deleteAreaFromWAM(id);

--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -119,7 +119,14 @@ export const AreaDataProperty = z.discriminatedUnion("type", [
 
 export const AreaDataProperties = z.array(AreaDataProperty);
 
-export const AreaData = z.object({
+export const AreaCoordinates = z.object({
+    x: z.number(),
+    y: z.number(),
+    width: z.number(),
+    height: z.number(),
+});
+
+export const AreaData = AreaCoordinates.extend({
     id: z.string(),
     x: z.number(),
     y: z.number(),
@@ -259,6 +266,7 @@ export type OpenWebsiteTypePropertiesKeys =
     | "googleSlides"
     | "googleForms"
     | "eraser";
+export type AreaCoordinates = z.infer<typeof areaCoordinates>;
 export type AreaData = z.infer<typeof AreaData>;
 export type AreaDataProperties = z.infer<typeof AreaDataProperties>;
 export type AreaDataProperty = z.infer<typeof AreaDataProperty>;

--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -266,7 +266,7 @@ export type OpenWebsiteTypePropertiesKeys =
     | "googleSlides"
     | "googleForms"
     | "eraser";
-export type AreaCoordinates = z.infer<typeof areaCoordinates>;
+export type AreaCoordinates = z.infer<typeof AreaCoordinates>;
 export type AreaData = z.infer<typeof AreaData>;
 export type AreaDataProperties = z.infer<typeof AreaDataProperties>;
 export type AreaDataProperty = z.infer<typeof AreaDataProperty>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24240,7 +24240,7 @@
     },
     "play": {
       "name": "workadventure-play",
-      "version": "1.14.9",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@16bits/nes.css": "^2.3.2",

--- a/play/package.json
+++ b/play/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "workadventure-play",
-  "version": "1.14.9",
+  "version": "1.0.0",
   "license": "SEE LICENSE IN LICENSE.txt",
   "repository": {
     "type": "git",

--- a/play/src/front/Components/Chat/Chat.svelte
+++ b/play/src/front/Components/Chat/Chat.svelte
@@ -25,6 +25,7 @@
     import { gameSceneIsLoadedStore } from "../../Stores/GameSceneStore";
     import { Locales } from "../../../i18n/i18n-types";
     import { localUserStore } from "../../Connection/LocalUserStore";
+    import { mapEditorModeStore } from "../../Stores/MapEditorStore";
 
     let chatIframe: HTMLIFrameElement;
     let searchElement: HTMLInputElement;
@@ -180,7 +181,7 @@
         if (e.key === "Escape" && $chatVisibilityStore) {
             closeChat();
             chatIframe.blur();
-        } else if (e.key === "c" && !$chatVisibilityStore && $enableUserInputsStore) {
+        } else if (e.key === "c" && !$chatVisibilityStore && !$mapEditorModeStore && $enableUserInputsStore) {
             chatVisibilityStore.set(true);
         }
     }

--- a/play/src/front/Components/MapEditor/AreaPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/AreaPropertiesEditor.svelte
@@ -43,7 +43,7 @@
 
     let selectedAreaPreviewUnsubscriber = mapEditorSelectedAreaPreviewStore.subscribe((currentAreaPreview) => {
         if (currentAreaPreview) {
-            properties = currentAreaPreview.getProperties() ?? [];
+            properties = structuredClone(currentAreaPreview.getProperties());
             areaName = currentAreaPreview.getAreaData().name;
             refreshFlags();
         }

--- a/play/src/front/Components/MapEditor/PropertyEditor/OpenWebsitePropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/OpenWebsitePropertyEditor.svelte
@@ -40,7 +40,6 @@
         return !!(property.policy || property.allowAPI || !property.closable || property.width || property.newTab);
     }
 
-    console.log("property", property);
     onMount(() => {
         // if klaxoon, open Activity Picker
         if (property.application === "klaxoon" && (property.link == undefined || property.link === "")) {

--- a/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
+++ b/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
@@ -154,23 +154,26 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
     }
 
     public addProperty(property: AreaDataProperty): void {
+        const oldAreaData = structuredClone(this.areaData);
         this.areaData.properties.push(property);
-        this.emit(AreaPreviewEvent.Updated, this.areaData);
+        this.emit(AreaPreviewEvent.Updated, this.areaData, oldAreaData);
     }
 
     public updateProperty(changes: AtLeast<AreaDataProperty, "id">): void {
+        const oldAreaData = structuredClone(this.areaData);
         const property = this.areaData.properties.find((property) => property.id === changes.id);
         if (property) {
             _.merge(property, changes);
         }
-        this.emit(AreaPreviewEvent.Updated, this.areaData);
+        this.emit(AreaPreviewEvent.Updated, this.areaData, oldAreaData);
     }
 
     public deleteProperty(id: string): boolean {
+        const oldAreaData = structuredClone(this.areaData);
         const index = this.areaData.properties.findIndex((property) => property.id === id);
         if (index !== -1) {
             this.areaData.properties.splice(index, 1);
-            this.emit(AreaPreviewEvent.Updated, this.areaData);
+            this.emit(AreaPreviewEvent.Updated, this.areaData, oldAreaData);
             return true;
         } else {
             return false;
@@ -187,9 +190,10 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
     }
 
     public updateAreaData(dataToChange: Partial<AreaData>): void {
+        const oldAreaData = structuredClone(this.areaData);
         const data = { id: this.areaData.id, ...dataToChange };
         this.updatePreview(data);
-        this.emit(AreaPreviewEvent.Updated, data);
+        this.emit(AreaPreviewEvent.Updated, data, oldAreaData);
     }
 
     private showSizeAlteringSquares(show = true): void {
@@ -405,9 +409,10 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
     }
 
     public setAreaName(name: string): void {
+        const oldAreaData = structuredClone(this.areaData);
         this.areaData.name = name;
         const data = { id: this.areaData.id, name };
-        this.emit(AreaPreviewEvent.Updated, data);
+        this.emit(AreaPreviewEvent.Updated, data, oldAreaData);
     }
 
     public getId(): string {

--- a/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
+++ b/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
@@ -412,6 +412,7 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
         const oldAreaData = structuredClone(this.areaData);
         this.areaData.name = name;
         const data = { id: this.areaData.id, name };
+        console.log("setAreaName", data);
         this.emit(AreaPreviewEvent.Updated, data, oldAreaData);
     }
 

--- a/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
+++ b/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
@@ -412,7 +412,6 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
         const oldAreaData = structuredClone(this.areaData);
         this.areaData.name = name;
         const data = { id: this.areaData.id, name };
-        console.log("setAreaName", data);
         this.emit(AreaPreviewEvent.Updated, data, oldAreaData);
     }
 

--- a/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
+++ b/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
@@ -248,15 +248,14 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
                 if (this.ctrlKey?.isDown) {
                     this.emit(AreaPreviewEvent.Copied, {
                         position: {
-                            x: this.oldPosition.x - this.areaData.width * 0.5,
-                            y: this.oldPosition.y - this.areaData.height * 0.5,
+                            x: this.areaData.x,
+                            y: this.areaData.y,
                         },
                         width: this.areaData.width,
                         height: this.areaData.height,
                         name: this.areaData.name,
                         properties: structuredClone(this.areaData.properties),
                     } as CopyAreaEventData);
-                    return;
                 }
                 this.updateAreaDataWithSquaresAdjustments();
                 const data: AtLeast<AreaData, "id"> = {

--- a/play/src/front/Phaser/ECS/Entity.ts
+++ b/play/src/front/Phaser/ECS/Entity.ts
@@ -13,7 +13,7 @@ import * as _ from "lodash";
 import { SimpleCoWebsite } from "../../WebRtc/CoWebsite/SimpleCoWebsite";
 import { coWebsiteManager } from "../../WebRtc/CoWebsiteManager";
 import { ActionsMenuAction, actionsMenuStore } from "../../Stores/ActionsMenuStore";
-import { mapEditorModeStore, mapEditorEntityModeStore } from "../../Stores/MapEditorStore";
+import { mapEditorModeStore } from "../../Stores/MapEditorStore";
 import { createColorStore } from "../../Stores/OutlineColorStore";
 import { ActivatableInterface } from "../Game/ActivatableInterface";
 import { GameScene } from "../Game/GameScene";
@@ -109,12 +109,12 @@ export class Entity extends Phaser.GameObjects.Image implements ActivatableInter
             return;
         }
 
-        const editorMode = get(mapEditorEntityModeStore);
+        /*        const editorMode = get(mapEditorEntityModeStore);
 
         if (editorMode !== "EDIT") {
             actionsMenuStore.clear();
             return;
-        }
+        }*/
 
         this.toggleActionsMenu();
     }

--- a/play/src/front/Phaser/ECS/Entity.ts
+++ b/play/src/front/Phaser/ECS/Entity.ts
@@ -104,9 +104,19 @@ export class Entity extends Phaser.GameObjects.Image implements ActivatableInter
     }
 
     public activate(): void {
-        if (!(get(mapEditorModeStore) && get(mapEditorEntityModeStore) === "EDIT")) {
-            this.toggleActionsMenu();
+        if (get(mapEditorModeStore)) {
+            actionsMenuStore.clear();
+            return;
         }
+
+        const editorMode = get(mapEditorEntityModeStore);
+
+        if (editorMode !== "EDIT") {
+            actionsMenuStore.clear();
+            return;
+        }
+
+        this.toggleActionsMenu();
     }
 
     public deactivate(): void {

--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -236,15 +236,6 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
         entity.on(EntityEvent.Updated, (data: EntityData) => {
             this.emit(EntitiesManagerEvent.UpdateEntity, data);
         });
-        entity.on(Phaser.Input.Events.DRAG_START, () => {
-            if (
-                get(mapEditorModeStore) &&
-                this.isEntityEditorToolActive() &&
-                get(mapEditorEntityModeStore) === "EDIT"
-            ) {
-                mapEditorSelectedEntityDraggedStore.set(true);
-            }
-        });
         entity.on(Phaser.Input.Events.DRAG, (pointer: Phaser.Input.Pointer, dragX: number, dragY: number) => {
             if (
                 get(mapEditorModeStore) &&
@@ -308,9 +299,10 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
             if (pointer.downElement?.tagName !== "CANVAS") {
                 return;
             }
+
             if (
                 get(mapEditorModeStore) &&
-                (this.isEntityEditorToolActive() || this.isTrashEditorToolActive()) &&
+                this.isEntityEditorToolActive() &&
                 !get(mapEditorSelectedEntityPrefabStore)
             ) {
                 if (document.activeElement instanceof HTMLElement) {
@@ -320,7 +312,9 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
                 if (this.isTrashEditorToolActive()) {
                     return;
                 }
+
                 mapEditorEntityModeStore.set("EDIT");
+                mapEditorSelectedEntityDraggedStore.set(true);
                 mapEditorSelectedEntityStore.set(entity);
             }
         });

--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -314,7 +314,6 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
                 !get(mapEditorSelectedEntityPrefabStore)
             ) {
                 if (this.isTrashEditorToolActive()) {
-                    entity.delete();
                     return;
                 }
                 mapEditorEntityModeStore.set("EDIT");

--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -69,8 +69,8 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
         super();
         this.scene = scene;
         this.gameMapFrontWrapper = gameMapFrontWrapper;
-        this.shiftKey = this.scene.input.keyboard?.addKey("SHIFT");
-        this.ctrlKey = this.scene.input.keyboard?.addKey("CTRL");
+        this.shiftKey = this.scene.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
+        this.ctrlKey = this.scene.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.CTRL);
         this.entities = new Map<string, Entity>();
         this.activatableEntities = [];
         this.properties = new Map<string, string | boolean | number>();

--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -310,16 +310,17 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
             }
             if (
                 get(mapEditorModeStore) &&
-                this.isEntityEditorToolActive() &&
+                (this.isEntityEditorToolActive() || this.isTrashEditorToolActive()) &&
                 !get(mapEditorSelectedEntityPrefabStore)
             ) {
+                if (document.activeElement instanceof HTMLElement) {
+                    document.activeElement.blur();
+                }
+
                 if (this.isTrashEditorToolActive()) {
                     return;
                 }
                 mapEditorEntityModeStore.set("EDIT");
-                if (document.activeElement instanceof HTMLElement) {
-                    document.activeElement.blur();
-                }
                 mapEditorSelectedEntityStore.set(entity);
             }
         });

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -728,10 +728,6 @@ export class GameMapFrontWrapper {
         return this.dynamicAreas.get(name);
     }
 
-    public deleteArea(id: string): void {
-        this.gameMap.getGameMapAreas()?.deleteArea(id, this.position);
-    }
-
     public deleteDynamicArea(name: string): void {
         this.dynamicAreas.delete(name);
     }
@@ -788,6 +784,17 @@ export class GameMapFrontWrapper {
         } else if (!isPlayerWasInsideArea && isPlayerInsideArea) {
             this.triggerSpecificAreaOnEnter(area);
             return;
+        }
+    }
+
+    public listenAreaDeletion(areaData: AreaData | undefined) {
+        if (areaData === undefined || this.position === undefined) {
+            console.error('Area with id "' + areaData?.id + '" does not exist, this not supposed to happen');
+            return;
+        }
+
+        if (this.isPlayerInsideAreaByCoordinates(areaData, this.position)) {
+            this.triggerSpecificAreaOnLeave(areaData);
         }
     }
 

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -784,7 +784,7 @@ export class GameMapFrontWrapper {
         const isOldCoordinates = AreaCoordinates.safeParse(oldConfig);
         const isNewCoordinates = AreaCoordinates.safeParse(newConfig);
 
-        if (!isOldCoordinates.success || !isNewCoordinates.success) {
+        if (!isOldCoordinates.success) {
             throw new Error("Something wrong happen! Area coordinates are not defined");
         }
 
@@ -796,7 +796,7 @@ export class GameMapFrontWrapper {
         }
 
         const oldAreaCoordinates = isOldCoordinates.data;
-        const newAreaCoordinates = isNewCoordinates.data;
+        const newAreaCoordinates = isNewCoordinates.success ? isNewCoordinates.data : oldAreaCoordinates;
 
         const isPlayerWasInsideArea = this.isPlayerInsideAreaByCoordinates(oldAreaCoordinates, this.position);
         const isPlayerInsideArea = this.isPlayerInsideAreaByCoordinates(newAreaCoordinates, this.position);

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -751,6 +751,16 @@ export class GameMapFrontWrapper {
         );
     }
 
+    public listenAreaCreation(areaData: AreaData): void {
+        if (this.position === undefined) {
+            return;
+        }
+
+        if (this.isPlayerInsideAreaByCoordinates(areaData, this.position)) {
+            this.triggerSpecificAreaOnEnter(areaData);
+        }
+    }
+
     public listenAreaChanges(oldConfig: AtLeast<AreaData, "id">, newConfig: AtLeast<AreaData, "id">): void {
         if (this.position === undefined) {
             return;

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -1,4 +1,4 @@
-import { AreaCoordinates, AreaDataProperties, GameMapProperties } from "@workadventure/map-editor";
+import { AreaCoordinates, AreaDataProperties, AreaUpdateCallback, GameMapProperties } from "@workadventure/map-editor";
 import type { AreaChangeCallback, AreaData, AtLeast, GameMap } from "@workadventure/map-editor";
 import type {
     ITiledMap,
@@ -444,6 +444,13 @@ export class GameMapFrontWrapper {
     }
 
     /**
+     * Registers a callback called when an area has been updated.
+     */
+    public onUpdateArea(callback: AreaUpdateCallback) {
+        this.gameMap.onUpdateArea(callback);
+    }
+
+    /**
      * Registers a callback called when the user moves outside another area.
      */
     public onLeaveArea(callback: AreaChangeCallback) {
@@ -712,6 +719,14 @@ export class GameMapFrontWrapper {
         this.gameMap.getGameMapAreas()?.triggerSpecificAreaOnEnter(area);
     }
 
+    public triggerSpecificAreaOnUpdate(
+        area: AreaData,
+        oldProperties: AreaDataProperties | undefined,
+        newProperties: AreaDataProperties | undefined
+    ): void {
+        this.gameMap.getGameMapAreas()?.triggerSpecificAreaOnUpdate(area, oldProperties, newProperties);
+    }
+
     public triggerSpecificAreaOnLeave(area: AreaData): void {
         this.gameMap.getGameMapAreas()?.triggerSpecificAreaOnLeave(area);
     }
@@ -787,7 +802,9 @@ export class GameMapFrontWrapper {
         const isPlayerInsideArea = this.isPlayerInsideAreaByCoordinates(newAreaCoordinates, this.position);
 
         if (isPlayerWasInsideArea && isPlayerInsideArea) {
-            //this.triggerAllProperties();
+            if (JSON.stringify(oldConfig.properties) !== JSON.stringify(newConfig.properties)) {
+                this.triggerSpecificAreaOnUpdate(area, oldConfig.properties, newConfig.properties);
+            }
         } else if (isPlayerWasInsideArea && !isPlayerInsideArea) {
             this.triggerSpecificAreaOnLeave(area);
             return;

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -349,7 +349,6 @@ export class GameMapFrontWrapper {
         this.oldPosition = this.position;
         this.position = { x, y };
         const areasChanged = this.gameMap.getGameMapAreas()?.triggerAreasChange(this.oldPosition, this.position);
-        //const tiledAreasChanged = this.triggerTiledAreasChange(this.oldPosition, this.position);
         const dynamicAreasChanged = this.triggerDynamicAreasChange(this.oldPosition, this.position);
         if (areasChanged /*|| tiledAreasChanged*/ || dynamicAreasChanged) {
             this.triggerAllProperties();

--- a/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
@@ -1,6 +1,6 @@
 import { get } from "svelte/store";
 import type { ITiledMapLayer, ITiledMapObject } from "@workadventure/tiled-map-type-guard";
-import { AreaData, GameMapProperties } from "@workadventure/map-editor";
+import { AreaData, AreaDataProperties, GameMapProperties } from "@workadventure/map-editor";
 import { Jitsi } from "@workadventure/shared-utils";
 import { getSpeakerMegaphoneAreaName } from "@workadventure/map-editor/src/Utils";
 import { z } from "zod";
@@ -338,6 +338,10 @@ export class GameMapPropertiesListener {
             this.onLeaveAreasHandler(oldAreas);
         });
 
+        this.gameMapFrontWrapper.onUpdateArea((area, oldProperties, newProperties) => {
+            this.onUpdateAreasHandler(area, oldProperties, newProperties);
+        });
+
         this.gameMapFrontWrapper.onEnterDynamicArea((newAreas) => {
             this.onEnterPlaceHandler(
                 newAreas.map((area) => this.gameMapFrontWrapper.mapDynamicAreaToTiledObject(area))
@@ -375,6 +379,14 @@ export class GameMapPropertiesListener {
 
     private onEnterAreasHandler(areas: AreaData[]): void {
         this.areasPropertiesListener.onEnterAreasHandler(areas);
+    }
+
+    private onUpdateAreasHandler(
+        area: AreaData,
+        oldProperties: AreaDataProperties | undefined,
+        newProperties: AreaDataProperties | undefined
+    ): void {
+        this.areasPropertiesListener.onUpdateAreasHandler(area, oldProperties, newProperties);
     }
 
     private onLeaveAreasHandler(areas: AreaData[]): void {

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -1,6 +1,7 @@
 import { get } from "svelte/store";
 import {
     AreaData,
+    AreaDataProperties,
     FocusablePropertyData,
     JitsiRoomPropertyData,
     ListenerMegaphonePropertyData,
@@ -94,6 +95,14 @@ export class AreasPropertiesListener {
                 }
             }
         }
+    }
+
+    public onUpdateAreasHandler(
+        area: AreaData,
+        oldProperties: AreaDataProperties | undefined,
+        newProperties: AreaDataProperties | undefined
+    ): void {
+        console.log(`Area ${area.name} updated`);
     }
 
     public onLeaveAreasHandler(areas: AreaData[]): void {

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/CreateAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/CreateAreaFrontCommand.ts
@@ -18,7 +18,7 @@ export class CreateAreaFrontCommand extends CreateAreaCommand implements FrontCo
 
     public async execute(): Promise<void> {
         await super.execute();
-        this.areaEditorTool.handleAreaPreviewCreation(this.areaConfig, this.localCommand);
+        this.areaEditorTool.handleAreaCreation(this.areaConfig, this.localCommand);
     }
 
     public getUndoCommand(): DeleteAreaFrontCommand {

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/DeleteAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/DeleteAreaFrontCommand.ts
@@ -18,8 +18,10 @@ export class DeleteAreaFrontCommand extends DeleteAreaCommand implements FrontCo
     }
 
     public execute(): Promise<void> {
+        const area = this.gameMap.getGameMapAreas()?.getArea(this.areaId);
         const returnVal = super.execute();
-        this.editorTool.handleAreaPreviewDeletion(this.areaId);
+
+        this.editorTool.handleAreaDeletion(this.areaId, area);
 
         return returnVal;
     }

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/UpdateAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/UpdateAreaFrontCommand.ts
@@ -15,8 +15,8 @@ export class UpdateAreaFrontCommand extends UpdateAreaCommand implements FrontCo
     }
 
     public async execute(): Promise<void> {
-        const returnVal = super.execute();
-        this.areaEditorTool.handleAreaPreviewUpdate(this.newConfig);
+        const returnVal = await super.execute();
+        this.areaEditorTool.handleAreaUpdate(this.oldConfig, this.newConfig);
 
         return returnVal;
     }

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Entity/DeleteEntityFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Entity/DeleteEntityFrontCommand.ts
@@ -31,7 +31,13 @@ export class DeleteEntityFrontCommand extends DeleteEntityCommand implements Fro
         if (!this.entityData) {
             return new VoidFrontCommand();
         }
-        return new CreateEntityFrontCommand(this.gameMap, undefined, this.entityData, undefined, this.entitiesManager);
+        return new CreateEntityFrontCommand(
+            this.gameMap,
+            this.entityId,
+            this.entityData,
+            undefined,
+            this.entitiesManager
+        );
     }
 
     public emitEvent(roomConnection: RoomConnection): void {

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -247,6 +247,7 @@ export class MapEditorModeManager {
                 break;
             }
             case "z": {
+                // Todo replace with key combo https://photonstorm.github.io/phaser3-docs/Phaser.Input.Keyboard.KeyCombo.html
                 if (this.ctrlKey?.isDown) {
                     if (this.shiftKey?.isDown) {
                         this.runningUndoRedoCommand = this.runningUndoRedoCommand

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -152,21 +152,19 @@ export class MapEditorModeManager {
     // A simple queue to be sure we run only one undo or redo at once.
     private runningUndoRedoCommand: Promise<void> = Promise.resolve();
 
-    public undoCommand(): void {
+    public async undoCommand(): Promise<void> {
         if (this.localCommandsHistory.length === 0 || this.currentCommandIndex === -1) {
             return;
         }
         try {
             const command = this.localCommandsHistory[this.currentCommandIndex];
-            const undoCommand1 = command.getUndoCommand();
-            this.pendingCommands.push(command);
-            logger("adding command to pendingList : ", command);
-
-            // do any necessary changes for active tool interface
-            //this.handleCommandExecutionByTools(undoCommand1, true);
+            const undoCommand = command.getUndoCommand();
+            await undoCommand.execute();
+            this.pendingCommands.push(undoCommand);
+            logger("adding command to pendingList : ", undoCommand);
 
             // this should not be called with every change. Use some sort of debounce
-            this.emitMapEditorUpdate(undoCommand1);
+            this.emitMapEditorUpdate(undoCommand);
             this.currentCommandIndex -= 1;
         } catch (e) {
             this.localCommandsHistory.splice(this.currentCommandIndex, 1);
@@ -175,7 +173,7 @@ export class MapEditorModeManager {
         }
     }
 
-    public redoCommand(): void {
+    public async redoCommand(): Promise<void> {
         if (
             this.localCommandsHistory.length === 0 ||
             this.currentCommandIndex === this.localCommandsHistory.length - 1
@@ -184,7 +182,7 @@ export class MapEditorModeManager {
         }
         try {
             const command = this.localCommandsHistory[this.currentCommandIndex + 1];
-            //const commandConfig = await command.execute();
+            await command.execute();
             this.pendingCommands.push(command);
             logger("adding command to pendingList : ", command);
 
@@ -292,6 +290,9 @@ export class MapEditorModeManager {
                     }
                     return;
                 }
+
+                logger("Received command from server", editMapCommandMessage.id);
+
                 if (this.pendingCommands.length > 0) {
                     if (this.pendingCommands[0].commandId === editMapCommandMessage.id) {
                         logger("removing command of pendingList : ", editMapCommandMessage.id);

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -293,6 +293,7 @@ export class MapEditorModeManager {
 
                 logger("Received command from server", editMapCommandMessage.id);
 
+                // Local command execution (undo/redo)
                 if (this.pendingCommands.length > 0) {
                     if (this.pendingCommands[0].commandId === editMapCommandMessage.id) {
                         logger("removing command of pendingList : ", editMapCommandMessage.id);
@@ -302,6 +303,7 @@ export class MapEditorModeManager {
                     await this.revertPendingCommands();
                 }
 
+                // Remote command execution
                 for (const tool of Object.values(this.editorTools)) {
                     //eslint-disable-next-line no-await-in-loop
                     await tool.handleIncomingCommandMessage(editMapCommandMessage);

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -444,7 +444,9 @@ export class AreaEditorTool extends MapEditorTool {
         mapEditorSelectedAreaPreviewStore.set(undefined);
     }
 
-    public handleAreaPreviewCreation(config: AreaData, localCommand: boolean): void {
+    public handleAreaCreation(config: AreaData, localCommand: boolean): void {
+        this.scene.getGameMapFrontWrapper().listenAreaCreation(config);
+
         if (!this.active) {
             return;
         }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -563,12 +563,8 @@ export class AreaEditorTool extends MapEditorTool {
     private bindAreaPreviewEventHandlers(areaPreview: AreaPreview): void {
         areaPreview.on(AreaPreviewEvent.DragStart, () => {
             this.draggingdArea = true;
-            this.drawAreaOldPositionPreview(
-                areaPreview.x - areaPreview.width * 0.5,
-                areaPreview.y - areaPreview.height * 0.5,
-                areaPreview.width,
-                areaPreview.height
-            );
+            const areaData = areaPreview.getAreaData();
+            this.drawAreaOldPositionPreview(areaData.x, areaData.y, areaData.width, areaData.height);
         });
         areaPreview.on(AreaPreviewEvent.Released, () => {
             this.draggingdArea = false;

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -59,8 +59,8 @@ export class AreaEditorTool extends MapEditorTool {
         this.mapEditorModeManager = mapEditorModeManager;
         this.scene = this.mapEditorModeManager.getScene();
 
-        this.shiftKey = this.scene.input.keyboard?.addKey("SHIFT");
-        this.ctrlKey = this.scene.input.keyboard?.addKey("CTRL");
+        this.shiftKey = this.scene.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
+        this.ctrlKey = this.scene.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.CTRL);
 
         this.areaPreviews = this.createAreaPreviews();
         this.active = false;

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -432,7 +432,9 @@ export class AreaEditorTool extends MapEditorTool {
         mapEditorSelectedAreaPreviewStore.set(areaPreview);
     }
 
-    public handleAreaPreviewDeletion(id: string): void {
+    public handleAreaDeletion(id: string, areaData: AreaData | undefined): void {
+        this.scene.getGameMapFrontWrapper().listenAreaDeletion(areaData);
+
         if (!this.active) {
             return;
         }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -580,11 +580,16 @@ export class AreaEditorTool extends MapEditorTool {
         areaPreview.on(AreaPreviewEvent.Copied, (data: CopyAreaEventData) => {
             this.copyArea(data);
         });
-        areaPreview.on(AreaPreviewEvent.Updated, (data: AtLeast<AreaData, "id">) => {
-            this.mapEditorModeManager
-                .executeCommand(new UpdateAreaFrontCommand(this.scene.getGameMap(), data, undefined, undefined, this))
-                .catch((e) => console.error(e));
-        });
+        areaPreview.on(
+            AreaPreviewEvent.Updated,
+            (newData: AtLeast<AreaData, "id">, oldData: AtLeast<AreaData, "id"> | undefined) => {
+                this.mapEditorModeManager
+                    .executeCommand(
+                        new UpdateAreaFrontCommand(this.scene.getGameMap(), newData, undefined, oldData, this)
+                    )
+                    .catch((e) => console.error(e));
+            }
+        );
         areaPreview.on(AreaPreviewEvent.Delete, () => {
             this.mapEditorModeManager
                 .executeCommand(

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -466,7 +466,14 @@ export class AreaEditorTool extends MapEditorTool {
             return;
         }
 
-        this.areaPreviews.find((area) => area.getAreaData().id === newConfig.id)?.updatePreview(newConfig);
+        console.log("handleAreaUpdate", oldConfig, newConfig);
+
+        const area = this.areaPreviews.find((area) => area.getAreaData().id === newConfig.id);
+
+        if (area) {
+            area.updatePreview(newConfig);
+            mapEditorSelectedAreaPreviewStore.set(area);
+        }
 
         this.scene.markDirty();
     }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -455,12 +455,15 @@ export class AreaEditorTool extends MapEditorTool {
         }
     }
 
-    public handleAreaPreviewUpdate(config: AtLeast<AreaData, "id">): void {
+    public handleAreaUpdate(oldConfig: AtLeast<AreaData, "id">, newConfig: AtLeast<AreaData, "id">): void {
+        this.scene.getGameMapFrontWrapper().listenAreaChanges(oldConfig, newConfig);
+
         if (!this.active) {
             return;
         }
 
-        this.areaPreviews.find((area) => area.getAreaData().id === config.id)?.updatePreview(config);
+        this.areaPreviews.find((area) => area.getAreaData().id === newConfig.id)?.updatePreview(newConfig);
+
         this.scene.markDirty();
     }
 

--- a/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
@@ -181,7 +181,9 @@ export class TrashEditorTool extends EntityRelatedEditorTool {
         this.scene.input.off(Phaser.Input.Events.POINTER_OUT, this.pointerOutEventHandler);
     }
 
-    public handleAreaPreviewDeletion(id: string): void {
+    public handleAreaDeletion(id: string, areaData: AreaData | undefined): void {
+        this.scene.getGameMapFrontWrapper().listenAreaDeletion(areaData);
+
         if (!this.active) {
             return;
         }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
@@ -17,7 +17,7 @@ export class TrashEditorTool extends EntityRelatedEditorTool {
         super(mapEditorModeManager);
 
         this.active = false;
-        this.ctrlKey = this.scene.input.keyboard?.addKey("CTRL");
+        this.ctrlKey = this.scene.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.CTRL);
         this.areaPreviews = this.createAreaPreviews();
         this.bindEventHandlers();
     }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
@@ -5,6 +5,7 @@ import { AreaPreview, AreaPreviewEvent } from "../../../Components/MapEditor/Are
 import { DeleteAreaFrontCommand } from "../Commands/Area/DeleteAreaFrontCommand";
 import { mapEditorSelectedAreaPreviewStore } from "../../../../Stores/MapEditorStore";
 import { SizeAlteringSquare } from "../../../Components/MapEditor/SizeAlteringSquare";
+import { Entity } from "../../../ECS/Entity";
 import { EntityRelatedEditorTool } from "./EntityRelatedEditorTool";
 
 export class TrashEditorTool extends EntityRelatedEditorTool {
@@ -107,6 +108,14 @@ export class TrashEditorTool extends EntityRelatedEditorTool {
         if (!this.active) {
             return;
         }
+
+        const firstGameObject = gameObjects[0];
+
+        if (firstGameObject && firstGameObject instanceof Entity) {
+            firstGameObject.delete();
+            return;
+        }
+
         const areaEditorToolObjects = this.getAreaEditorToolObjectsFromGameObjects(gameObjects);
         if (areaEditorToolObjects.length === 1) {
             if (this.isAreaPreview(areaEditorToolObjects[0])) {

--- a/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
@@ -193,6 +193,17 @@ export class TrashEditorTool extends EntityRelatedEditorTool {
         mapEditorSelectedAreaPreviewStore.set(undefined);
     }
 
+    public handleAreaCreation(config: AreaData, localCommand: boolean): void {
+        this.scene.getGameMapFrontWrapper().listenAreaCreation(config);
+
+        if (!this.active) {
+            return;
+        }
+
+        this.createAreaPreview(config);
+        this.scene.markDirty();
+    }
+
     public handleAreaPreviewCreation(config: AreaData, localCommand: boolean): void {
         console.info("handleAreaPreviewCreation => No create area preview in trash mode");
     }


### PR DESCRIPTION
Fix the following issues:
- [x] When you are deleting a entity who is above an area both are removed
- [x] When you're in a test environment, an error message appears in the console to tell you that the wam file cannot be found.
- [x] When you delete an entity, it remains visible with low opacity.
- [x] Shortcut to undo/redo don't works properly
- [x] Update the size of the old area preview while your are moving an area
- [x] https://github.com/workadventure/workadventure/issues/3396
- [x] Fix old config on area properties update
- [ ] Trigger areas and entities when there are updated
  - [x] Trigger when an area is created
  - [x] Trigger when an area properties is updated
  - [x] Trigger when an area is resized
  - [x] Trigger when an area is deleted
  - [x] Trigger changes on reconnect
  - [x] Refresh properties interface on remote update or ctrl + z / ctrl + shift + z