### PR TITLE
Fix output device saving

### DIFF
--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -8,7 +8,6 @@
     import { requestedScreenSharingState } from "../../Stores/ScreenSharingStore";
     import {
         cameraListStore,
-        localStreamStore,
         microphoneListStore,
         speakerListStore,
         requestedCameraState,
@@ -370,27 +369,7 @@
 
     onDestroy(() => {
         subscribers.map((subscriber) => subscriber());
-        unsubscribeLocalStreamStore();
         chatTotalMessagesSubscription?.unsubscribe();
-    });
-
-    let stream: MediaStream | null;
-    const unsubscribeLocalStreamStore = localStreamStore.subscribe((value) => {
-        if (value.type === "success") {
-            stream = value.stream;
-
-            if (stream !== null) {
-                const audioTracks = stream.getAudioTracks();
-                if (audioTracks.length > 0) {
-                    // set default speaker selected
-                    if ($speakerListStore && $speakerListStore.length > 0) {
-                        speakerSelectedStore.set($speakerListStore[0].deviceId);
-                    }
-                }
-            }
-        } else {
-            stream = null;
-        }
     });
 
     function buttonActionBarTrigger(id: string) {

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -804,7 +804,7 @@ speakerListStore.subscribe((devices) => {
     }
 });
 
-export const speakerSelectedStore = writable<string | undefined>();
+export const speakerSelectedStore = writable<string | undefined>(localUserStore.getSpeakerDeviceId() ?? undefined);
 
 function removeDuplicateDevices(devices: MediaDeviceInfo[]) {
     const uniqueDevices = new Map<string, MediaDeviceInfo>();


### PR DESCRIPTION
Previously, the output device configured was lost each time a new local stream was started. Furthermore, the speaker id stored in local storage was never read.

We fix here both issues. Now, a selected speaker remains selected, even after a page refresh. If the speaker is no longer available, we fallback to the default speaker.

Tested with Chrome and Firefox on Ubuntu.

Closes #3666 