### PR TITLE
Fixing default selected option in map editor

### DIFF
--- a/play/src/front/Components/MapEditor/PropertyEditor/ExitPropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/ExitPropertyEditor.svelte
@@ -107,7 +107,7 @@
                     on:blur={onValueChange}
                 >
                     {#each startAreas as areaName (areaName)}
-                        <option value={areaName}>{areaName}</option>
+                        <option value={areaName} selected={areaName === property.areaName}>{areaName}</option>
                     {/each}
                     {#if startAreas.length === 0}
                         <option value={""} selected>No start area found</option>


### PR DESCRIPTION
In the exit properties, the default selected option for the start area was always the last option. This is due to an issue with bind:value and <select>

This commit provides a workaround.

Closes #3657