### PR TITLE
Trying access by id before access by name for moveTo area

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2495,7 +2495,11 @@ ${escapedMessage}
                 if (posFromParam) {
                     endPos = this.gameMapFrontWrapper.getTileIndexAt(posFromParam.x, posFromParam.y);
                 } else {
-                    const areaData = this.gameMapFrontWrapper.getAreaByName(moveToParam);
+                    // First, try by id
+                    let areaData = this.gameMapFrontWrapper.getAreas()?.get(moveToParam);
+                    if (!areaData) {
+                        areaData = this.gameMapFrontWrapper.getAreaByName(moveToParam);
+                    }
                     if (areaData) {
                         const pixelEndPos = MathUtils.randomPositionFromRect(areaData);
                         endPos = this.gameMapFrontWrapper.getTileIndexAt(pixelEndPos.x, pixelEndPos.y);


### PR DESCRIPTION
`#moveto=` now accepts an area ID (checked before the area name).
Useful to target areas that don't have a name.