### PR TITLE
Improving the audio selector in map editor

### DIFF
--- a/play/src/front/Components/AudioManager/AudioManager.svelte
+++ b/play/src/front/Components/AudioManager/AudioManager.svelte
@@ -70,7 +70,7 @@
             audioManagerVisibilityStore.set(false);
         };
 
-        void HTMLAudioPlayer.play()
+        HTMLAudioPlayer.play()
             .then(() => {
                 state = "playing";
             })

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -59,6 +59,7 @@ const mapEditor: BaseTranslation = {
             audioLinkLabel: "Audio Link",
             audioLinkPlaceholder: "https://xxx.yyy/smthing.mp3",
             defaultButtonLabel: "Play music",
+            error: "Could not load sound",
         },
         linkProperties: {
             label: "Open Link",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -60,6 +60,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             audioLinkPlaceholder: "https://xxx.yyy/smthing.mp3",
             defaultButtonLabel: "Jouer de la musique",
             volumeLabel: "Volume",
+            error: "Impossible de charger le son",
         },
         linkProperties: {
             label: "Ouvrir un lien",


### PR DESCRIPTION
Adding a button to test the audio, right next to the input field where you type the sound URL. This will make testing sound way faster.

Also, changing the volume selector from a number to a range.

![image](https://github.com/workadventure/workadventure/assets/1290952/d87af047-17a7-4072-8d92-750b37f67b39)

Related to #3656 and #3651