### PR TITLE
Showing embedded iframes only when scene is loaded AND connection established

### DIFF
--- a/play/src/front/Phaser/Game/EmbeddedWebsiteManager.ts
+++ b/play/src/front/Phaser/Game/EmbeddedWebsiteManager.ts
@@ -205,9 +205,13 @@ height,*/
         }
         domElement.setVisible(visible);
 
-        this.gameScene.load.once("complete", () => {
-            iframe.style.visibility = "visible";
-        });
+        this.gameScene.sceneReadyToStartPromise
+            .then(() => {
+                iframe.style.visibility = "visible";
+            })
+            .catch((e) => {
+                console.error(e);
+            });
 
         switch (embeddedWebsiteEvent.origin) {
             case "player":

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -207,6 +207,8 @@ export class GameScene extends DirtyScene {
     private connectionAnswerPromiseDeferred: Deferred<RoomJoinedMessageInterface>;
     // A promise that will resolve when the "create" method is called (signaling loading is ended)
     private createPromiseDeferred: Deferred<void>;
+    // A promise that will resolve when the scene is ready to start (all assets have been loaded and the connection to the room is established)
+    private sceneReadyToStartDeferred: Deferred<void> = new Deferred<void>();
     private iframeSubscriptionList!: Array<Subscription>;
     private gameMapChangedSubscription!: Subscription;
     private messageSubscription: Subscription | null = null;
@@ -877,6 +879,7 @@ export class GameScene extends DirtyScene {
         ])
             .then(() => {
                 this.hide(false);
+                this.sceneReadyToStartDeferred.resolve();
             })
             .catch((e) =>
                 console.error(
@@ -3291,5 +3294,9 @@ ${escapedMessage}
 
     get room(): Room {
         return this._room;
+    }
+
+    get sceneReadyToStartPromise(): Promise<void> {
+        return this.sceneReadyToStartDeferred.promise;
     }
 }


### PR DESCRIPTION
This is a fix on top of https://github.com/workadventure/workadventure/pull/3644/files Waiting for the scene to be loaded is not enough. The loader only goes away when the room connection is established too.
We need to wait for both conditions before showing the iframes again.