### PR TITLE
Refactoring /api/room-api/authorization error handling

### DIFF
--- a/play/src/room-api/authentication/AdminAuthenticator.ts
+++ b/play/src/room-api/authentication/AdminAuthenticator.ts
@@ -1,17 +1,36 @@
 import { Status } from "@grpc/grpc-js/build/src/constants";
 import axios, { isAxiosError } from "axios";
 import { setupCache } from "axios-cache-interceptor";
+import { z } from "zod";
 import { ADMIN_API_URL } from "../../pusher/enums/EnvironmentVariable";
 import { GuardError } from "../types/GuardError";
 import { AuthenticatorInterface } from "./AuthenticatorInterface";
 
 const client = setupCache(axios);
 
+const authorizationSuccessResponse = z.object({
+    success: z.literal(true),
+});
+
+const authorizationErrorResponse = z.object({
+    success: z.literal(false),
+    error: z.union([
+        z.literal("UNAUTHENTICATED"),
+        z.literal("NOT_FOUND"),
+        z.literal("PERMISSION_DENIED"),
+        z.literal("INTERNAL"),
+        z.literal("UNKNOWN"),
+    ]),
+    message: z.string(),
+});
+
+const authorizationResponse = z.union([authorizationSuccessResponse, authorizationErrorResponse]);
+
 const authenticator: AuthenticatorInterface = async (apiKey, room) => {
     const encodedRoom = encodeURI(room);
 
     try {
-        const response = await client.get(ADMIN_API_URL + "/api/room-api/authorization", {
+        const rawResponse = await client.get<unknown>(ADMIN_API_URL + "/api/room-api/authorization", {
             cache: process.env.NODE_ENV === "production" ? undefined : false,
             id: `room-api-authorization-${encodedRoom}-${apiKey}`,
             headers: {
@@ -22,9 +41,30 @@ const authenticator: AuthenticatorInterface = async (apiKey, room) => {
             },
         });
 
-        if (!response.data.success) {
-            console.error("Weird response from the API:", response);
+        const responseParsed = authorizationResponse.safeParse(rawResponse.data);
+        if (!responseParsed.success) {
+            console.error("Invalid response from the API for endpoint /api/room-api/authorization:", rawResponse);
             throw new GuardError(Status.INTERNAL, "Unexpected error! Please contact us!");
+        }
+
+        const response = responseParsed.data;
+
+        if (response.success) {
+            return;
+        }
+
+        if (response.error === "UNAUTHENTICATED") {
+            throw new GuardError(Status.UNAUTHENTICATED, response.message);
+        } else if (response.error === "NOT_FOUND") {
+            throw new GuardError(Status.NOT_FOUND, response.message);
+        } else if (response.error === "PERMISSION_DENIED") {
+            throw new GuardError(Status.PERMISSION_DENIED, response.message);
+        } else if (response.error === "INTERNAL") {
+            throw new GuardError(Status.INTERNAL, response.message);
+        } else if (response.error === "UNKNOWN") {
+            throw new GuardError(Status.UNKNOWN, response.message);
+        } else {
+            const _exhaustiveCheck: never = response.error;
         }
 
         return;


### PR DESCRIPTION
The endpoint signature is changed.
It now accepts a JSON message containing success or errors (instead of relying on the HTTP code).