### PR TITLE
Fix screen sharing error

### DIFF
--- a/play/src/front/Stores/PeerStore.ts
+++ b/play/src/front/Stores/PeerStore.ts
@@ -1,4 +1,5 @@
 import { get, readable, writable } from "svelte/store";
+import * as Sentry from "@sentry/svelte";
 import type { VideoPeer } from "../WebRtc/VideoPeer";
 import type { ScreenSharingPeer } from "../WebRtc/ScreenSharingPeer";
 
@@ -23,7 +24,7 @@ function createPeerStore<T>() {
             update((users) => {
                 const peerConnectionDeleted = users.delete(userId);
                 if (!peerConnectionDeleted) {
-                    throw new Error("Error deleting peer connection");
+                    Sentry.captureException(new Error("Error deleting peer connection"));
                 }
                 return users;
             });

--- a/play/src/front/WebRtc/P2PMessages/StreamEndedMessage.ts
+++ b/play/src/front/WebRtc/P2PMessages/StreamEndedMessage.ts
@@ -1,7 +1,16 @@
 import { z } from "zod";
 
-export const StreamEndedMessage = z.object({
-    type: z.literal("stream_ended"),
-});
+export const STREAM_STOPPED_MESSAGE_TYPE = "stream_stopped";
+export const STREAM_ENDED_MESSAGE_TYPE = "stream_ended";
 
+export const StreamStoppedMessage = z.object({
+    type: z.literal(STREAM_STOPPED_MESSAGE_TYPE),
+});
+export type StreamStoppedMessage = z.infer<typeof StreamStoppedMessage>;
+
+export const StreamEndedMessage = z.object({
+    type: z.literal(STREAM_ENDED_MESSAGE_TYPE),
+});
 export type StreamEndedMessage = z.infer<typeof StreamEndedMessage>;
+
+export const StreamMessage = z.union([StreamStoppedMessage, StreamEndedMessage]);


### PR DESCRIPTION
When one user opens and closes screen sharing, the second user in the bubble discussion cannot open new screen sharing.