### PR TITLE
In the exit editor, adding a "default start area" in the start area dropdown

### DIFF
--- a/play/src/front/Components/MapEditor/PropertyEditor/ExitPropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/ExitPropertyEditor.svelte
@@ -106,6 +106,9 @@
                     on:change={onValueChange}
                     on:blur={onValueChange}
                 >
+                    <option value="" selected={!property.areaName}
+                        >{$LL.mapEditor.properties.exitProperties.defaultStartArea()}</option
+                    >
                     {#each startAreas as areaName (areaName)}
                         <option value={areaName} selected={areaName === property.areaName}>{areaName}</option>
                     {/each}

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -112,6 +112,7 @@ const mapEditor: BaseTranslation = {
             description: "Where people can exit the map to another one.",
             exitMap: "Exit map",
             exitMapStartAreaName: "Start area name",
+            defaultStartArea: "Default start area",
         },
         youtubeProperties: {
             label: "Open Youtube Video",

--- a/play/src/i18n/en-US/woka.ts
+++ b/play/src/i18n/en-US/woka.ts
@@ -2,7 +2,7 @@ import type { BaseTranslation } from "../i18n-types";
 
 const woka: BaseTranslation = {
     customWoka: {
-        title: "Customize your WOKA",
+        title: "Build your WOKA",
         navigation: {
             return: "Return",
             back: "Back",
@@ -13,7 +13,7 @@ const woka: BaseTranslation = {
     selectWoka: {
         title: "Select your WOKA",
         continue: "Continue",
-        customize: "Customize your WOKA",
+        customize: "Build your WOKA",
     },
     menu: {
         businessCard: "Business Card",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -111,6 +111,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             description: "Où les joueurs apparaissent lorsqu'ils quittent la carte.",
             exitMap: "Quitter la carte",
             exitMapStartAreaName: "Nom de la zone de départ",
+            defaultStartArea: "Zone de départ par défaut",
         },
     },
     areaEditor: {


### PR DESCRIPTION
Previously, it was not possible to select no start position.

Closes #3706