### PR TITLE
Remove hardcoded image digests

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,5 +1,5 @@
 # protobuf build
-FROM --platform=$BUILDPLATFORM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e as proto-builder
+FROM --platform=$BUILDPLATFORM node:20.8-bullseye-slim as proto-builder
 WORKDIR /usr/src
 COPY messages/package-lock.json messages/package.json ./
 RUN npm ci
@@ -8,7 +8,7 @@ COPY libs ./../libs
 RUN npm run tag-version && npm run ts-proto
 
 # final production image
-FROM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e
+FROM node:20.8-bullseye-slim
 EXPOSE 8080 50051
 WORKDIR /usr/src
 RUN apt-get update && apt-get install -y git curl

--- a/chat/Dockerfile
+++ b/chat/Dockerfile
@@ -3,7 +3,7 @@
 # When the issue above is closed, we can move back messages building inside Dockerfile
 
 # protobuf build
-FROM --platform=$BUILDPLATFORM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e as proto-builder
+FROM --platform=$BUILDPLATFORM node:20.8-bullseye-slim as proto-builder
 WORKDIR /usr/src
 COPY messages/package-lock.json messages/package.json ./
 RUN npm ci
@@ -12,7 +12,7 @@ COPY libs ./../libs
 RUN npm run tag-version && npm run ts-proto
 
 # typescript build
-FROM --platform=$BUILDPLATFORM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e as builder
+FROM --platform=$BUILDPLATFORM node:20.8-bullseye-slim as builder
 WORKDIR /usr/src
 RUN apt-get update && apt-get install -y git
 COPY package.json package-lock.json ./

--- a/map-storage/Dockerfile
+++ b/map-storage/Dockerfile
@@ -3,7 +3,7 @@
 # When the issue above is closed, we can move back messages building inside Dockerfile
 
 # protobuf build
-FROM --platform=$BUILDPLATFORM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e as proto-builder
+FROM --platform=$BUILDPLATFORM node:20.8-bullseye-slim as proto-builder
 WORKDIR /usr/src
 COPY messages/package-lock.json messages/package.json ./
 RUN npm ci
@@ -12,7 +12,7 @@ COPY libs ./../libs
 RUN npm run tag-version && npm run ts-proto
 
 # typescript build
-FROM --platform=$BUILDPLATFORM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e as builder
+FROM --platform=$BUILDPLATFORM node:20.8-bullseye-slim as builder
 EXPOSE 3000 50053
 WORKDIR /usr/src
 ENV STORAGE_DIRECTORY=/maps
@@ -33,7 +33,7 @@ COPY --chown=node:node map-storage map-storage
 RUN cd map-storage && npm run front:build
 
 # final production image
-FROM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e
+FROM node:20.8-bullseye-slim
 EXPOSE 3000 50053
 WORKDIR /usr/src
 ENV STORAGE_DIRECTORY=/maps

--- a/play/Dockerfile
+++ b/play/Dockerfile
@@ -1,5 +1,5 @@
 # protobuf build
-FROM --platform=$BUILDPLATFORM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e as proto-builder
+FROM --platform=$BUILDPLATFORM node:20.8-bullseye-slim as proto-builder
 WORKDIR /usr/src
 COPY messages/package-lock.json messages/package.json ./
 RUN npm ci
@@ -8,7 +8,7 @@ COPY libs ./../libs
 RUN npm run tag-version && npm run ts-proto
 
 # typescript build
-FROM --platform=$BUILDPLATFORM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e as builder
+FROM --platform=$BUILDPLATFORM node:20.8-bullseye-slim as builder
 WORKDIR /usr/src
 RUN apt-get update && apt-get install -y git
 COPY package.json package-lock.json ./
@@ -45,7 +45,7 @@ RUN --mount=type=secret,id=SENTRY_RELEASE \
     SENTRY_RELEASE=$SENTRY_RELEASE SENTRY_URL=$SENTRY_URL SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_ORG=$SENTRY_ORG SENTRY_PROJECT=$SENTRY_PROJECT SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT NODE_OPTIONS="--max-old-space-size=6144" npm run build
 
 # final production image
-FROM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e
+FROM node:20.8-bullseye-slim
 EXPOSE 3000
 WORKDIR /usr/src
 RUN apt-get update && apt-get install -y git curl

--- a/uploader/Dockerfile
+++ b/uploader/Dockerfile
@@ -1,5 +1,5 @@
 # final production image
-FROM node:20.8.0-bullseye-slim@sha256:9027d0d778368a3091ee36b0bfdc98ebf3d7815ee4e2811b05cc40ec2a0adf4e
+FROM node:20.8-bullseye-slim
 EXPOSE 8080
 WORKDIR /usr/src
 RUN apt-get update && apt-get install -y git


### PR DESCRIPTION
As documented in #3625, the hard-coded image digests prevent a proper ARM build. This PR removes the hard-coded digests. Additionally, it removes the patch version in the image, see discussion in #3625 for background.

I have tested that all of the images still build, but have not tested that they start correctly.