### PR TITLE
Fixing iframe API file paths

### DIFF
--- a/play/packages/iframe-api-typings/.gitignore
+++ b/play/packages/iframe-api-typings/.gitignore
@@ -1,1 +1,3 @@
 *.d.ts
+!/iframe_api.d.ts
+

--- a/play/packages/iframe-api-typings/iframe_api.d.ts
+++ b/play/packages/iframe-api-typings/iframe_api.d.ts
@@ -1,0 +1,1 @@
+export type * from "./play/src/iframe_api";

--- a/play/src/iframe_api.ts
+++ b/play/src/iframe_api.ts
@@ -46,9 +46,11 @@ export type {
     ModifyEmbeddedWebsiteEvent,
     Rectangle,
 } from "./front/Api/Events/EmbeddedWebsiteEvent";
+export type { HasPlayerMovedEvent } from "./front/Api/Events/HasPlayerMovedEvent";
 export type { UIWebsite } from "./front/Api/Iframe/Ui/UIWebsite";
 export type { Menu } from "./front/Api/Iframe/Ui/Menu";
 export type { ActionMessage } from "./front/Api/Iframe/Ui/ActionMessage";
+export type { Position } from "./front/Api/Iframe/player";
 export type { EmbeddedWebsite } from "./front/Api/Iframe/Room/EmbeddedWebsite";
 export type { Area } from "./front/Api/Iframe/Area/Area";
 export type { ActionsMenuAction } from "./front/Api/Iframe/ui";


### PR DESCRIPTION
The included files have moved in the iframe-api-typings (because we are now including a file from /lib). As a result, all imports are broken.
We fix this by restoring the iframe_api.d.ts file and exporting evrything from files at the new location of the file.