### PR TITLE
Saving textures in Admin + Refactoring errors

### DIFF
--- a/libs/messages/src/JsonMessages/CapabilitiesData.ts
+++ b/libs/messages/src/JsonMessages/CapabilitiesData.ts
@@ -18,6 +18,10 @@ export const isCapabilities = z.object({
         description: "Means the api can save the name of the Woka when configured in WorkAdventure.",
         example: "v1",
     }),
+    "api/save-textures": extendApi(z.optional(z.string()), {
+        description: "Means the api can save the textures of the Woka when configured in WorkAdventure.",
+        example: "v1",
+    }),
 });
 
 export type Capabilities = z.infer<typeof isCapabilities>;

--- a/libs/messages/src/JsonMessages/ErrorApiData.ts
+++ b/libs/messages/src/JsonMessages/ErrorApiData.ts
@@ -3,6 +3,7 @@ import { extendApi } from "@anatine/zod-openapi";
 
 export const isErrorApiErrorData = extendApi(
   z.object({
+    status: z.literal("error"),
     type: z.literal("error"),
     code: extendApi(z.string(), {
       description:
@@ -38,6 +39,7 @@ export const isErrorApiErrorData = extendApi(
 
 export const isErrorApiRetryData = extendApi(
   z.object({
+    status: z.literal("error"),
     type: z.literal("retry"),
     code: extendApi(z.string(), {
       description:
@@ -88,6 +90,7 @@ export const isErrorApiRetryData = extendApi(
 
 export const isErrorApiRedirectData = extendApi(
   z.object({
+    status: z.literal("error"),
     type: z.literal("redirect"),
     urlToRedirect: extendApi(z.string(), {
       description: "A URL specified to redirect the user onto it directly",
@@ -103,6 +106,7 @@ export const isErrorApiRedirectData = extendApi(
 
 export const isErrorApiUnauthorizedData = extendApi(
   z.object({
+    status: z.literal("error"),
     type: z.literal("unauthorized"),
     code: extendApi(z.string(), {
       description:

--- a/libs/messages/src/JsonMessages/MeRequest.ts
+++ b/libs/messages/src/JsonMessages/MeRequest.ts
@@ -1,0 +1,10 @@
+import {z} from "zod";
+
+export const MeRequest = z.object({
+    token: z.string(),
+    playUri: z.string(),
+    localStorageCharacterTextureIds: z.array(z.string()).optional(),
+    localStorageCompanionTextureId: z.string().optional(),
+});
+
+export type MeRequest = z.infer<typeof MeRequest>;

--- a/libs/messages/src/JsonMessages/MeResponse.ts
+++ b/libs/messages/src/JsonMessages/MeResponse.ts
@@ -1,6 +1,7 @@
 import {z} from "zod";
 import {extendApi} from "@anatine/zod-openapi";
 import {ErrorApiData} from "./ErrorApiData";
+import {WokaDetail} from "./PlayerTextures";
 
 export const MeSuccessResponse = extendApi(
     z.object({
@@ -38,6 +39,16 @@ export const MeSuccessResponse = extendApi(
         visitCardUrl: extendApi(z.string().nullable().optional(), {
             description:
                 "The visit card URL of the Woka.",
+        }),
+        isCharacterTexturesValid: extendApi(z.boolean(), {
+            description:
+                "True if the character textures are valid, false if we need to redirect the user to the Woka selection page.",
+            example: true,
+        }),
+        isCompanionTextureValid: extendApi(z.boolean(), {
+            description:
+                "True if the companion texture is valid, false if we need to redirect the user to the companion selection page.",
+            example: true,
         }),
     }),
     {

--- a/libs/messages/src/JsonMessages/MeResponse.ts
+++ b/libs/messages/src/JsonMessages/MeResponse.ts
@@ -1,0 +1,52 @@
+import {z} from "zod";
+import {extendApi} from "@anatine/zod-openapi";
+import {ErrorApiData} from "./ErrorApiData";
+
+export const MeSuccessResponse = extendApi(
+    z.object({
+        status: z.literal("ok"),
+        authToken: extendApi(z.string(), {
+            description:
+                "The authToken.",
+        }),
+        userUuid: extendApi(z.string(), {
+            description: "A unique identifier for the user.",
+        }),
+        email: extendApi(z.string().nullable().optional(), {
+            description:
+                "The email of the user.",
+        }),
+        username: extendApi(z.string().nullable().optional(), {
+            description:
+                "The name of the Woka.",
+            example:
+                "John",
+        }),
+        locale: extendApi(z.string().nullable().optional(), {
+            description:
+                "The locale (if returned by OpenID Connect).",
+        }),
+        /*textures: extendApi(z.array(z.object({
+            id: extendApi(z.string(), {
+                description:
+                    "The id of the texture.",
+            }),
+        })), {
+            description:
+                "The textures of the Woka.",
+        }),*/
+        visitCardUrl: extendApi(z.string().nullable().optional(), {
+            description:
+                "The visit card URL of the Woka.",
+        }),
+    }),
+    {
+        description:
+            'This is a response to the /me endpoint.',
+    }
+);
+
+export type MeSuccessResponse = z.infer<typeof MeSuccessResponse>;
+
+export const MeResponse = z.union([MeSuccessResponse, ErrorApiData]);
+export type MeResponse = z.infer<typeof MeResponse>;

--- a/libs/messages/src/index.ts
+++ b/libs/messages/src/index.ts
@@ -16,3 +16,4 @@ export * from './JsonMessages/RegisterData';
 export * from './JsonMessages/RoomRedirect';
 export * from './JsonMessages/OpidWokaNamePolicy';
 export * from './JsonMessages/MeResponse';
+export * from './JsonMessages/MeRequest';

--- a/libs/messages/src/index.ts
+++ b/libs/messages/src/index.ts
@@ -15,3 +15,4 @@ export * from './JsonMessages/PlayerTextures';
 export * from './JsonMessages/RegisterData';
 export * from './JsonMessages/RoomRedirect';
 export * from './JsonMessages/OpidWokaNamePolicy';
+export * from './JsonMessages/MeResponse';

--- a/play/src/front/Components/Chat/Chat.svelte
+++ b/play/src/front/Components/Chat/Chat.svelte
@@ -45,7 +45,7 @@
     let wokaSrc =
         " data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAAAdCAYAAABBsffGAAAB/ElEQVRIia1WMW7CQBC8EAoqFy74AD1FqNzkAUi09DROwwN4Ag+gMQ09dcQXXNHQIucBPAJFc2Iue+dd40QZycLc7c7N7d7u+cU9wXw+ryyL0+n00eU9tCZIOp1O/f/ZbBbmzuczX6uuRVTlIAYpCSeTScumaZqw0OVyURd47SIGaZ7n6s4wjmc0Grn7/e6yLFtcr9dPaaOGhcTEeDxu2dxut2hXUJ9ioKmW0IidMg6/NPmD1EmqtojTBWAvE26SW8r+YhfIu87zbyB5BiRerVYtikXxXuLRuK058HABMyz/AX8UHwXgV0NRaEXzDKzaw+EQCioo1yrsLfvyjwZrTvK0yp/xh/o+JwbFhFYgFRNqzGEIB1ZhH2INkXJZoShn2WNSgJRNS/qoYSHxer1+qkhChnC320ULRI1LEsNhv99HISBkLmhP/7L8OfqhiKC6SzEJtSTLHMkGFhK6XC79L89rmtC6rv0YfjXV9COPDwtVQxEc2ZflIu7R+WADQrkA7eCH5BdFwQRXQ8bKxXejeWFoYZGCQM7Yh7BAkcw0DEnEEPHhbjBPQfCDvwzlEINlWZq3OAiOx2O0KwAKU8gehXfzu2Wz2VQMTXqCeLZZSNvtVv20MFsu48gQpDvjuHYxE+ZHESBPSJ/x3sqBvhe0hc5vRXkfypBY4xGcc9+lcFxartG6LgAAAABJRU5ErkJggg==";
     const playUri = window.location.protocol + "//" + window.location.hostname + window.location.pathname;
-    let name = localUserStore.getName() ?? "unknown";
+    let name = gameManager.getPlayerName() ?? "unknown";
     name = name.replace(
         /[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}]/gu,
         (match) => {

--- a/play/src/front/Components/MyCamera.svelte
+++ b/play/src/front/Components/MyCamera.svelte
@@ -11,7 +11,7 @@
     } from "../Stores/MediaStore";
     import { LL } from "../../i18n/i18n-svelte";
     import { inExternalServiceStore } from "../Stores/MyMediaStore";
-    import { localUserStore } from "../Connection/LocalUserStore";
+    import { gameManager } from "../Phaser/Game/GameManager";
     import SoundMeterWidget from "./SoundMeterWidget.svelte";
     import { srcObject } from "./Video/utils";
     import Woka from "./Woka/WokaFromUserId.svelte";
@@ -19,7 +19,7 @@
     import cameraOffImg from "./images/camera-off.png";
 
     let stream: MediaStream | null;
-    let userName = localUserStore.getName();
+    let userName = gameManager.getPlayerName();
     let backgroundColor = Color.getColorByString(userName ?? "default");
     let textColor = Color.getTextColorByBackgroundColor(backgroundColor);
 

--- a/play/src/front/Components/ReportMenu/ReportSubMenu.svelte
+++ b/play/src/front/Components/ReportMenu/ReportSubMenu.svelte
@@ -2,7 +2,6 @@
     import { showReportScreenStore, userReportEmpty } from "../../Stores/ShowReportScreenStore";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { LL } from "../../../i18n/i18n-svelte";
-    import { localUserStore } from "../../Connection/LocalUserStore";
 
     export let userUUID: string | undefined;
     export let userName: string | undefined;
@@ -25,7 +24,7 @@
             }
             reportMessage = `
                 -- Date: ${new Date().getTime()} -- \r
-                -- Reporter: ${localUserStore.getName()} -- \r
+                -- Reporter: ${gameManager.getPlayerName()} -- \r
                 -- Reported: ${userName} -- \n\r
                 ${reportMessage}
             `;

--- a/play/src/front/Components/SelectCharacter/SelectCharacterScene.svelte
+++ b/play/src/front/Components/SelectCharacter/SelectCharacterScene.svelte
@@ -23,7 +23,9 @@
     }
 
     function cameraScene() {
-        selectCharacterScene.nextSceneToCameraScene();
+        selectCharacterScene.nextSceneToCameraScene().catch((e) => {
+            console.error(e);
+        });
     }
 
     function customizeScene() {

--- a/play/src/front/Components/SelectCompanion/SelectCompanionScene.svelte
+++ b/play/src/front/Components/SelectCompanion/SelectCompanionScene.svelte
@@ -22,7 +22,7 @@
     }
 
     function selectCompanion() {
-        selectCompanionScene.selectCompanion();
+        selectCompanionScene.selectCompanion().catch((e) => console.error(e));
     }
 
     function selectLeftCollection() {

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -251,7 +251,7 @@
         {#if videoEnabled}
             {#if displayNoVideoWarning}
                 <div
-                    class="tw-flex media-box-camera-on-size tw-absolute tw-justify-center tw-items-center tw-bg-danger/50 tw-text-white"
+                    class="tw-flex media-box-camera-on-size tw-absolute tw-w-full tw-h-full ntw-justify-center tw-items-center tw-bg-danger/50 tw-text-white"
                 >
                     <div class="tw-text-center">
                         <h1>{$LL.video.connection_issue()}</h1>

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -1,5 +1,5 @@
 import type { AvailabilityStatus } from "@workadventure/messages";
-import { isRegisterData, MeResponse } from "@workadventure/messages";
+import { isRegisterData, MeRequest, MeResponse } from "@workadventure/messages";
 import { isAxiosError } from "axios";
 import { analyticsClient } from "../Administration/AnalyticsClient";
 import { subMenusStore, userIsConnected, warningContainerStore } from "../Stores/MenuStore";
@@ -425,16 +425,21 @@ class ConnectionManager {
         //set connected store for menu at false
         userIsConnected.set(false);
 
+        const playUri = this.currentRoom?.key;
+        if (playUri == undefined) {
+            throw new Error("playUri is undefined");
+        }
+
         // TODO: the call to "/me" could be completely removed and the request data could come from the FrontController
         // For this to work, the authToken should be stored in a cookie instead of localStorage.
         const data = await axiosToPusher
             .get("me", {
                 params: {
                     token,
-                    playUri: this.currentRoom?.key,
+                    playUri,
                     localStorageCharacterTextureIds: localUserStore.getCharacterTextures() ?? undefined,
-                    localStorageCompanionTextureId: localUserStore.getCompanionTextureId(),
-                },
+                    localStorageCompanionTextureId: localUserStore.getCompanionTextureId() ?? undefined,
+                } satisfies MeRequest,
             })
             .then((res) => {
                 return res.data;

--- a/play/src/front/Phaser/Game/GameManager.ts
+++ b/play/src/front/Phaser/Game/GameManager.ts
@@ -12,7 +12,6 @@ import {
 import { menuIconVisiblilityStore } from "../../Stores/MenuStore";
 import { EnableCameraSceneName } from "../Login/EnableCameraScene";
 import { LoginSceneName } from "../Login/LoginScene";
-import { SelectCharacterSceneName } from "../Login/SelectCharacterScene";
 import { EmptySceneName } from "../Login/EmptyScene";
 import { gameSceneIsLoadedStore } from "../../Stores/GameSceneStore";
 import { myCameraStore } from "../../Stores/MyMediaStore";
@@ -59,9 +58,6 @@ export class GameManager {
         //If Room si not public and Auth was not set, show login scene to authenticate user (OpenID - SSO - Anonymous)
         if (!this.playerName || (this.startRoom.authenticationMandatory && !localUserStore.getAuthToken())) {
             return LoginSceneName;
-        } else if (!this.characterTextureIds) {
-            console.info("Any Woka texture has been found, you will be redirect to the Woka selection scene");
-            return SelectCharacterSceneName;
         } else if (preferredVideoInputDeviceId === undefined || preferredAudioInputDeviceId === undefined) {
             return EnableCameraSceneName;
         } else {

--- a/play/src/front/Phaser/Game/GameManager.ts
+++ b/play/src/front/Phaser/Game/GameManager.ts
@@ -94,7 +94,11 @@ export class GameManager {
 
     public setCharacterTextureIds(textureIds: string[]): void {
         this.characterTextureIds = textureIds;
-        localUserStore.setCharacterTextures(textureIds);
+        // Only save the textures if the user is not logged in
+        // If the user is logged in, the textures will be fetched from the server. No need to save them locally.
+        if (!localUserStore.isLogged()) {
+            localUserStore.setCharacterTextures(textureIds);
+        }
     }
 
     getPlayerName(): string | null {

--- a/play/src/front/Phaser/Game/GameManager.ts
+++ b/play/src/front/Phaser/Game/GameManager.ts
@@ -111,10 +111,7 @@ export class GameManager {
         return this.visitCardUrl;
     }
 
-    getCharacterTextureIds(): string[] {
-        if (!this.characterTextureIds) {
-            throw new Error("characterTextures are not set");
-        }
+    getCharacterTextureIds(): string[] | null {
         return this.characterTextureIds;
     }
 

--- a/play/src/front/Phaser/Game/GameManager.ts
+++ b/play/src/front/Phaser/Game/GameManager.ts
@@ -12,9 +12,11 @@ import {
 import { menuIconVisiblilityStore } from "../../Stores/MenuStore";
 import { EnableCameraSceneName } from "../Login/EnableCameraScene";
 import { LoginSceneName } from "../Login/LoginScene";
+import { SelectCharacterSceneName } from "../Login/SelectCharacterScene";
 import { EmptySceneName } from "../Login/EmptyScene";
 import { gameSceneIsLoadedStore } from "../../Stores/GameSceneStore";
 import { myCameraStore } from "../../Stores/MyMediaStore";
+import { SelectCompanionSceneName } from "../Login/SelectCompanionScene";
 import { GameScene } from "./GameScene";
 
 /**
@@ -45,7 +47,7 @@ export class GameManager {
             // so we need to redirect to an empty Phaser scene, waiting for the redirection to take place
             return EmptySceneName;
         }
-        this.startRoom = result;
+        this.startRoom = result.room;
         this.loadMap(this.startRoom);
 
         const preferredAudioInputDeviceId = localUserStore.getPreferredAudioInputDevice();
@@ -58,6 +60,10 @@ export class GameManager {
         //If Room si not public and Auth was not set, show login scene to authenticate user (OpenID - SSO - Anonymous)
         if (!this.playerName || (this.startRoom.authenticationMandatory && !localUserStore.getAuthToken())) {
             return LoginSceneName;
+        } else if (result.nextScene === "selectCharacterScene") {
+            return SelectCharacterSceneName;
+        } else if (result.nextScene === "selectCompanionScene") {
+            return SelectCompanionSceneName;
         } else if (preferredVideoInputDeviceId === undefined || preferredAudioInputDeviceId === undefined) {
             return EnableCameraSceneName;
         } else {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -281,6 +281,7 @@ export class GameScene extends DirtyScene {
     private throttledSendViewportToServer!: () => void;
     private playersDebugLogAlreadyDisplayed = false;
     private _broadcastService: BroadcastService | undefined;
+    private hideTimeout: ReturnType<typeof setTimeout> | undefined;
 
     constructor(private _room: Room, customKey?: string | undefined) {
         super({
@@ -806,7 +807,8 @@ export class GameScene extends DirtyScene {
                 }, 0);
             } else if (this.connection === undefined) {
                 // Let's wait 1 second before printing the "connecting" screen to avoid blinking
-                setTimeout(() => {
+                this.hideTimeout = setTimeout(() => {
+                    this.hideTimeout = undefined;
                     if (this.connection === undefined) {
                         try {
                             this.hide();
@@ -2436,6 +2438,10 @@ ${escapedMessage}
         gameSceneIsLoadedStore.set(false);
         gameSceneStore.set(undefined);
         this.cleanupDone = true;
+        if (this.hideTimeout) {
+            clearTimeout(this.hideTimeout);
+            this.hideTimeout = undefined;
+        }
     }
 
     private removeAllRemotePlayers(): void {

--- a/play/src/front/Phaser/Login/CustomizeScene.ts
+++ b/play/src/front/Phaser/Login/CustomizeScene.ts
@@ -19,6 +19,7 @@ import type { IconButtonConfig } from "../Components/Ui/IconButton";
 import { IconButton, IconButtonEvent } from "../Components/Ui/IconButton";
 import { selectCharacterCustomizeSceneVisibleStore } from "../../Stores/SelectCharacterStore";
 import { ABSOLUTE_PUSHER_URL } from "../../Enum/ComputedConst";
+import { connectionManager } from "../../Connection/ConnectionManager";
 import { SelectCharacterSceneName } from "./SelectCharacterScene";
 import { AbstractCharacterScene } from "./AbstractCharacterScene";
 import { EnableCameraSceneName } from "./EnableCameraScene";
@@ -161,6 +162,7 @@ export class CustomizeScene extends AbstractCharacterScene {
         analyticsClient.validationWoka("CustomizeWoka");
 
         gameManager.setCharacterTextureIds(layers);
+        connectionManager.saveTextures(layers).catch((e) => console.error(e));
         this.scene.stop(CustomizeSceneName);
         gameManager.tryResumingGame(EnableCameraSceneName);
     }

--- a/play/src/front/Phaser/Login/CustomizeScene.ts
+++ b/play/src/front/Phaser/Login/CustomizeScene.ts
@@ -179,9 +179,7 @@ export class CustomizeScene extends AbstractCharacterScene {
             const savedWokaTextureIds = gameManager.getCharacterTextureIds();
             if (savedWokaTextureIds) {
                 for (let i = 0; i < savedWokaTextureIds.length; i += 1) {
-                    const index = this.layers[i].findIndex(
-                        (item) => item.id === gameManager.getCharacterTextureIds()[i]
-                    );
+                    const index = this.layers[i].findIndex((item) => item.id === savedWokaTextureIds[i]);
                     // set first item as default if not found
                     this.selectedTextures[i] = index !== -1 ? index : 0;
                 }

--- a/play/src/front/Phaser/Login/SelectCharacterScene.ts
+++ b/play/src/front/Phaser/Login/SelectCharacterScene.ts
@@ -23,6 +23,7 @@ import { myCameraStore, myMicrophoneStore } from "../../Stores/MyMediaStore";
 import { gameManager } from "../Game/GameManager";
 import { ABSOLUTE_PUSHER_URL } from "../../Enum/ComputedConst";
 import { batchGetUserMediaStore } from "../../Stores/MediaStore";
+import { connectionManager } from "../../Connection/ConnectionManager";
 import { AbstractCharacterScene } from "./AbstractCharacterScene";
 import { CustomizeSceneName } from "./CustomizeScene";
 import { EnableCameraSceneName } from "./EnableCameraScene";
@@ -142,7 +143,7 @@ export class SelectCharacterScene extends AbstractCharacterScene {
         }
     }
 
-    public nextSceneToCameraScene(): void {
+    public async nextSceneToCameraScene(): Promise<void> {
         if (this.selectedWoka !== null && !areCharacterTexturesValid([this.selectedWoka.texture.key])) {
             return;
         }
@@ -153,6 +154,7 @@ export class SelectCharacterScene extends AbstractCharacterScene {
         analyticsClient.validationWoka("SelectWoka");
 
         gameManager.setCharacterTextureIds([this.selectedWoka.texture.key]);
+        await connectionManager.saveTextures([this.selectedWoka.texture.key]);
         this.selectedWoka = null;
         this.scene.stop(SelectCharacterSceneName);
         gameManager.tryResumingGame(EnableCameraSceneName);

--- a/play/src/front/Phaser/Login/SelectCompanionScene.ts
+++ b/play/src/front/Phaser/Login/SelectCompanionScene.ts
@@ -11,6 +11,7 @@ import { SuperLoaderPlugin } from "../Services/SuperLoaderPlugin";
 import { companionListMetakey, CompanionTexturesLoadingManager } from "../Companion/CompanionTexturesLoadingManager";
 import { CompanionTextureDescriptionInterface, CompanionTextures } from "../Companion/CompanionTextures";
 import { collectionsSizeStore, selectedCollection } from "../../Stores/SelectCharacterSceneStore";
+import { connectionManager } from "../../Connection/ConnectionManager";
 import { EnableCameraSceneName } from "./EnableCameraScene";
 import { ResizableScene } from "./ResizableScene";
 
@@ -85,7 +86,9 @@ export class SelectCompanionScene extends ResizableScene {
             }
         }
         // input events
-        this.input.keyboard?.on("keyup-ENTER", this.selectCompanion.bind(this));
+        this.input.keyboard?.on("keyup-ENTER", () => {
+            this.selectCompanion.bind(this)().catch(console.error);
+        });
 
         this.input.keyboard?.on("keydown-RIGHT", this.moveToRight.bind(this));
         this.input.keyboard?.on("keydown-LEFT", this.moveToLeft.bind(this));
@@ -109,9 +112,10 @@ export class SelectCompanionScene extends ResizableScene {
         }
     }
 
-    public selectCompanion(): void {
+    public async selectCompanion(): Promise<void> {
         localUserStore.setCompanionTextureId(this.companionCurrentCollection[this.currentCompanion].id);
         gameManager.setCompanionTextureId(this.companionCurrentCollection[this.currentCompanion].id);
+        await connectionManager.saveCompanionTexture(this.companionCurrentCollection[this.currentCompanion].id);
 
         this.closeScene();
     }

--- a/play/src/front/Stores/ErrorScreenStore.ts
+++ b/play/src/front/Stores/ErrorScreenStore.ts
@@ -81,18 +81,30 @@ function createErrorScreenStore() {
             }
             if (error instanceof ApiError) {
                 const errorApi = error.errorApiData;
+                const { status: _exhaustiveCheck, ...errorApiWithoutStatus } = errorApi;
 
-                if (errorApi.type === "error" || errorApi.type === "redirect") {
-                    set(ErrorScreenMessage.fromPartial(errorApi));
-                } else if (errorApi.type === "retry" || errorApi.type === "unauthorized") {
-                    set(
-                        ErrorScreenMessage.fromPartial({
-                            ...errorApi,
-                            buttonTitle: errorApi.buttonTitle ?? undefined,
-                        })
-                    );
-                } else {
-                    const _exhaustiveCheck: never = errorApi;
+                switch (errorApiWithoutStatus.type) {
+                    case "error":
+                    case "redirect": {
+                        set(ErrorScreenMessage.fromPartial(errorApiWithoutStatus));
+                        return;
+                    }
+                    case "retry":
+                    case "unauthorized": {
+                        set(
+                            ErrorScreenMessage.fromPartial({
+                                ...errorApiWithoutStatus,
+                                buttonTitle: errorApiWithoutStatus.buttonTitle ?? undefined,
+                            })
+                        );
+                        return;
+                    }
+                    default: {
+                        // Typescript compiler is lost because of the removal of the status field.
+                        //@ts-ignore
+                        const _exhaustiveCheck: never = errorApi;
+                        throw new Error("This should never happen.");
+                    }
                 }
                 return;
             }

--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -133,12 +133,14 @@ export class AuthenticateController extends BaseHttpController {
                 z.object({
                     token: z.string(),
                     playUri: z.string(),
+                    localStorageCharacterTextureIds: z.array(z.string()).optional(),
+                    localStorageCompanionTextureId: z.string().optional(),
                 })
             );
             if (query === undefined) {
                 return;
             }
-            const { token, playUri } = query;
+            const { token, playUri, localStorageCharacterTextureIds, localStorageCompanionTextureId } = query;
             try {
                 const authTokenData: AuthTokenData = jwtTokenManager.verifyJWTToken(token, false);
 
@@ -149,7 +151,8 @@ export class AuthenticateController extends BaseHttpController {
                     authTokenData.accessToken,
                     playUri,
                     IPAddress,
-                    [],
+                    localStorageCharacterTextureIds ?? [],
+                    localStorageCompanionTextureId,
                     req.header("accept-language")
                 );
 

--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -1,5 +1,5 @@
 import { v4 } from "uuid";
-import { ErrorApiData, RegisterData } from "@workadventure/messages";
+import { ErrorApiData, RegisterData, MeResponse } from "@workadventure/messages";
 import { isAxiosError } from "axios";
 import { z } from "zod";
 import * as Sentry from "@sentry/node";
@@ -14,7 +14,6 @@ import { BaseHttpController } from "./BaseHttpController";
 
 export class AuthenticateController extends BaseHttpController {
     routes(): void {
-        this.roomAccess();
         this.openIDLogin();
         this.me();
         this.openIDCallback();
@@ -22,35 +21,6 @@ export class AuthenticateController extends BaseHttpController {
         this.register();
         this.anonymLogin();
         this.profileCallback();
-    }
-
-    private roomAccess(): void {
-        this.app.get("/room/access", async (req, res) => {
-            try {
-                const query = validateQuery(
-                    req,
-                    res,
-                    z.object({
-                        uuid: z.string(),
-                        playUri: z.string(),
-                        token: z.string().optional(),
-                    })
-                );
-                if (query === undefined) {
-                    return;
-                }
-
-                const { uuid, playUri, token } = query;
-
-                res.json(await adminService.fetchMemberDataByUuid(uuid, token, playUri, req.ip, []));
-                return;
-            } catch (e) {
-                console.warn(e);
-            }
-            res.status(500);
-            res.send("User cannot be identified.");
-            return;
-        });
     }
 
     private openIDLogin(): void {
@@ -148,53 +118,11 @@ export class AuthenticateController extends BaseHttpController {
          *        type: "string"
          *     responses:
          *       200:
-         *         description: NOTE - THERE ARE ADDITIONAL PROPERTIES NOT DISPLAYED HERE. THEY COME FROM THE CALL TO openIDClient.checkTokenAuth
-         *         content:
-         *           application/json:
-         *             schema:
-         *               type: object
-         *               properties:
-         *                 authToken:
-         *                   type: string
-         *                   description: A new JWT token (if no token was passed in parameter), or returns the token that was passed in parameter if one was supplied
-         *                 username:
-         *                   type: string|undefined
-         *                   description: Contains the username stored in the JWT token passed in parameter. If no token was passed, contains the data from OpenID.
-         *                   example: John Doe
-         *                 locale:
-         *                   type: string|undefined
-         *                   description: Contains the locale stored in the JWT token passed in parameter. If no token was passed, contains the data from OpenID.
-         *                   example: fr_FR
-         *                 email:
-         *                   type: string
-         *                   description: TODO
-         *                   example: TODO
-         *                 userUuid:
-         *                   type: string
-         *                   description: TODO
-         *                   example: TODO
-         *                 visitCardUrl:
-         *                   type: string|null
-         *                   description: TODO
-         *                   example: TODO
-         *                 tags:
-         *                   type: array
-         *                   description: The list of tags of the user
-         *                   items:
-         *                     type: string
-         *                     example: speaker
-         *                 textures:
-         *                   type: array
-         *                   description: The list of textures of the user
-         *                   items:
-         *                     type: TODO
-         *                     example: TODO
-         *                 messages:
-         *                   type: array
-         *                   description: The list of messages to be displayed to the user
-         *                   items:
-         *                     type: TODO
-         *                     example: TODO
+         *         description: Response to the /me endpoint
+         *         schema:
+         *           $ref: '#/definitions/MeResponse'
+         *       401:
+         *         description: Thrown when the token is invalid
          */
         //eslint-disable-next-line @typescript-eslint/no-misused-promises
         this.app.get("/me", async (req, res) => {
@@ -225,6 +153,13 @@ export class AuthenticateController extends BaseHttpController {
                     req.header("accept-language")
                 );
 
+                if (resUserData.status === "error") {
+                    res.atomic(() => {
+                        res.json(resUserData);
+                    });
+                    return;
+                }
+
                 if (authTokenData.accessToken == undefined) {
                     //if not nonce and code, anonymous user connected
                     //get data with identifier and return token
@@ -232,8 +167,9 @@ export class AuthenticateController extends BaseHttpController {
                         authToken: token,
                         username: authTokenData?.username,
                         locale: authTokenData?.locale,
+                        // TODO: replace ... with each property
                         ...resUserData,
-                    });
+                    } satisfies MeResponse);
                     return;
                 }
 
@@ -243,9 +179,10 @@ export class AuthenticateController extends BaseHttpController {
                         username: authTokenData?.username,
                         authToken: token,
                         locale: authTokenData?.locale,
+                        // TODO: replace ... with each property
                         ...resUserData,
                         ...resCheckTokenAuth,
-                    });
+                    } satisfies MeResponse);
                 } catch (err) {
                     console.warn("Error while checking token auth", err);
                     throw new JsonWebTokenError("Invalid token");

--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -1,5 +1,5 @@
 import { v4 } from "uuid";
-import { ErrorApiData, RegisterData, MeResponse } from "@workadventure/messages";
+import { ErrorApiData, RegisterData, MeResponse, MeRequest } from "@workadventure/messages";
 import { isAxiosError } from "axios";
 import { z } from "zod";
 import * as Sentry from "@sentry/node";
@@ -127,16 +127,7 @@ export class AuthenticateController extends BaseHttpController {
         //eslint-disable-next-line @typescript-eslint/no-misused-promises
         this.app.get("/me", async (req, res) => {
             const IPAddress = req.header("x-forwarded-for");
-            const query = validateQuery(
-                req,
-                res,
-                z.object({
-                    token: z.string(),
-                    playUri: z.string(),
-                    localStorageCharacterTextureIds: z.array(z.string()).optional(),
-                    localStorageCompanionTextureId: z.string().optional(),
-                })
-            );
+            const query = validateQuery(req, res, MeRequest);
             if (query === undefined) {
                 return;
             }

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -241,7 +241,7 @@ export class IoSocketController {
                             roomId: z.string(),
                             token: z.string().optional(),
                             name: z.string(),
-                            characterTextureIds: z.union([z.string(), z.string().array()]),
+                            characterTextureIds: z.union([z.string(), z.string().array()]).optional(),
                             x: z.coerce.number(),
                             y: z.coerce.number(),
                             top: z.coerce.number(),
@@ -313,7 +313,9 @@ export class IoSocketController {
                         }
 
                         const characterTextureIds: string[] =
-                            typeof query.characterTextureIds === "string"
+                            query.characterTextureIds === undefined
+                                ? []
+                                : typeof query.characterTextureIds === "string"
                                 ? [query.characterTextureIds]
                                 : query.characterTextureIds;
 

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -419,18 +419,6 @@ export class IoSocketController {
                                         // If the response points to nowhere, don't attempt an upgrade
                                         return;
                                     }
-                                    return res.upgrade(
-                                        {
-                                            rejected: true,
-                                            reason: null,
-                                            message: err?.response?.data,
-                                            roomId: roomId,
-                                        } satisfies UpgradeFailedData,
-                                        websocketKey,
-                                        websocketProtocol,
-                                        websocketExtensions,
-                                        context
-                                    );
                                 }
                                 throw err;
                             }
@@ -471,34 +459,6 @@ export class IoSocketController {
                             console.info("Ouch! Client disconnected before we could upgrade it!");
                             /* You must not upgrade now */
                             return;
-                        }
-
-                        if (characterTextureIds.length !== characterTextures.length) {
-                            return res.upgrade(
-                                {
-                                    rejected: true,
-                                    reason: "invalidTexture",
-                                    entityType: "character",
-                                } satisfies UpgradeFailedInvalidTexture,
-                                websocketKey,
-                                websocketProtocol,
-                                websocketExtensions,
-                                context
-                            );
-                        }
-
-                        if (companionTextureId && !companionTexture) {
-                            return res.upgrade(
-                                {
-                                    rejected: true,
-                                    reason: "invalidTexture",
-                                    entityType: "companion",
-                                } satisfies UpgradeFailedInvalidTexture,
-                                websocketKey,
-                                websocketProtocol,
-                                websocketExtensions,
-                                context
-                            );
                         }
 
                         const socketData: SocketData = {

--- a/play/src/pusher/controllers/UserController.ts
+++ b/play/src/pusher/controllers/UserController.ts
@@ -9,16 +9,16 @@ export class UserController extends BaseHttpController {
     // Returns a map mapping map name to file name of the map
     routes(): void {
         this.saveName();
+        this.saveTextures();
+        this.saveCompanionTexture();
     }
 
     /**
      * @openapi
      * /save-name:
      *   post:
-     *     description: Forces anyone out of the room. The request must be authenticated with the "admin-token" header.
-     *     tags:
-     *      - Admin endpoint
-     *    requestBody:
+     *     description: Saves the name of the user in the (admin) database, if any.
+     *     requestBody:
      *       required: true
      *       content:
      *         application/json:
@@ -78,5 +78,145 @@ export class UserController extends BaseHttpController {
             });
             return;
         });
+    }
+
+    /**
+     * @openapi
+     * /save-textures:
+     *   post:
+     *     description: Saves the selected textures of the Woka in admin database, if any.
+     *    requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             type: "object"
+     *             properties:
+     *               roomUrl:
+     *                 type: string
+     *                 required: true
+     *                 description: The URL of the room
+     *                 example: "https://play.workadventu.re/@/teamSlug/worldSlug/roomSlug"
+     *               textures:
+     *                 type: array
+     *                 items:
+     *                   type: string
+     *                 required: true
+     *                 description: The textures of the Woka
+     *                 example: ["ab7ce839-3dea-4698-8b41-ebbdf7688ad9"]
+     *               userIdentifier:
+     *                 type: string
+     *                 required: true
+     *                 description: "It can be an uuid or an email"
+     *                 example: "998ce839-3dea-4698-8b41-ebbdf7688ad9"
+     *     responses:
+     *      204:
+     *         description: Save succeeded
+     *       404:
+     *         description: User or room not found
+     *         schema:
+     *             $ref: '#/definitions/ErrorApiErrorData'
+     */
+    private saveTextures(): void {
+        this.app.post("/save-textures", [authenticated], async (req: Request, res: ResponseWithUserIdentifier) => {
+            const body = await validatePostQuery(
+                req,
+                res,
+                z.object({
+                    textures: z.array(z.string()),
+                    roomUrl: z.string(),
+                })
+            );
+
+            if (body === undefined) {
+                return;
+            }
+
+            if (!res.userIdentifier) {
+                res.status(401).send("Undefined userIdentifier");
+                return;
+            }
+
+            // Not logged? Nothing to save!
+            if (res.isLogged) {
+                await adminService.saveTextures(res.userIdentifier, body.textures, body.roomUrl);
+            }
+
+            res.atomic(() => {
+                res.status(204).send("");
+            });
+            return;
+        });
+    }
+
+    /**
+     * @openapi
+     * /save-companion-texture:
+     *   post:
+     *     description: Saves the selected texture of the companion in admin database, if any.
+     *    requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             type: "object"
+     *             properties:
+     *               roomUrl:
+     *                 type: string
+     *                 required: true
+     *                 description: The URL of the room
+     *                 example: "https://play.workadventu.re/@/teamSlug/worldSlug/roomSlug"
+     *               texture:
+     *                 type: string
+     *                 required: true
+     *                 description: The textures of the companion
+     *                 example: "ab7ce839-3dea-4698-8b41-ebbdf7688ad9"
+     *               userIdentifier:
+     *                 type: string
+     *                 required: true
+     *                 description: "It can be an uuid or an email"
+     *                 example: "998ce839-3dea-4698-8b41-ebbdf7688ad9"
+     *     responses:
+     *      204:
+     *         description: Save succeeded
+     *       404:
+     *         description: User or room not found
+     *         schema:
+     *             $ref: '#/definitions/ErrorApiErrorData'
+     */
+    private saveCompanionTexture(): void {
+        this.app.post(
+            "/save-companion-texture",
+            [authenticated],
+            async (req: Request, res: ResponseWithUserIdentifier) => {
+                const body = await validatePostQuery(
+                    req,
+                    res,
+                    z.object({
+                        texture: z.string(),
+                        roomUrl: z.string(),
+                    })
+                );
+
+                if (body === undefined) {
+                    return;
+                }
+
+                if (!res.userIdentifier) {
+                    res.status(401).send("Undefined userIdentifier");
+                    return;
+                }
+
+                // Not logged? Nothing to save!
+                if (res.isLogged) {
+                    await adminService.saveCompanionTexture(res.userIdentifier, body.texture, body.roomUrl);
+                }
+
+                res.atomic(() => {
+                    res.status(204).send("");
+                });
+                return;
+            }
+        );
     }
 }

--- a/play/src/pusher/services/AdminApi.ts
+++ b/play/src/pusher/services/AdminApi.ts
@@ -380,8 +380,8 @@ class AdminApi implements AdminInterface {
             return fetchMemberDataByUuidResponse.data;
         }
 
-        console.error(fetchMemberDataByUuidResponse.error.issues);
-        Sentry.captureException(fetchMemberDataByUuidResponse.error.issues);
+        console.error(fetchMemberDataByUuidResponse.error.flatten());
+        Sentry.captureException(fetchMemberDataByUuidResponse.error.flatten());
         throw new Error(
             "Invalid answer received from the admin for the /api/room/access endpoint. Received: " +
                 JSON.stringify(res.data)

--- a/play/src/pusher/services/AdminApi.ts
+++ b/play/src/pusher/services/AdminApi.ts
@@ -4,6 +4,7 @@ import type { AdminApiData, MapDetailsData, RoomRedirect } from "@workadventure/
 import {
     Capabilities,
     CompanionDetail,
+    ErrorApiData,
     isAdminApiData,
     isApplicationDefinitionInterface,
     isCapabilities,
@@ -32,7 +33,11 @@ export interface AdminBannedData {
     message: string;
 }
 
-export const isFetchMemberDataByUuidResponse = z.object({
+export const isFetchMemberDataByUuidSuccessResponse = z.object({
+    status: extendApi(z.literal("ok"), {
+        description: "MUST be 'ok' if the system successfully authenticated the user.",
+        example: "ok",
+    }),
     email: extendApi(z.string().nullable(), {
         description: "The email of the fetched user, it can be an email, an uuid or null.",
         example: "example@workadventu.re",
@@ -53,8 +58,19 @@ export const isFetchMemberDataByUuidResponse = z.object({
         description: "URL of the visitCard of the user fetched.",
         example: "https://mycompany.com/contact/me",
     }),
+    isCharacterTexturesValid: extendApi(z.boolean(), {
+        description:
+            "True if the character textures are valid, false if we need to redirect the user to the Woka selection page.",
+        example: true,
+    }),
     characterTextures: extendApi(z.array(WokaDetail), {
-        description: "This data represents the textures (WOKA) that will be available to users.",
+        description:
+            "This data represents the textures (WOKA) that will be available to users. If an empty array is returned, the user is redirected to the Woka selection page.",
+    }),
+    isCompanionTextureValid: extendApi(z.boolean(), {
+        description:
+            "True if the companion texture is valid, false if we need to redirect the user to the companion selection page.",
+        example: true,
     }),
     companionTexture: extendApi(CompanionDetail.optional().nullable(), {
         description: "This data represents the companion texture that will be use.",
@@ -88,6 +104,10 @@ export const isFetchMemberDataByUuidResponse = z.object({
         description: "True if the user can edit the map",
     }),
 });
+
+export type FetchMemberDataByUuidSuccessResponse = z.infer<typeof isFetchMemberDataByUuidSuccessResponse>;
+
+export const isFetchMemberDataByUuidResponse = z.union([isFetchMemberDataByUuidSuccessResponse, ErrorApiData]);
 
 export type FetchMemberDataByUuidResponse = z.infer<typeof isFetchMemberDataByUuidResponse>;
 
@@ -340,19 +360,6 @@ class AdminApi implements AdminInterface {
          *         description: The details of the member
          *         schema:
          *             $ref: "#/definitions/FetchMemberDataByUuidResponse"
-         *       401:
-         *         description: Error while retrieving the data because you are not authorized
-         *         schema:
-         *             $ref: '#/definitions/ErrorApiRedirectData'
-         *       403:
-         *         description: Error while retrieving the data because you are not authorized
-         *         schema:
-         *             $ref: '#/definitions/ErrorApiUnauthorizedData'
-         *       404:
-         *         description: Error while retrieving the data
-         *         schema:
-         *             $ref: '#/definitions/ErrorApiErrorData'
-         *
          */
         const res = await axios.get<unknown, AxiosResponse<unknown>>(ADMIN_API_URL + "/api/room/access", {
             params: {
@@ -746,6 +753,134 @@ class AdminApi implements AdminInterface {
                 playUri: roomUrl,
                 userIdentifier,
                 name,
+            },
+            {
+                headers: { Authorization: `${ADMIN_API_TOKEN}` },
+            }
+        );
+        if (response.status !== 204) {
+            throw new Error(
+                "Error while saving name. Got unexpected status code. Expected 204, got " + response.status
+            );
+        }
+        return;
+    }
+
+    async saveTextures(userIdentifier: string, textures: string[], roomUrl: string): Promise<void> {
+        if (this.capabilities["api/save-textures"] === undefined) {
+            // Save-name is not implemented in admin. Do nothing.
+            return;
+        }
+
+        /**
+         * @openapi
+         * /api/save-textures:
+         *   post:
+         *     tags: ["AdminAPI"]
+         *     description: Saves the textures of the Woka on the admin side.
+         *     security:
+         *      - Bearer: []
+         *     requestBody:
+         *       required: true
+         *       content:
+         *         application/json:
+         *           schema:
+         *             type: "object"
+         *             properties:
+         *               roomUrl:
+         *                 type: string
+         *                 required: true
+         *                 description: The URL of the room
+         *                 example: "https://play.workadventu.re/@/teamSlug/worldSlug/roomSlug"
+         *               textures:
+         *                 type: array
+         *                 items:
+         *                   type: string
+         *                 required: true
+         *                 description: The IDs of the textures
+         *                 example: ["ab7ce839-3dea-4698-8b41-ebbdf7688ad9"]
+         *               userIdentifier:
+         *                 type: string
+         *                 required: true
+         *                 description: "It can be an uuid or an email"
+         *                 example: "998ce839-3dea-4698-8b41-ebbdf7688ad9"
+         *     responses:
+         *       204:
+         *         description: Save succeeded
+         *       404:
+         *         description: User or room not found
+         *         schema:
+         *             $ref: '#/definitions/ErrorApiErrorData'
+         */
+        const response = await axios.post<unknown>(
+            ADMIN_API_URL + "/api/save-textures",
+            {
+                playUri: roomUrl,
+                userIdentifier,
+                textures,
+            },
+            {
+                headers: { Authorization: `${ADMIN_API_TOKEN}` },
+            }
+        );
+        if (response.status !== 204) {
+            throw new Error(
+                "Error while saving name. Got unexpected status code. Expected 204, got " + response.status
+            );
+        }
+        return;
+    }
+
+    async saveCompanionTexture(userIdentifier: string, texture: string, roomUrl: string): Promise<void> {
+        if (this.capabilities["api/save-textures"] === undefined) {
+            // Save-name is not implemented in admin. Do nothing.
+            return;
+        }
+
+        /**
+         * @openapi
+         * /api/save-companion-texture:
+         *   post:
+         *     tags: ["AdminAPI"]
+         *     description: Saves the texture of the companion on the admin side.
+         *     security:
+         *      - Bearer: []
+         *     requestBody:
+         *       required: true
+         *       content:
+         *         application/json:
+         *           schema:
+         *             type: "object"
+         *             properties:
+         *               roomUrl:
+         *                 type: string
+         *                 required: true
+         *                 description: The URL of the room
+         *                 example: "https://play.workadventu.re/@/teamSlug/worldSlug/roomSlug"
+         *               texture:
+         *                 type: string
+         *                 required: true
+         *                 description: The ID of the textures
+         *                 example: "ab7ce839-3dea-4698-8b41-ebbdf7688ad9"
+         *               userIdentifier:
+         *                 type: string
+         *                 required: true
+         *                 description: "It can be an uuid or an email"
+         *                 example: "998ce839-3dea-4698-8b41-ebbdf7688ad9"
+         *     responses:
+         *       204:
+         *         description: Save succeeded
+         *       404:
+         *         description: User or room not found
+         *         schema:
+         *             $ref: '#/definitions/ErrorApiErrorData'
+         */
+        const response = await axios.post<unknown>(
+            ADMIN_API_URL + "/api/save-companion-texture",
+            {
+                playUri: roomUrl,
+                userIdentifier,
+                texture,
             },
             {
                 headers: { Authorization: `${ADMIN_API_TOKEN}` },

--- a/play/src/pusher/services/AdminInterface.ts
+++ b/play/src/pusher/services/AdminInterface.ts
@@ -108,5 +108,9 @@ export interface AdminInterface {
      */
     saveName(userIdentifier: string, name: string, roomUrl: string): Promise<void>;
 
+    saveTextures(userIdentifier: string, textures: string[], roomUrl: string): Promise<void>;
+
+    saveCompanionTexture(userIdentifier: string, texture: string, roomUrl: string): Promise<void>;
+
     getCapabilities(): Promise<Capabilities>;
 }

--- a/play/src/pusher/services/LocalAdmin.ts
+++ b/play/src/pusher/services/LocalAdmin.ts
@@ -1,5 +1,11 @@
 import path from "path";
-import type { MapDetailsData, RoomRedirect, AdminApiData, ErrorApiData } from "@workadventure/messages";
+import type {
+    MapDetailsData,
+    RoomRedirect,
+    AdminApiData,
+    ErrorApiData,
+    CompanionDetail,
+} from "@workadventure/messages";
 import { Capabilities, OpidWokaNamePolicy } from "@workadventure/messages";
 import axios from "axios";
 import { MapsCacheFileFormat } from "@workadventure/map-editor";
@@ -59,16 +65,34 @@ class LocalAdmin implements AdminInterface {
         if (ENABLE_CHAT) {
             mucRooms.push({ name: "Welcome", url: `${playUri}/forum/welcome`, type: "forum", subscribe: false });
         }
+
+        let isCharacterTexturesValid = true;
+
+        const characterTextures = await localWokaService.fetchWokaDetails(characterTextureIds);
+        if (characterTextures === undefined) {
+            isCharacterTexturesValid = false;
+        }
+
+        let isCompanionTextureValid = true;
+        let companionTexture: CompanionDetail | undefined = undefined;
+        if (companionTextureId) {
+            companionTexture = await localCompanionService.fetchCompanionDetails(companionTextureId);
+            if (companionTexture === undefined) {
+                isCompanionTextureValid = false;
+            }
+        }
+
         return {
+            status: "ok",
             email: userIdentifier,
             userUuid: userIdentifier,
             tags: [],
             messages: [],
             visitCardUrl: null,
-            characterTextures: (await localWokaService.fetchWokaDetails(characterTextureIds)) ?? [],
-            companionTexture: companionTextureId
-                ? await localCompanionService.fetchCompanionDetails(companionTextureId)
-                : undefined,
+            isCharacterTexturesValid,
+            characterTextures: characterTextures ?? [],
+            isCompanionTextureValid,
+            companionTexture,
             userRoomToken: undefined,
             mucRooms,
             activatedInviteUser: true,
@@ -106,6 +130,7 @@ class LocalAdmin implements AdminInterface {
             match = /\/_\/[^/]+\/(.+)/.exec(roomUrl.pathname);
             if (!match) {
                 return Promise.resolve({
+                    status: "error",
                     type: "error",
                     code: "UNSUPPORTED_URL_FORMAT",
                     title: "Unsupported URL format",
@@ -232,8 +257,15 @@ class LocalAdmin implements AdminInterface {
     }
 
     saveName(userIdentifier: string, name: string, roomUrl: string): Promise<void> {
-        // Nothing to do, we don't have any database locally.
-        return Promise.resolve();
+        return Promise.reject(new Error("No admin backoffice set!"));
+    }
+
+    saveTextures(userIdentifier: string, textures: string[], roomUrl: string): Promise<void> {
+        return Promise.reject(new Error("No admin backoffice set!"));
+    }
+
+    saveCompanionTexture(userIdentifier: string, texture: string, roomUrl: string): Promise<void> {
+        return Promise.reject(new Error("No admin backoffice set!"));
     }
 
     public getCapabilities(): Promise<Capabilities> {

--- a/play/src/pusher/services/QueryValidator.ts
+++ b/play/src/pusher/services/QueryValidator.ts
@@ -75,8 +75,8 @@ export function validateWebsocketQuery<T extends ZodObject<ZodRawShape>>(
             {
                 rejected: true,
                 reason: "error",
-                status: 400,
                 error: {
+                    status: "error",
                     type: "error",
                     title: "400 Bad Request",
                     subtitle: "Something wrong while connection!",


### PR DESCRIPTION
Adding a new capability in Admin: a endpoint to save the selected texture for both the Woka and the companion.

WARNING: this commit comes with a refactoring of the Admin API error handling.

Error messages returned by the AdminAPI must now add

```
{
  "status": "error"
}
```

Also, the "/api/room/access" endpoint must contain 3 new fields:

```
{
  "status": "ok"
  'isCharacterTexturesValid': true,
  'isCompanionTextureValid': true,
}
```

This commit also adds proper typing to the "/me" endpoint.