### PR TITLE
Adding support for retrieving hash from scripting API

### DIFF
--- a/docs/developer/map-scripting/references/api-room.md
+++ b/docs/developer/map-scripting/references/api-room.md
@@ -237,6 +237,28 @@ Check
 the [Tiled documentation to learn more about the format of the JSON map](https://doc.mapeditor.org/en/stable/reference/json-map-format/)
 .
 
+### Get the URL hash parameters
+
+```ts
+WA.room.hashParameters: Record<string, string>;
+```
+
+The parameters passed in the hash (#) are available in `WA.room.hashParameters` property.
+Use this to pass parameters from the URL to your script.
+
+:::info
+You need to wait for the end of the initialization before accessing `WA.room.hashParameters`
+:::
+
+```ts
+// If the URL is https://play.workadventu.re/_/global/mymap.org/map.json#myparam=hello
+
+WA.onInit().then(() => {
+  console.log("Map URL: ", WA.room.hashParameters.myparam);
+  // Will output something like: 'hello"
+});
+```
+
 ### Changing tiles
 
 ```ts

--- a/play/src/front/Api/Events/GameStateEvent.ts
+++ b/play/src/front/Api/Events/GameStateEvent.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const isGameStateEvent = z.object({
     roomId: z.string(),
+    hashParameters: z.record(z.string(), z.string()),
     mapUrl: z.string(),
     nickname: z.string(),
     language: z.string().optional(),

--- a/play/src/front/Api/Iframe/room.ts
+++ b/play/src/front/Api/Iframe/room.ts
@@ -32,6 +32,12 @@ export const setRoomId = (id: string) => {
     roomId = id;
 };
 
+let hashParameters: Record<string, string> | undefined;
+
+export const setHashParameters = (theHashParameters: Record<string, string>) => {
+    hashParameters = theHashParameters;
+};
+
 let mapURL: string | undefined;
 
 export const setMapURL = (url: string) => {
@@ -218,6 +224,19 @@ export class WorkadventureRoomCommands extends IframeApiContribution<Workadventu
             );
         }
         return mapURL;
+    }
+
+    /**
+     * The parameters behind the hash (#) of the URL are available from the WA.room.hashParameters property.
+     * They should follow the format key=value&key2=value2.
+     */
+    get hashParameters(): Record<string, string> {
+        if (hashParameters === undefined) {
+            throw new Error(
+                "hashParameters is not initialized yet. You should call WA.room.hashParameters within a WA.onInit callback."
+            );
+        }
+        return hashParameters;
     }
 
     /**

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1946,6 +1946,7 @@ ${escapedMessage}
             return {
                 playerId: this.connection?.getUserId(),
                 mapUrl: this.mapUrlFile,
+                hashParameters: urlManager.getHashParameters(),
                 startLayerName: this.startPositionCalculator.getStartPositionName() ?? undefined,
                 uuid: localUserStore.getLocalUser()?.uuid,
                 nickname: this.playerName,

--- a/play/src/front/Url/UrlManager.ts
+++ b/play/src/front/Url/UrlManager.ts
@@ -70,7 +70,7 @@ class UrlManager {
         history.pushState("", document.title, window.location.pathname + window.location.search);
     }
 
-    private getHashParameters(): Record<string, string> {
+    public getHashParameters(): Record<string, string> {
         return window.location.hash
             .substring(1)
             .split("&")

--- a/play/src/iframe_api.ts
+++ b/play/src/iframe_api.ts
@@ -13,7 +13,7 @@ import controls from "./front/Api/Iframe/controls";
 import ui from "./front/Api/Iframe/ui";
 import sound from "./front/Api/Iframe/sound";
 import event from "./front/Api/Iframe/event";
-import room, { setMapURL, setRoomId } from "./front/Api/Iframe/room";
+import room, { setHashParameters, setMapURL, setRoomId } from "./front/Api/Iframe/room";
 import { createState } from "./front/Api/Iframe/state";
 import player, {
     setPlayerName,
@@ -77,6 +77,7 @@ const initPromise = queryWorkadventure({
     setPlayerName(gameState.nickname);
     setPlayerLanguage(gameState.language);
     setRoomId(gameState.roomId);
+    setHashParameters(gameState.hashParameters);
     setMapURL(gameState.mapUrl);
     setTags(gameState.tags);
     setUuid(gameState.uuid);

--- a/tests/tests/iframe_script.spec.ts
+++ b/tests/tests/iframe_script.spec.ts
@@ -77,4 +77,22 @@ test.describe('Iframe API', () => {
 
     await expect(page.locator('.menu-container')).toContainText("Share the link of the room");
   });
+
+  test('base room properties', async ({
+                                                          page
+                                                        }) => {
+    await page.goto(
+        'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json#foo=bar'
+    );
+
+    await login(page);
+
+    const parameter = await evaluateScript(page, async () => {
+      await WA.onInit();
+
+      return WA.room.hashParameters.foo;
+    });
+
+    expect(parameter).toEqual('bar');
+  });
 });


### PR DESCRIPTION
The new `WA.room.hashParameters` property that contains the hash, parsed like GET parameters.

TODO:

- [x] Add tests