### PR TITLE
feat(ux): Area editor ux improvement

### DIFF
--- a/play/src/front/Components/MapEditor/AreaEditor.svelte
+++ b/play/src/front/Components/MapEditor/AreaEditor.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-    import { mapEditorAreaModeStore, mapEditorSelectedAreaPreviewStore } from "../../Stores/MapEditorStore";
+    import {mapEditorAreaModeStore, mapEditorSelectedAreaPreviewStore} from "../../Stores/MapEditorStore";
     import AreaPropertiesEditor from "./AreaPropertiesEditor.svelte";
+    import AreaEditorInstructions from "./AreaEditorInstructions.svelte";
 </script>
 
 {#if $mapEditorAreaModeStore === "ADD"}
-    <!-- <AreaPropertiesEditor /> -->
+    <AreaEditorInstructions/>
 {/if}
 {#if $mapEditorAreaModeStore === "EDIT"}
     {#if $mapEditorSelectedAreaPreviewStore !== undefined}
-        <AreaPropertiesEditor />
+        <AreaPropertiesEditor/>
     {/if}
 {/if}
 

--- a/play/src/front/Components/MapEditor/AreaEditor.svelte
+++ b/play/src/front/Components/MapEditor/AreaEditor.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-    import {mapEditorAreaModeStore, mapEditorSelectedAreaPreviewStore} from "../../Stores/MapEditorStore";
+    import { mapEditorAreaModeStore, mapEditorSelectedAreaPreviewStore } from "../../Stores/MapEditorStore";
     import AreaPropertiesEditor from "./AreaPropertiesEditor.svelte";
     import AreaEditorInstructions from "./AreaEditorInstructions.svelte";
 </script>
 
 {#if $mapEditorAreaModeStore === "ADD"}
-    <AreaEditorInstructions/>
+    <AreaEditorInstructions />
 {/if}
 {#if $mapEditorAreaModeStore === "EDIT"}
     {#if $mapEditorSelectedAreaPreviewStore !== undefined}
-        <AreaPropertiesEditor/>
+        <AreaPropertiesEditor />
     {/if}
 {/if}
 

--- a/play/src/front/Components/MapEditor/AreaEditorInstructions.svelte
+++ b/play/src/front/Components/MapEditor/AreaEditorInstructions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import {LL} from "../../../i18n/i18n-svelte";
+    import { LL } from "../../../i18n/i18n-svelte";
 </script>
 
 <div class="area-name-container">

--- a/play/src/front/Components/MapEditor/AreaEditorInstructions.svelte
+++ b/play/src/front/Components/MapEditor/AreaEditorInstructions.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    import {LL} from "../../../i18n/i18n-svelte";
+</script>
+
+<div class="area-name-container">
+    <h3>{$LL.mapEditor.areaEditorInstructions.title()}</h3>
+    <p>{$LL.mapEditor.areaEditorInstructions.description()}</p>
+</div>
+
+<style lang="scss">
+</style>

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -181,6 +181,7 @@ export class AreaEditorTool extends MapEditorTool {
                         this.scene.input.setDefaultCursor("crosshair");
                     })
                     .catch((e) => console.error(e));
+                this.changeAreaMode("ADD");
                 break;
             }
             default: {

--- a/play/src/i18n/de-DE/mapEditor.ts
+++ b/play/src/i18n/de-DE/mapEditor.ts
@@ -154,6 +154,10 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         editInstructions: "Klicken Sie auf eine Fläche, um ihre Eigenschaften zu ändern.",
         nameLabel: "Name",
     },
+    areaEditorInstructions: {
+        title: "Wie funktioniert das?",
+        description: "Zeichnen Sie ein Gebiet auf der Karte, um ein neues zu erstellen.",
+    },
     entityEditor: {
         itemPicker: {
             searchPlaceholder: "Forschen",

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -162,6 +162,10 @@ const mapEditor: BaseTranslation = {
         editInstructions: "Click an area to modify its properties.",
         nameLabel: "Name",
     },
+    areaEditorInstructions: {
+        title: "How it works ?",
+        description: "Draw a zone on the map to create a new one.",
+    },
     entityEditor: {
         itemPicker: {
             searchPlaceholder: "Search",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -160,6 +160,10 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         editInstructions: "Sélectionnez une zone pour modifier ses propriétés.",
         nameLabel: "Nom de la zone",
     },
+    areaEditorInstructions: {
+        title: "Comment ca marche ?",
+        description: "Dessinez une zone sur la carte afin d'en créer une nouvelle.",
+    },
     entityEditor: {
         itemPicker: {
             searchPlaceholder: "Rechercher",

--- a/play/src/i18n/hsb-DE/mapEditor.ts
+++ b/play/src/i18n/hsb-DE/mapEditor.ts
@@ -153,6 +153,10 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         editInstructions: "Klikńće na płoninu, zo byšće jeje kajkosće změnili.",
         nameLabel: "mjeno",
     },
+    areaEditorInstructions: {
+        title: "Kako deluje?",
+        description: "Če želite ustvariti novo območje, ga narišite na zemljevidu.",
+    },
     entityEditor: {
         itemPicker: {
             searchPlaceholder: "slědźić",


### PR DESCRIPTION
Add "how to" instruction on Area Editor to help user understand that he can draw a zone on the map to create a new area.