### PR TITLE
Fixing contextual menu customization

### DIFF
--- a/play/src/front/Phaser/Entity/RemotePlayer.ts
+++ b/play/src/front/Phaser/Entity/RemotePlayer.ts
@@ -10,6 +10,7 @@ import type { ActivatableInterface } from "../Game/ActivatableInterface";
 import { LL } from "../../../i18n/i18n-svelte";
 import { blackListManager } from "../../WebRtc/BlackListManager";
 import { showReportScreenStore } from "../../Stores/ShowReportScreenStore";
+import { iframeListener } from "../../Api/IframeListener";
 
 export enum RemotePlayerEvent {
     Clicked = "Clicked",
@@ -104,6 +105,15 @@ export class RemotePlayer extends Character implements ActivatableInterface {
         for (const action of this.getDefaultActionsMenuActions()) {
             actionsMenuStore.addAction(action);
         }
+
+        const userFound = this.scene.getRemotePlayersRepository().getPlayers().get(this.userId);
+
+        if (!userFound) {
+            console.error("Undefined clicked player!");
+            return;
+        }
+
+        iframeListener.sendRemotePlayerClickedEvent(userFound);
     }
 
     private getDefaultActionsMenuActions(): ActionsMenuAction[] {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -45,7 +45,7 @@ import { localUserStore } from "../../Connection/LocalUserStore";
 import { HtmlUtils } from "../../WebRtc/HtmlUtils";
 import { SimplePeer } from "../../WebRtc/SimplePeer";
 import { Loader } from "../Components/Loader";
-import { RemotePlayer, RemotePlayerEvent } from "../Entity/RemotePlayer";
+import { RemotePlayer } from "../Entity/RemotePlayer";
 import { SelectCharacterScene, SelectCharacterSceneName } from "../Login/SelectCharacterScene";
 import { hasMovedEventName, Player, requestEmoteEventName } from "../Player/Player";
 import { ErrorSceneName } from "../Reconnecting/ErrorScene";
@@ -2881,17 +2881,6 @@ ${escapedMessage}
         player.on(Phaser.Input.Events.POINTER_OUT, () => {
             this.activatablesManager.handlePointerOutActivatableObject();
             this.markDirty();
-        });
-
-        player.on(RemotePlayerEvent.Clicked, () => {
-            const userFound = this.remotePlayersRepository.getPlayers().get(player.userId);
-
-            if (!userFound) {
-                console.error("Undefined clicked player!");
-                return;
-            }
-
-            iframeListener.sendRemotePlayerClickedEvent(userFound);
         });
     }
 


### PR DESCRIPTION
The customization of the contextual menu of users was broken due to a race condition in event handling. The custom menu was added on "mouse down", but the menu was reset on "mouse up".

Now, the menu is reset, and then scripts are asked for customization in the same method.