### PR TITLE
Fixing environment variables validation in map-storage

### DIFF
--- a/deeployer.libsonnet
+++ b/deeployer.libsonnet
@@ -174,9 +174,10 @@
            "env": {
              "API_URL": "back1:50051,back2:50051",
              "PROMETHEUS_AUTHORIZATION_TOKEN": "promToken",
-             "AUTHENTICATION_STRATEGY": if (adminUrl == null) then "Basic" else "Bearer",
+             "ENABLE_BASIC_AUTHENTICATION": "true",
              "AUTHENTICATION_USER": "john.doe",
              "AUTHENTICATION_PASSWORD": "password",
+             "ENABLE_BEARER_AUTHENTICATION": if (adminUrl == null) then "false" else "true",
              "AUTHENTICATION_TOKEN": "SomeSecretToken",
              "USE_DOMAIN_NAME_IN_PATH": if (adminUrl == null) then "false" else "true",
              "DEBUG": "*",

--- a/map-storage/src/Enum/EnvironmentVariableValidator.ts
+++ b/map-storage/src/Enum/EnvironmentVariableValidator.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
     BoolAsString,
+    emptyStringToUndefined,
     PositiveIntAsString,
     toBool,
     toNumber,
@@ -72,11 +73,12 @@ export const EnvironmentVariables = z.object({
         .transform((val) => toNumber(val, 0.1))
         .describe("The sampling rate for Sentry traces. Only used if SENTRY_DSN is configured. Defaults to 0.1"),
     AUTHENTICATION_STRATEGY: z
-        .union([z.literal("bearer"), z.literal("basic"), z.literal("digest")])
+        .union([z.literal("Bearer"), z.literal("Basic"), z.literal("Digest"), z.literal("")])
         .optional()
         .describe(
             "Deprecated. Use ENABLE_BEARER_AUTHENTICATION, ENABLE_BASIC_AUTHENTICATION or ENABLE_DIGEST_AUTHENTICATION instead"
-        ),
+        )
+        .transform(emptyStringToUndefined),
     ENABLE_BEARER_AUTHENTICATION: BoolAsString.optional()
         .transform((val) => toBool(val, false))
         .describe(
@@ -84,15 +86,16 @@ export const EnvironmentVariables = z.object({
         ),
     AUTHENTICATION_TOKEN: z
         .string()
-        .min(1)
         .optional()
-        .describe("The hard-coded bearer token to use for authentication"),
+        .describe("The hard-coded bearer token to use for authentication")
+        .transform(emptyStringToUndefined),
     AUTHENTICATION_VALIDATOR_URL: z
         .string()
         .url()
-        .min(1)
+        .or(z.literal(""))
         .optional()
-        .describe("The URL that will be used to remotely validate a bearer token"),
+        .describe("The URL that will be used to remotely validate a bearer token")
+        .transform(emptyStringToUndefined),
     ENABLE_BASIC_AUTHENTICATION: BoolAsString.optional()
         .transform((val) => toBool(val, false))
         .describe(

--- a/map-storage/src/Services/Authentication.ts
+++ b/map-storage/src/Services/Authentication.ts
@@ -16,17 +16,21 @@ if (ENV_VARS.AUTHENTICATION_STRATEGY) {
         "The AUTHENTICATION_STRATEGY environment variable is deprecated. Use ENABLE_BEARER_AUTHENTICATION, ENABLE_BASIC_AUTHENTICATION or ENABLE_DIGEST_AUTHENTICATION instead"
     );
     switch (ENV_VARS.AUTHENTICATION_STRATEGY) {
-        case "bearer":
+        case "Bearer":
             ENV_VARS.ENABLE_BEARER_AUTHENTICATION = true;
             break;
-        case "basic":
+        case "Basic":
             ENV_VARS.ENABLE_BASIC_AUTHENTICATION = true;
             break;
-        case "digest":
+        case "Digest":
             ENV_VARS.ENABLE_DIGEST_AUTHENTICATION = true;
             break;
+        case "":
+            break;
         default: {
-            const _exhaustiveCheck: never = ENV_VARS.AUTHENTICATION_STRATEGY;
+            throw new Error(
+                "Invalid AUTHENTICATION_STRATEGY environment variable, must be Bearer, Basic, Digest or empty"
+            );
         }
     }
 }


### PR DESCRIPTION
#3693 introduced a bug when validating env vars.
Empty string environment variables are not detected properly and were causing startup errors.

This should fix those errors.