### PR TITLE
Adding the ability to a play a sound to players in a bubble

### DIFF
--- a/docs/developer/map-scripting/references/api-player.md
+++ b/docs/developer/map-scripting/references/api-player.md
@@ -474,3 +474,24 @@ WA.player.proximityMeeting.onParticipantLeave().subscribe(async (player: RemoteP
     WA.chat.sendChatMessage("A participant left the proximity chat", "System");
 });
 ```
+
+## Playing a sound to players in the same meeting
+
+:::warning
+This feature is experimental. The signature of the function might change in the future.
+:::
+
+```ts
+WA.player.proximityMeeting.playSound(url: string): Promise<void>
+```
+
+The `playSound` function plays a sound to all the players in the same bubble.
+The sound will appear to come from the microphone of the player who called the function.
+
+Example:
+
+```ts
+await WA.player.proximityMeeting.playSound("https://example.com/my_sound.mp3");
+```
+
+The method returns a promise that resolves when the sound has been played.

--- a/maps/tests/SoundInBubble/sound_in_bubble.js
+++ b/maps/tests/SoundInBubble/sound_in_bubble.js
@@ -1,0 +1,11 @@
+/// <reference types="@workadventure/iframe-api-typings/iframe_api" />
+
+WA.onInit().then(() => {
+    WA.player.proximityMeeting.onJoin().subscribe(() => {
+        setTimeout(() => {
+            WA.player.proximityMeeting.playSound('../Audience.mp3').catch((e) => {
+                console.error('Error while playing sound', e);
+            });
+        }, 1000);
+    });
+});

--- a/maps/tests/SoundInBubble/sound_in_bubble.tmj
+++ b/maps/tests/SoundInBubble/sound_in_bubble.tmj
@@ -1,0 +1,122 @@
+{ "compressionlevel":-1,
+ "height":10,
+ "infinite":false,
+ "layers":[
+        {
+         "data":[1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+         "height":10,
+         "id":1,
+         "name":"floor",
+         "opacity":1,
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "data":[0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            12, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+         "height":10,
+         "id":2,
+         "name":"start",
+         "opacity":1,
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "draworder":"topdown",
+         "id":3,
+         "name":"floorLayer",
+         "objects":[
+                {
+                 "height":304.037037037037,
+                 "id":3,
+                 "name":"",
+                 "rotation":0,
+                 "text":
+                    {
+                     "fontfamily":"Sans Serif",
+                     "pixelsize":11,
+                     "text":"Test:\n - Open chat,\n - Check if chat message was received in TimeLine",
+                     "wrap":true
+                    },
+                 "type":"",
+                 "visible":false,
+                 "width":252.4375,
+                 "x":2.78125,
+                 "y":2.5
+                }, 
+                {
+                 "height":122.296875,
+                 "id":11,
+                 "name":"",
+                 "rotation":0,
+                 "text":
+                    {
+                     "text":"Start a bubble.\nAfter 1 second, a sound should be played to both participants originating from the other participant.",
+                     "wrap":true
+                    },
+                 "type":"",
+                 "visible":true,
+                 "width":286.21875,
+                 "x":8.63048497102848,
+                 "y":9.23362430589087
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
+        }],
+ "nextlayerid":9,
+ "nextobjectid":12,
+ "orientation":"orthogonal",
+ "properties":[
+        {
+         "name":"script",
+         "type":"string",
+         "value":"sound_in_bubble.js"
+        }],
+ "renderorder":"right-down",
+ "tiledversion":"1.10.2",
+ "tileheight":32,
+ "tilesets":[
+        {
+         "columns":11,
+         "firstgid":1,
+         "image":"..\/tileset1.png",
+         "imageheight":352,
+         "imagewidth":352,
+         "margin":0,
+         "name":"tileset1",
+         "spacing":0,
+         "tilecount":121,
+         "tileheight":32,
+         "tilewidth":32
+        }],
+ "tilewidth":32,
+ "type":"map",
+ "version":"1.10",
+ "width":10
+}

--- a/maps/tests/index.html
+++ b/maps/tests/index.html
@@ -461,6 +461,14 @@
                 </tr>
                 <tr>
                     <td>
+                        <input type="radio" name="test-proximitymeetingsounds"> Success <input type="radio" name="test-proximitymeetingsounds"> Failure <input type="radio" name="test-proximitymeetingsounds" checked> Pending
+                    </td>
+                    <td>
+                        <a href="#" class="testLink" data-testmap="SoundInBubble/sound_in_bubble.tmj" target="_blank">Play a sound to bubble participants from the scripting API</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <input type="radio" name="test-modalevents"> Success <input type="radio" name="test-modalevents"> Failure <input type="radio" name="test-modalevents" checked> Pending
                     </td>
                     <td>

--- a/play/index.html
+++ b/play/index.html
@@ -13,7 +13,7 @@
         />
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; font-src * data: ; frame-src *; style-src * 'unsafe-inline';" />
+            content="default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src data: * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; font-src * data: ; frame-src *; style-src * 'unsafe-inline';" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
         <!-- TRACK CODE -->

--- a/play/src/front/Api/Events/IframeEvent.ts
+++ b/play/src/front/Api/Events/IframeEvent.ts
@@ -61,6 +61,7 @@ import { isBannerEvent } from "./Ui/BannerEvent";
 import { isTeleportPlayerToEventConfig } from "./TeleportPlayerToEvent";
 import { isSendEventEvent } from "./SendEventEvent";
 import { isReceiveEventEvent } from "./ReceiveEventEvent";
+import { isPlaySoundInBubbleEvent } from "./ProximityMeeting/PlaySoundInBubbleEvent";
 
 export interface TypedMessageEvent<T> extends MessageEvent {
     data: T;
@@ -603,6 +604,10 @@ export const iframeQueryMapTypeGuards = {
     getWoka: {
         query: z.undefined(),
         answer: z.string(),
+    },
+    playSoundInBubble: {
+        query: isPlaySoundInBubbleEvent,
+        answer: z.undefined(),
     },
 };
 

--- a/play/src/front/Api/Events/ProximityMeeting/PlaySoundInBubbleEvent.ts
+++ b/play/src/front/Api/Events/ProximityMeeting/PlaySoundInBubbleEvent.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const isPlaySoundInBubbleEvent = z.object({
+    url: z.string(),
+});
+
+/**
+ * A message sent from the iFrame to the game to play a message to all players in a bubble.
+ */
+export type PlaySoundInBubbleEvent = z.infer<typeof isPlaySoundInBubbleEvent>;

--- a/play/src/front/Api/Iframe/Player/ProximityMeeting.ts
+++ b/play/src/front/Api/Iframe/Player/ProximityMeeting.ts
@@ -2,7 +2,7 @@ import { Subject } from "rxjs";
 import type { JoinProximityMeetingEvent } from "../../Events/ProximityMeeting/JoinProximityMeetingEvent";
 import type { ParticipantProximityMeetingEvent } from "../../Events/ProximityMeeting/ParticipantProximityMeetingEvent";
 
-import { IframeApiContribution } from "../IframeApiContribution";
+import { IframeApiContribution, queryWorkadventure } from "../IframeApiContribution";
 import { RemotePlayer } from "../Players/RemotePlayer";
 import { apiCallback } from "../registeredCallbacks";
 
@@ -87,6 +87,15 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
             leaveStream = new Subject<void>();
         }
         return leaveStream;
+    }
+
+    async playSound(url: string): Promise<void> {
+        await queryWorkadventure({
+            type: "playSoundInBubble",
+            data: {
+                url: url,
+            },
+        });
     }
 }
 

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2218,6 +2218,11 @@ ${escapedMessage}
             }
             scriptUtils.goToPage("/login");
         });
+
+        iframeListener.registerAnswerer("playSoundInBubble", async (message) => {
+            const soundUrl = new URL(message.url, this.mapUrlFile);
+            await this.simplePeer.dispatchSound(soundUrl);
+        });
     }
 
     private setPropertyLayer(
@@ -2379,6 +2384,7 @@ ${escapedMessage}
         iframeListener.unregisterAnswerer("closeUIWebsite");
         iframeListener.unregisterAnswerer("enablePlayersTracking");
         iframeListener.unregisterAnswerer("goToLogin");
+        iframeListener.unregisterAnswerer("playSoundInBubble");
         this.sharedVariablesManager?.close();
         this.playerVariablesManager?.close();
         this.scriptingEventsManager?.close();

--- a/play/src/front/Stores/ApparentMediaContraintStore.ts
+++ b/play/src/front/Stores/ApparentMediaContraintStore.ts
@@ -1,0 +1,38 @@
+import { derived, writable } from "svelte/store";
+import { obtainedMediaConstraintStore } from "./MediaStore";
+
+/**
+ * A store that contains the camera state requested by the user (on or off).
+ */
+function createNbSoundPlayedInBubbleStore() {
+    const { subscribe, update } = writable(0);
+
+    return {
+        subscribe,
+        soundStarted: () => {
+            update((n) => n + 1);
+        },
+        soundEnded: () => {
+            update((n) => n - 1);
+        },
+    };
+}
+export const nbSoundPlayedInBubbleStore = createNbSoundPlayedInBubbleStore();
+
+/**
+ * The "apparent media constraint store" represents what the OTHER users see as the media constraint for this user.
+ * It is used to display / hide the webcam or the muted sound icon.
+ *
+ * It is based on the "obtained media constraint store" (so whether the user is really streaming or not)
+ * but it adds on top of it the fact that the user could be sending a sound in the bubbles (via the scripting API)
+ * If the user sends a sound, the "audio" is turn on.
+ */
+export const apparentMediaContraintStore = derived(
+    [obtainedMediaConstraintStore, nbSoundPlayedInBubbleStore],
+    ([$obtainedMediaConstraintStore, $nbSoundPlayedInBubbleStore]) => {
+        return {
+            ...$obtainedMediaConstraintStore,
+            audio: $obtainedMediaConstraintStore.audio || $nbSoundPlayedInBubbleStore > 0,
+        };
+    }
+);

--- a/play/src/front/WebRtc/VideoPeer.ts
+++ b/play/src/front/WebRtc/VideoPeer.ts
@@ -3,7 +3,7 @@ import type { Subscription } from "rxjs";
 import { Readable, Writable, Unsubscriber, get, readable, writable } from "svelte/store";
 import Peer from "simple-peer/simplepeer.min.js";
 import type { RoomConnection } from "../Connection/RoomConnection";
-import { localStreamStore, obtainedMediaConstraintStore, videoBandwidthStore } from "../Stores/MediaStore";
+import { localStreamStore, videoBandwidthStore } from "../Stores/MediaStore";
 import { playersStore } from "../Stores/PlayersStore";
 import {
     chatMessagesService,
@@ -14,6 +14,7 @@ import {
 import { getIceServersConfig, getSdpTransform } from "../Components/Video/utils";
 import { SoundMeter } from "../Phaser/Components/SoundMeter";
 import { gameManager } from "../Phaser/Game/GameManager";
+import { apparentMediaContraintStore } from "../Stores/ApparentMediaContraintStore";
 import type { ConstraintMessage, ObtainedMediaStreamConstraints } from "./P2PMessages/ConstraintMessage";
 import type { UserSimplePeerInterface } from "./SimplePeer";
 import { blackListManager } from "./BlackListManager";
@@ -47,7 +48,7 @@ export class VideoPeer extends Peer {
     private newWritingStatusMessageSubscription: Subscription | undefined;
     private volumeStoreSubscribe?: Unsubscriber;
     private readonly localStreamStoreSubscribe: Unsubscriber;
-    private readonly obtainedMediaConstraintStoreSubscribe: Unsubscriber;
+    private readonly apparentMediaConstraintStoreSubscribe: Unsubscriber;
 
     constructor(
         public user: UserSimplePeerInterface,
@@ -243,7 +244,7 @@ export class VideoPeer extends Peer {
         this.localStreamStoreSubscribe = localStreamStore.subscribe((streamValue) => {
             if (streamValue.type === "success" && streamValue.stream) this.addStream(streamValue.stream);
         });
-        this.obtainedMediaConstraintStoreSubscribe = obtainedMediaConstraintStore.subscribe((constraints) => {
+        this.apparentMediaConstraintStoreSubscribe = apparentMediaContraintStore.subscribe((constraints) => {
             this.write(
                 new Buffer(
                     JSON.stringify({
@@ -309,7 +310,7 @@ export class VideoPeer extends Peer {
             this.newWritingStatusMessageSubscription?.unsubscribe();
             chatMessagesService.addOutcomingUser(this.userId);
             if (this.localStreamStoreSubscribe) this.localStreamStoreSubscribe();
-            if (this.obtainedMediaConstraintStoreSubscribe) this.obtainedMediaConstraintStoreSubscribe();
+            if (this.apparentMediaConstraintStoreSubscribe) this.apparentMediaConstraintStoreSubscribe();
             if (this.volumeStoreSubscribe) this.volumeStoreSubscribe();
             super.destroy();
         } catch (err) {


### PR DESCRIPTION
The scripting API can now play a sound (from any valid URL) to all the players in a bubble. The sound will appear to originate from the microphone of the player who is calling the new method.

```ts
await WA.player.proximityMeeting.playSound("https://example.com/my_sound.mp3");
```