### PR TITLE
Conditionally call the revocation endpoint

### DIFF
--- a/play/src/pusher/services/OpenIDClient.ts
+++ b/play/src/pusher/services/OpenIDClient.ts
@@ -146,6 +146,9 @@ class OpenIDClient {
 
     public logoutUser(token: string): Promise<void> {
         return this.initClient().then((client) => {
+            if (!client.metadata.revocation_endpoint) {
+                return;
+            }
             return client.revoke(token);
         });
     }


### PR DESCRIPTION
Only call the revocation endpoint if there is a revocation endpoint in the Openid provider we are using.