### PR TITLE
Adding an error message when an audio file is not found

### DIFF
--- a/maps/tests/AllowAudio/map-audio-not-found.json
+++ b/maps/tests/AllowAudio/map-audio-not-found.json
@@ -1,0 +1,277 @@
+{ "compressionlevel":-1,
+ "height":10,
+ "infinite":false,
+ "layers":[
+        {
+         "data":[0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 444, 444, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+         "height":10,
+         "id":6,
+         "name":"start",
+         "opacity":1,
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "data":[0, 0, 0, 0, 444, 444, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+         "height":10,
+         "id":40,
+         "name":"no-audio",
+         "opacity":1,
+         "properties":[
+                {
+                 "name":"startLayer",
+                 "type":"bool",
+                 "value":true
+                }],
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "data":[201, 201, 201, 201, 201, 201, 201, 201, 201, 201,
+            201, 201, 201, 201, 201, 201, 201, 201, 201, 201,
+            201, 201, 201, 201, 201, 201, 201, 201, 201, 201,
+            201, 201, 201, 201, 201, 201, 201, 201, 201, 201,
+            201, 201, 201, 201, 201, 201, 201, 201, 201, 201,
+            201, 201, 201, 201, 201, 201, 201, 201, 201, 201,
+            201, 201, 201, 201, 201, 201, 201, 201, 201, 201,
+            201, 201, 201, 201, 201, 201, 201, 201, 201, 201,
+            201, 201, 201, 201, 201, 201, 201, 201, 201, 201,
+            201, 201, 201, 201, 201, 201, 201, 201, 201, 201],
+         "height":10,
+         "id":4,
+         "name":"floor",
+         "opacity":1,
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "data":[0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            449, 449, 449, 449, 449, 449, 449, 449, 449, 449,
+            449, 449, 449, 449, 449, 449, 449, 449, 449, 449],
+         "height":10,
+         "id":39,
+         "name":"audio",
+         "opacity":1,
+         "properties":[
+                {
+                 "name":"audioLoop",
+                 "type":"bool",
+                 "value":true
+                }, 
+                {
+                 "name":"playAudio",
+                 "type":"string",
+                 "value":"..\/..\/assets\/audio\/doesNotExists.ogg"
+                }],
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "draworder":"topdown",
+         "id":2,
+         "name":"floorLayer",
+         "objects":[
+                {
+                 "height":227.294588060257,
+                 "id":9,
+                 "name":"",
+                 "rotation":0,
+                 "text":
+                    {
+                     "fontfamily":"Sans Serif",
+                     "pixelsize":13,
+                     "text":"\"Allow audio\" button test case. The linked audio file does not exist.\n\n1. Load the page\n2. You should see an error displayed at the top of the screen + in the logs\n\n(use #no-audio start layer to spawn outside the audio zone)",
+                     "wrap":true
+                    },
+                 "type":"",
+                 "visible":true,
+                 "width":317.982661490298,
+                 "x":1.53139349868751,
+                 "y":29.8384428152397
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
+        }],
+ "nextlayerid":41,
+ "nextobjectid":10,
+ "orientation":"orthogonal",
+ "properties":[
+        {
+         "name":"mapCopyright",
+         "type":"string",
+         "value":"Credits: Valdo Romao https:\/\/www.linkedin.com\/in\/valdo-romao\/ \nLicense: CC-BY-SA 3.0 (http:\/\/creativecommons.org\/licenses\/by-sa\/3.0\/)"
+        }, 
+        {
+         "name":"mapDescription",
+         "type":"string",
+         "value":"A perfect virtual office to get started with WorkAdventure!"
+        }, 
+        {
+         "name":"mapImage",
+         "type":"string",
+         "value":"map.png"
+        }, 
+        {
+         "name":"mapLink",
+         "type":"string",
+         "value":"https:\/\/thecodingmachine.github.io\/workadventure-map-starter-kit\/map.json"
+        }, 
+        {
+         "name":"mapName",
+         "type":"string",
+         "value":"Allow audio test"
+        }],
+ "renderorder":"right-down",
+ "tiledversion":"1.10.2",
+ "tileheight":32,
+ "tilesets":[
+        {
+         "columns":10,
+         "firstgid":1,
+         "image":"..\/..\/assets\/tileset5_export.png",
+         "imageheight":320,
+         "imagewidth":320,
+         "margin":0,
+         "name":"tileset5_export",
+         "properties":[
+                {
+                 "name":"tilesetCopyright",
+                 "type":"string",
+                 "value":"\u00a9 2021 WorkAdventure <https:\/\/workadventu.re\/> \nLicence: WORKADVENTURE SPECIFIC RESOURCES LICENSE (see LICENSE.assets file)"
+                }],
+         "spacing":0,
+         "tilecount":100,
+         "tileheight":32,
+         "tilewidth":32
+        }, 
+        {
+         "columns":10,
+         "firstgid":101,
+         "image":"..\/..\/assets\/tileset6_export.png",
+         "imageheight":320,
+         "imagewidth":320,
+         "margin":0,
+         "name":"tileset6_export",
+         "properties":[
+                {
+                 "name":"tilesetCopyright",
+                 "type":"string",
+                 "value":"\u00a9 2021 WorkAdventure <https:\/\/workadventu.re\/> \nLicence: WORKADVENTURE SPECIFIC RESOURCES LICENSE (see LICENSE.assets file)"
+                }],
+         "spacing":0,
+         "tilecount":100,
+         "tileheight":32,
+         "tilewidth":32
+        }, 
+        {
+         "columns":11,
+         "firstgid":201,
+         "image":"..\/..\/assets\/tileset1.png",
+         "imageheight":352,
+         "imagewidth":352,
+         "margin":0,
+         "name":"tileset1",
+         "properties":[
+                {
+                 "name":"tilesetCopyright",
+                 "type":"string",
+                 "value":"\u00a9 2021 WorkAdventure <https:\/\/workadventu.re\/> \nLicence: WORKADVENTURE SPECIFIC RESOURCES LICENSE (see LICENSE.assets file)"
+                }],
+         "spacing":0,
+         "tilecount":121,
+         "tileheight":32,
+         "tilewidth":32
+        }, 
+        {
+         "columns":11,
+         "firstgid":322,
+         "image":"..\/..\/assets\/tileset1-repositioning.png",
+         "imageheight":352,
+         "imagewidth":352,
+         "margin":0,
+         "name":"tileset1-repositioning",
+         "properties":[
+                {
+                 "name":"tilesetCopyright",
+                 "type":"string",
+                 "value":"\u00a9 2021 WorkAdventure <https:\/\/workadventu.re\/> \nLicence: WORKADVENTURE SPECIFIC RESOURCES LICENSE (see LICENSE.assets file)"
+                }],
+         "spacing":0,
+         "tilecount":121,
+         "tileheight":32,
+         "tilewidth":32
+        }, 
+        {
+         "columns":6,
+         "firstgid":443,
+         "image":"..\/..\/assets\/Special_Zones.png",
+         "imageheight":64,
+         "imagewidth":192,
+         "margin":0,
+         "name":"Special_Zones",
+         "properties":[
+                {
+                 "name":"tilesetCopyright",
+                 "type":"string",
+                 "value":"\u00a9 2021 WorkAdventure <https:\/\/workadventu.re\/> \nLicence: WORKADVENTURE SPECIFIC RESOURCES LICENSE (see LICENSE.assets file)"
+                }],
+         "spacing":0,
+         "tilecount":12,
+         "tileheight":32,
+         "tiles":[
+                {
+                 "id":0,
+                 "properties":[
+                        {
+                         "name":"collides",
+                         "type":"bool",
+                         "value":true
+                        }]
+                }],
+         "tilewidth":32
+        }],
+ "tilewidth":32,
+ "type":"map",
+ "version":"1.10",
+ "width":10
+}

--- a/maps/tests/index.html
+++ b/maps/tests/index.html
@@ -130,6 +130,14 @@
                 </tr>
                 <tr>
                     <td>
+                        <input type="radio" name="test-audio-not-found"> Success <input type="radio" name="test-audio-not-found"> Failure <input type="radio" name="test-audio-not-found" checked> Pending
+                    </td>
+                    <td>
+                        <a href="#" class="testLink" data-testmap="AllowAudio/map-audio-not-found.json" target="_blank">Test audio errors (audio file not found)</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <input type="radio" name="test-jitsi-silent"> Success <input type="radio" name="test-jitsi-silent"> Failure <input type="radio" name="test-jitsi-silent" checked> Pending
                     </td>
                     <td>

--- a/play/src/front/Components/AudioManager/AudioManager.svelte
+++ b/play/src/front/Components/AudioManager/AudioManager.svelte
@@ -18,7 +18,7 @@
     let unsubscriberFileStore: Unsubscriber | null = null;
     let unsubscriberVolumeStore: Unsubscriber | null = null;
 
-    let isAudioAllowed = true;
+    let state: "loading" | "playing" | "not_allowed" | "error" = "loading";
 
     onMount(() => {
         let volume = Math.min(localUserStore.getAudioPlayerVolume(), get(audioManagerVolumeStore).volume);
@@ -69,13 +69,20 @@
             // Audiovisilibily is set to false when audio is ended
             audioManagerVisibilityStore.set(false);
         };
+
         void HTMLAudioPlayer.play()
             .then(() => {
-                isAudioAllowed = true;
+                state = "playing";
             })
             .catch((e) => {
-                console.error("The audio could not be played: ", e);
-                isAudioAllowed = false;
+                if (e instanceof DOMException && e.name === "NotAllowedError") {
+                    // The browser does not allow audio to be played, possibly because the user has not interacted with the page yet.
+                    // Let's ask the user to interact with the page first.
+                    state = "not_allowed";
+                } else {
+                    state = "error";
+                    console.error("The audio could not be played: ", e.name, e);
+                }
             });
     }
 
@@ -122,7 +129,7 @@
 </script>
 
 <div class="main-audio-manager">
-    <div class:hidden={!isAudioAllowed}>
+    <div class:hidden={state !== "playing"}>
         <div class="audio-manager-player-volume">
             <span id="audioplayer_volume_icon_playing" bind:this={audioPlayerVolumeIcon} on:click={onMute}>
                 <svg
@@ -173,12 +180,18 @@
             <audio class="audio-manager-audioplayer" bind:this={HTMLAudioPlayer} />
         </section>
     </div>
-    <div class:hidden={isAudioAllowed} class="tw-text-center tw-flex tw-justify-center">
+    <div class:hidden={state !== "not_allowed"} class="tw-text-center tw-flex tw-justify-center">
         <button
             type="button"
             class="btn light tw-justify-center tw-font-bold tw-text-xs sm:tw-text-base tw-w-fit"
             on:click={tryPlay}>{$LL.audio.manager.allow()}</button
         >
+    </div>
+    <div
+        class:hidden={state !== "error"}
+        class="tw-text-center tw-flex tw-justify-center tw-text-danger tw-h-6 tw-truncate"
+    >
+        ⚠️ {$LL.audio.manager.error()} ⚠️
     </div>
 </div>
 

--- a/play/src/i18n/en-US/audio.ts
+++ b/play/src/i18n/en-US/audio.ts
@@ -4,6 +4,7 @@ const audio: BaseTranslation = {
     manager: {
         reduce: "Decrease audio player volume while speaking",
         allow: "Allow audio",
+        error: "Could not load sound",
     },
     message: "Audio message",
     disable: "Turn off your microphone",

--- a/play/src/i18n/fr-FR/audio.ts
+++ b/play/src/i18n/fr-FR/audio.ts
@@ -5,6 +5,7 @@ const audio: DeepPartial<Translation["audio"]> = {
     manager: {
         reduce: "Diminuer le volume du lecteur audio dans les conversations",
         allow: "Autoriser l'audio",
+        error: "Impossible de charger le son",
     },
     message: "Message audio",
     disable: "Couper le microphone",


### PR DESCRIPTION
Previously, the "allow audio" button was displayed. Now, we make a distinction between the "browser doesn't grant access" error and the "network/other" errors.

![image](https://github.com/workadventure/workadventure/assets/1290952/f3f87ffb-dd8f-43cb-9622-11d256cff61c)

Related to: https://github.com/workadventure/workadventure/issues/3656
