### PR TITLE
Adding support for errors with HTTP 200 code on /map endpoint in AdminAPI

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -773,12 +773,12 @@ export class GameRoom implements BrothersFinder {
         }
 
         console.error(result.error.issues);
-        console.error("Unexpected room redirect received while querying map details", result);
+        console.error("Unexpected room redirect or error received while querying map details", result);
         Sentry.captureException(result.error.issues);
         Sentry.captureException(
-            `Unexpected room redirect received while querying map details ${JSON.stringify(result)}`
+            `Unexpected room redirect or error received while querying map details ${JSON.stringify(result)}`
         );
-        throw new Error("Unexpected room redirect received while querying map details");
+        throw new Error("Unexpected room redirect received or error while querying map details");
     }
 
     private mapPromise: Promise<ITiledMap> | undefined;

--- a/back/src/Services/AdminApi.ts
+++ b/back/src/Services/AdminApi.ts
@@ -1,10 +1,17 @@
-import axios from "axios";
-import { isMapDetailsData, MapDetailsData, isRoomRedirect, RoomRedirect } from "@workadventure/messages";
+import axios, { isAxiosError } from "axios";
+import {
+    isMapDetailsData,
+    MapDetailsData,
+    isRoomRedirect,
+    RoomRedirect,
+    isErrorApiErrorData,
+    ErrorApiData,
+} from "@workadventure/messages";
 import * as Sentry from "@sentry/node";
 import { ADMIN_API_TOKEN, ADMIN_API_URL } from "../Enum/EnvironmentVariable";
 
 class AdminApi {
-    async fetchMapDetails(playUri: string): Promise<MapDetailsData | RoomRedirect> {
+    async fetchMapDetails(playUri: string): Promise<MapDetailsData | RoomRedirect | ErrorApiData> {
         if (!ADMIN_API_URL) {
             return Promise.reject(new Error("No admin backoffice set!"));
         }
@@ -13,29 +20,72 @@ class AdminApi {
             playUri,
         };
 
-        const res = await axios.get(ADMIN_API_URL + "/api/map", {
-            headers: { Authorization: `${ADMIN_API_TOKEN ?? ""}` },
-            params,
-        });
+        try {
+            const res = await axios.get(ADMIN_API_URL + "/api/map", {
+                headers: { Authorization: `${ADMIN_API_TOKEN ?? ""}` },
+                params,
+            });
 
-        const mapDetailData = isMapDetailsData.safeParse(res.data);
-        const roomRedirect = isRoomRedirect.safeParse(res.data);
+            const mapDetailData = isMapDetailsData.safeParse(res.data);
 
-        if (mapDetailData.success) {
-            return mapDetailData.data;
+            if (mapDetailData.success) {
+                return mapDetailData.data;
+            }
+
+            const roomRedirect = isRoomRedirect.safeParse(res.data);
+            if (roomRedirect.success) {
+                return roomRedirect.data;
+            }
+
+            const errorData = isErrorApiErrorData.safeParse(res.data);
+            if (errorData.success) {
+                return errorData.data;
+            }
+
+            console.error(
+                "Invalid answer received from the admin for the /api/map endpoint. Errors:",
+                mapDetailData.error.issues
+            );
+            Sentry.captureException(mapDetailData.error.issues);
+            console.error(roomRedirect.error.issues);
+            return {
+                status: "error",
+                type: "error",
+                title: "Invalid server response",
+                subtitle: "Something wrong happened while fetching map details!",
+                image: "",
+                code: "MAP_VALIDATION",
+                details: "The server answered with an invalid response. The administrator has been notified.",
+            };
+        } catch (err) {
+            let message = "Unknown error";
+            if (isAxiosError(err)) {
+                Sentry.captureException(
+                    `An error occurred during call to /api/map endpoint. HTTP Status: ${
+                        err.status ?? "none"
+                    }. ${err.toString()}`
+                );
+                console.error(
+                    `An error occurred during call to /api/map endpoint. HTTP Status: ${err.status ?? "none"}.`,
+                    err
+                );
+            } else {
+                Sentry.captureException(`An error occurred during call to /api/map endpoint.`);
+                console.error(`An error occurred during call to /api/map endpoint.`, err);
+            }
+            if (err instanceof Error) {
+                message = err.message;
+            }
+            return {
+                status: "error",
+                type: "error",
+                title: "Connection error",
+                subtitle: "Something wrong happened while fetching map details!",
+                image: "",
+                code: "ROOM_ACCESS_ERROR",
+                details: message,
+            };
         }
-
-        if (roomRedirect.success) {
-            return roomRedirect.data;
-        }
-
-        console.error(mapDetailData.error.issues);
-        console.error(roomRedirect.error.issues);
-        console.error("Unexpected answer from the /api/map admin endpoint.", res.data);
-        Sentry.captureException(mapDetailData.error.issues);
-        Sentry.captureException(roomRedirect.error.issues);
-        Sentry.captureException(`Unexpected answer from the /api/map admin endpoint. ${JSON.stringify(res.data)}`);
-        throw new Error("Unexpected answer from the /api/map admin endpoint.");
     }
 }
 

--- a/play/src/pusher/controllers/MapController.ts
+++ b/play/src/pusher/controllers/MapController.ts
@@ -1,6 +1,5 @@
 import { isMapDetailsData } from "@workadventure/messages";
 import { z } from "zod";
-import { isAxiosError } from "axios";
 import type { Request, Response } from "hyper-express";
 import { JsonWebTokenError } from "jsonwebtoken";
 import { DISABLE_ANONYMOUS } from "../enums/EnvironmentVariable";
@@ -88,7 +87,7 @@ export class MapController extends BaseHttpController {
                         res.send("The Token is invalid");
                     });
                     return;
-                } else if (isAxiosError(error)) {
+                } /* else if (isAxiosError(error)) {
                     if (error.response?.status === 404) {
                         // An error 404 means the map was not found.
                         // Note: we should definitely change this.
@@ -101,7 +100,7 @@ export class MapController extends BaseHttpController {
                         res.send("Error while fetching map details");
                     });
                     return;
-                } else {
+                }*/ else {
                     throw error;
                 }
             }


### PR DESCRIPTION
The AdminAPI can/should now return HTTP 200 code with errors.