### PR TITLE
Add Helm chart and release workflow

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,40 @@
+name: Release Chart
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Add repositories
+        run: |
+          for dir in $(ls -d contrib/helm/*/); do
+            helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
+          done
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: ./contrib/helm
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ node_modules
 _
 *.code-workspace
 /install.lock
+
+# Helm
+# Chart dependencies
+**/charts/*.tgz

--- a/contrib/helm/workadventure-k8s/.helmignore
+++ b/contrib/helm/workadventure-k8s/.helmignore
@@ -1,0 +1,25 @@
+test-values.yml
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/contrib/helm/workadventure-k8s/Chart.lock
+++ b/contrib/helm/workadventure-k8s/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 17.11.7
+digest: sha256:f8fbedf1dc26337563f281f9ce328e32670c7c5fb0f06cb3f45bf1e20adaf4df
+generated: "2023-07-09T07:47:55.015555868Z"

--- a/contrib/helm/workadventure-k8s/Chart.yaml
+++ b/contrib/helm/workadventure-k8s/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: workadventure
+description: Run workadventure on Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.17.7"
+
+dependencies:
+  - name: redis
+    version: 17.11.7
+    repository: https://charts.bitnami.com/bitnami

--- a/contrib/helm/workadventure-k8s/LICENSE
+++ b/contrib/helm/workadventure-k8s/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/contrib/helm/workadventure-k8s/README.md
+++ b/contrib/helm/workadventure-k8s/README.md
@@ -1,0 +1,26 @@
+# Workadventure on Kubernetes
+
+This Helm chart deploys [Workadventure](https://github.com/workadventure/workadventure) on Kubernetes.
+
+It is an adaption of the [official Docker Compose deployment](https://github.com/workadventure/workadventure/tree/master/contrib/docker).
+
+## Installation
+
+    helm repo add workadventure-k8s https://workadventure.github.io/workadventure-k8s
+    helm install workadventure workadventure-k8s/workadventure
+
+## Configuration
+
+Since the original Container images are completely configured via environment variables, this Helm chart have to use the same approach. Theres is a corresponding `xxx-secret-env.yaml` file and a `xxx-env.yaml` file, which contains all environments variables. There are many pre initialized variables in the template files. Additional entries can be easely added in the corresponding sections of the values file.
+
+There are the `commonEnv` and `commonSecretEnv` sections, which are used in all services.
+
+Please use the original [docker-compose file](https://github.com/workadventure/workadventure/blob/master/contrib/docker/docker-compose.prod.yaml) for reference. Look at the [original configuration template](https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template) for more informations about the available variables.
+
+## Upload your map
+
+Open your browser and go to https://< your-domain >/map-storage/.
+
+You will be asked to authenticate. The user is 'admin' and the password is the one you set in the value `mapstorage.secretEnv.AUTHENTICATION_PASSWORD`
+
+You can upload a map as a zip file here. But it is highly recommended to use the [workadventure map starter kit](https://docs.workadventu.re/map-building/tiled-editor/) to create and maintain your maps.

--- a/contrib/helm/workadventure-k8s/templates/_helpers.tpl
+++ b/contrib/helm/workadventure-k8s/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "workadventure.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "workadventure.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "workadventure.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "workadventure.labels" -}}
+helm.sh/chart: {{ include "workadventure.chart" . }}
+{{ include "workadventure.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "workadventure.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "workadventure.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "workadventure.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "workadventure.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/contrib/helm/workadventure-k8s/templates/back-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/back-env.yaml
@@ -1,0 +1,24 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-env-back
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+data:
+  PLAY_URL: https://{{ .Values.domainName }}
+  REDIS_HOST: {{ .Release.Name }}-redis-master
+  MAP_STORAGE_URL: {{ include "workadventure.fullname" . }}-mapstorage:50053
+  INTERNAL_MAP_STORAGE_URL: http://{{ include "workadventure.fullname" . }}-mapstorage:3000
+  PUBLIC_MAP_STORAGE_URL: https://{{ .Values.domainName }}/map-storage
+  PLAYER_VARIABLES_MAX_TTL: "-1"
+  EJABBERD_API_URI: http://{{ include "workadventure.fullname" . }}-ejabberd:5443/api
+  EJABBERD_DOMAIN: {{ .Values.ejabberdDomain }}
+
+  {{- range $key, $val := .Values.commonEnv }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.back.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/back-secret-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/back-secret-env.yaml
@@ -1,0 +1,18 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-secret-env-back
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+type: Opaque
+data:
+  SECRET_KEY: "{{ .Values.secretKey | b64enc }}"
+
+  {{- range $key, $val := .Values.commonSecretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.back.secretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/back-service.yaml
+++ b/contrib/helm/workadventure-k8s/templates/back-service.yaml
@@ -1,0 +1,26 @@
+{{- range $replica, $f := until (int $.Values.back.replicaCount) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workadventure.fullname" $ }}-back-{{ $replica }}
+  labels:
+    {{- include "workadventure.labels" $ | nindent 4 }}
+    role: back
+    statefulset.kubernetes.io/pod-name: {{ include "workadventure.fullname" $ }}-back-{{ $replica }}
+spec:
+  type: {{ $.Values.back.service.type }}
+  ports:
+    - port: {{ $.Values.back.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 50051
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "workadventure.selectorLabels" $ | nindent 4 }}
+    role: back
+    statefulset.kubernetes.io/pod-name: {{ include "workadventure.fullname" $ }}-back-{{ $replica }}
+{{ end -}}

--- a/contrib/helm/workadventure-k8s/templates/back-statefulset.yaml
+++ b/contrib/helm/workadventure-k8s/templates/back-statefulset.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "workadventure.fullname" . }}-back
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: back
+spec:
+  {{- if not .Values.back.autoscaling.enabled }}
+  replicas: {{ .Values.back.replicaCount }}
+  {{- end }}
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+    # Back servers are independent, so we can update all at once
+    # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#maximum-unavailable-pods
+    maxUnavailable: "100%"
+  selector:
+    matchLabels:
+      {{- include "workadventure.selectorLabels" . | nindent 6 }}
+      role: back
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/back-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/back-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.back.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "workadventure.selectorLabels" . | nindent 8 }}
+        role: back
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.back.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-back
+          securityContext:
+            {{- toYaml .Values.back.securityContext | nindent 12 }}
+          image: "{{ .Values.back.image.repository }}:{{ .Values.back.image.tag | default .Values.appVersion }}"
+          imagePullPolicy: {{ .Values.back.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "workadventure.fullname" . }}-env-back
+            - secretRef:
+                name: {{ include "workadventure.fullname" . }}-secret-env-back
+          ports:
+            - name: http
+              containerPort: {{ .Values.back.service.port }}
+              protocol: TCP
+            - name: grpc
+              containerPort: 50051
+              protocol: TCP
+          # livenessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          # readinessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          resources:
+            {{- toYaml .Values.back.resources | nindent 12 }}
+      {{- with .Values.back.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.back.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.back.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/chat-deployment.yaml
+++ b/contrib/helm/workadventure-k8s/templates/chat-deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workadventure.fullname" . }}-chat
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: chat
+spec:
+  {{- if not .Values.chat.autoscaling.enabled }}
+  replicas: {{ .Values.chat.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "workadventure.selectorLabels" . | nindent 6 }}
+      role: chat
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/chat-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/chat-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.chat.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "workadventure.selectorLabels" . | nindent 8 }}
+        role: chat
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.chat.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-chat
+          securityContext:
+            {{- toYaml .Values.chat.securityContext | nindent 12 }}
+          image: "{{ .Values.chat.image.repository }}:{{ .Values.chat.image.tag | default .Values.appVersion }}"
+          imagePullPolicy: {{ .Values.chat.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "workadventure.fullname" . }}-env-chat
+            - secretRef:
+                name: {{ include "workadventure.fullname" . }}-secret-env-chat
+          ports:
+            - name: http
+              containerPort: {{ .Values.chat.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.chat.resources | nindent 12 }}
+      {{- with .Values.chat.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.chat.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.chat.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/chat-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/chat-env.yaml
@@ -1,0 +1,20 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-env-chat
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+data:
+  PUSHER_URL: /
+  UPLOADER_URL: /uploader
+  EJABBERD_WS_URI: wss://{{ .Values.domainName }}/xmpp/ws
+  EJABBERD_DOMAIN: {{ .Values.ejabberdDomain }}
+
+  {{- range $key, $val := .Values.commonEnv }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.chat.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/chat-secret-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/chat-secret-env.yaml
@@ -1,0 +1,16 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-secret-env-chat
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $val := .Values.commonSecretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.chat.secretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/chat-service.yaml
+++ b/contrib/helm/workadventure-k8s/templates/chat-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workadventure.fullname" . }}-chat
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: chat
+spec:
+  type: {{ .Values.chat.service.type }}
+  ports:
+    - port: {{ .Values.chat.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "workadventure.selectorLabels" . | nindent 4 }}
+    role: chat

--- a/contrib/helm/workadventure-k8s/templates/ejabberd-deployment.yaml
+++ b/contrib/helm/workadventure-k8s/templates/ejabberd-deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workadventure.fullname" . }}-ejabberd
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: ejabberd
+spec:
+  {{- if not .Values.ejabberd.autoscaling.enabled }}
+  replicas: {{ .Values.ejabberd.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "workadventure.selectorLabels" . | nindent 6 }}
+      role: ejabberd
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/ejabberd-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/ejabberd-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.ejabberd.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "workadventure.selectorLabels" . | nindent 8 }}
+        role: ejabberd
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.ejabberd.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: ejabberd-template
+          configMap:
+            name: {{ include "workadventure.fullname" . }}-ejabberd-template
+      containers:
+        - name: {{ .Chart.Name }}-ejabberd
+          securityContext:
+            {{- toYaml .Values.ejabberd.securityContext | nindent 12 }}
+          image: "{{ .Values.ejabberd.image.repository }}:{{ .Values.ejabberd.image.tag | default .Values.appVersion }}"
+          imagePullPolicy: {{ .Values.ejabberd.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "workadventure.fullname" . }}-env-ejabberd
+            - secretRef:
+                name: {{ include "workadventure.fullname" . }}-secret-env-ejabberd
+          ports:
+            - name: http
+              containerPort: {{ .Values.ejabberd.service.port }}
+              protocol: TCP
+          # livenessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          # readinessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          resources:
+            {{- toYaml .Values.ejabberd.resources | nindent 12 }}
+          volumeMounts:
+            - name: ejabberd-template
+              mountPath: /tmp/ejabberd.template.yml
+              subPath: ejabberd.template.yml
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - |
+                    cp /tmp/ejabberd.template.yml /opt/ejabberd/conf/ejabberd.template.yml
+      {{- with .Values.ejabberd.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ejabberd.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ejabberd.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/ejabberd-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/ejabberd-env.yaml
@@ -1,0 +1,18 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-env-ejabberd
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+data:
+  CTL_ON_CREATE: "register {{ .Values.commonEnv.EJABBERD_USER }} {{ .Values.commonEnv.EJABBERD_DOMAIN }} {{ .Values.commonSecretEnv.EJABBERD_PASSWORD }}"
+  EJABBERD_DOMAIN: {{ .Values.ejabberdDomain }}
+
+  {{- range $key, $val := .Values.commonEnv }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.ejabberd.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/ejabberd-secret-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/ejabberd-secret-env.yaml
@@ -1,0 +1,18 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-secret-env-ejabberd
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+type: Opaque
+data:
+  JWT_SECRET: "{{ .Values.ejabberdJwtSecret | b64enc }}"
+
+  {{- range $key, $val := .Values.commonSecretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.ejabberd.secretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/ejabberd-service.yaml
+++ b/contrib/helm/workadventure-k8s/templates/ejabberd-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workadventure.fullname" . }}-ejabberd
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: ejabberd
+spec:
+  type: {{ .Values.ejabberd.service.type }}
+  ports:
+    - port: {{ .Values.ejabberd.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "workadventure.selectorLabels" . | nindent 4 }}
+    role: ejabberd

--- a/contrib/helm/workadventure-k8s/templates/ejabberd-template.yaml
+++ b/contrib/helm/workadventure-k8s/templates/ejabberd-template.yaml
@@ -1,0 +1,288 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-ejabberd-template
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+
+data:
+  ejabberd.template.yml: |-
+    ###
+    ###              ejabberd configuration file
+    ###
+    ### The parameters used in this configuration file are explained at
+    ###
+    ###       https://docs.ejabberd.im/admin/configuration
+    ###
+    hosts:
+      - ${EJABBERD_DOMAIN}
+
+    loglevel: 3
+    log_rotate_size: 10485760
+    log_rotate_count: 1
+
+    certfiles:
+      - /opt/ejabberd/conf/server.pem
+
+    ca_file: "/opt/ejabberd/conf/cacert.pem"
+
+    ## When using let's encrypt to generate certificates
+    ##certfiles:
+    ##  - /etc/letsencrypt/live/localhost/fullchain.pem
+    ##  - /etc/letsencrypt/live/localhost/privkey.pem
+    ##
+    ##ca_file: "/etc/letsencrypt/live/localhost/fullchain.pem"
+
+    auth_method:
+      - jwt
+      - internal
+    allow_multiple_connections: true
+    auth_use_cache: false
+    jwt_key: /opt/ejabberd/conf/jwt_key
+    disable_sasl_mechanisms: ["X-OAUTH2"]
+
+    #jwt_jid_field: "identifier"
+    #jwt_key: "/opt/ejabberd/conf/jwtKey"
+
+    listen:
+      -
+        port: 5222
+        ip: "::"
+        module: ejabberd_c2s
+        max_stanza_size: 262144
+        shaper: c2s_shaper
+        access: c2s
+        starttls_required: true
+      -
+        port: 5269
+        ip: "::"
+        module: ejabberd_s2s_in
+        max_stanza_size: 524288
+      -
+        port: 5443
+        ip: "::"
+        module: ejabberd_http
+        #tls: true
+        request_handlers:
+          "/admin": ejabberd_web_admin
+          "/api": mod_http_api
+          "/bosh": mod_bosh
+          "/captcha": ejabberd_captcha
+          "/upload": mod_http_upload
+          "/ws": ejabberd_http_ws
+          "/oauth": ejabberd_oauth
+      -
+        port: 5280
+        ip: "::"
+        module: ejabberd_http
+        request_handlers:
+          #"/admin": ejabberd_web_admin
+          "/api": mod_http_api
+          "/bosh": mod_bosh
+          "/captcha": ejabberd_captcha
+          "/upload": mod_http_upload
+          "/ws": ejabberd_http_ws
+          "/oauth": ejabberd_oauth
+      -
+        port: 5380
+        ip: "::"
+        module: ejabberd_http
+        request_handlers:
+          "/": ejabberd_web_admin
+      -
+        port: 1883
+        ip: "::"
+        module: mod_mqtt
+        backlog: 1000
+
+    s2s_use_starttls: optional
+
+    acl:
+      local:
+        user_regexp: ""
+      loopback:
+        ip:
+          - 127.0.0.0/8
+          - ::1/128
+          - ::FFFF:127.0.0.1/128
+          - ::FFFF:172.19.0.0/16
+      admin:
+        user:
+          - "${EJABBERD_USER}@${EJABBERD_DOMAIN}"
+          - "${EJABBERD_USER}"
+        ip:
+          - ::FFFF:172.19.0.0/16
+
+    access_rules:
+      local:
+        allow: local
+      c2s:
+        deny: blocked
+        allow: all
+      announce:
+        allow: admin
+      configure:
+        allow: admin
+      muc_create:
+        - allow: local
+        - deny: blocked
+      pubsub_createnode:
+        allow: local
+      trusted_network:
+        allow: loopback
+
+    api_permissions:
+      "console commands":
+        from:
+          - ejabberd_ctl
+        who: all
+        what: "*"
+      "admin access":
+        who:
+          - access:
+            - allow:
+              - acl: loopback
+              - acl: admin
+          - oauth:
+            - scope:
+              - "${EJABBERD_DOMAIN}:admin"
+            - access:
+              - allow:
+                - acl: loopback
+                - acl: admin
+        what:
+          - "*"
+          - "!stop"
+          - "!start"
+      "public commands":
+        who:
+          - ip: 127.0.0.1/8
+        what:
+          - status
+          - connected_users_number
+
+    shaper:
+      normal: 1000
+      fast: 50000
+
+    shaper_rules:
+      max_user_sessions: 10
+      max_user_offline_messages:
+        5000: admin
+        100: all
+      c2s_shaper:
+        none: admin
+        normal: all
+      s2s_shaper: fast
+
+    max_fsm_queue: 10000
+
+    acme:
+      contact: "mailto:example-admin@example.com"
+      ca_url: "https://acme-staging-v02.api.letsencrypt.org/directory"
+
+    modules:
+      mod_adhoc: {}
+      mod_admin_extra: {}
+      mod_announce:
+        access: announce
+      mod_avatar: {}
+      mod_blocking: {}
+      mod_bosh: {}
+      mod_caps: {}
+      mod_carboncopy: {}
+      mod_client_state: {}
+      mod_configure: {}
+      mod_disco: {}
+      mod_fail2ban: {}
+      mod_http_api: {}
+      ##mod_restful_admin:
+      ##  api:
+      ##    - path: [ "admin" ]
+      ##      module: mod_restful_admin
+      ##      params:
+      ##        key: "secret"
+      ##        allowed_commands: [ register, unregister,status, add_rosteritem, create_room, send_direct_invitation, set_room_affiliation ]
+      ##    - path: [ "register" ]
+      ##      module: mod_restful_register
+      ##      params:
+      ##        key: "secret"
+      mod_http_upload:
+        put_url: https://@HOST@:5443/upload
+      mod_last: {}
+      mod_mam:
+        ## Mnesia is limited to 2GB, better to use an SQL backend
+        ## For small servers SQLite is a good fit and is very easy
+        ## to configure. Uncomment this when you have SQL configured:
+        ## db_type: sql
+        assume_mam_usage: true
+        default: never
+      mod_mqtt: {}
+      mod_muc:
+        hosts:
+          - conference.${EJABBERD_DOMAIN}
+        access:
+          - allow
+        access_admin:
+          - allow: admin
+        access_create: muc_create
+        access_persistent: muc_create
+        access_mam:
+          - allow
+        default_room_options:
+          allow_subscription: true  # enable MucSub
+          mam: true
+          persistent: true
+          anonymous: false
+      mod_muc_admin: {}
+      mod_offline:
+        access_max_user_messages: max_user_offline_messages
+      mod_ping: {}
+      mod_privacy: {}
+      mod_private: {}
+      mod_proxy65:
+        access: local
+        max_connections: 5
+      mod_pubsub:
+        access_createnode: pubsub_createnode
+        plugins:
+          - flat
+          - pep
+        force_node_config:
+          ## Avoid buggy clients to make their bookmarks public
+          storage:bookmarks:
+            access_model: whitelist
+      mod_push: {}
+      mod_push_keepalive:
+        resume_timeout: 72
+        wake_on_start: false
+        wake_on_timeout: true
+      mod_register:
+        ## Only accept registration requests from the "trusted"
+        ## network (see access_rules section above).
+        ## Think twice before enabling registration from any
+        ## address. See the Jabber SPAM Manifesto for details:
+        ## https://github.com/ge0rg/jabber-spam-fighting-manifesto
+        ip_access: trusted_network
+      mod_roster:
+        versioning: true
+        store_current_id: false
+      mod_sip: {}
+      mod_s2s_dialback: {}
+      mod_shared_roster: {}
+      mod_stream_mgmt:
+        ack_timeout: infinity
+        resend_on_timeout: if_offline
+        resume_timeout: 0
+      mod_vcard: {}
+      mod_vcard_xupdate: {}
+      mod_version:
+        show_os: false
+
+    websocket_ping_interval: 300
+    websocket_timeout: 900
+    ### Local Variables:
+    ### mode: yaml
+    ### End:
+    ### vim: set filetype=yaml tabstop=8

--- a/contrib/helm/workadventure-k8s/templates/icon-deployment.yaml
+++ b/contrib/helm/workadventure-k8s/templates/icon-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workadventure.fullname" . }}-icon
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: icon
+spec:
+  replicas: {{ .Values.icon.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "workadventure.selectorLabels" . | nindent 6 }}
+      role: icon
+  template:
+    metadata:
+      {{- with .Values.icon.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "workadventure.selectorLabels" . | nindent 8 }}
+        role: icon
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.icon.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-icon
+          securityContext:
+            {{- toYaml .Values.icon.securityContext | nindent 12 }}
+          image: "{{ .Values.icon.image.repository }}:{{ .Values.icon.image.tag | default .Values.appVersion }}"
+          imagePullPolicy: {{ .Values.icon.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.icon.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.icon.resources | nindent 12 }}
+      {{- with .Values.icon.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.icon.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.icon.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/icon-service.yaml
+++ b/contrib/helm/workadventure-k8s/templates/icon-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workadventure.fullname" . }}-icon
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: icon
+spec:
+  type: {{ .Values.icon.service.type }}
+  ports:
+    - port: {{ .Values.icon.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "workadventure.selectorLabels" . | nindent 4 }}
+    role: icon

--- a/contrib/helm/workadventure-k8s/templates/ingress-ejabberd.yaml
+++ b/contrib/helm/workadventure-k8s/templates/ingress-ejabberd.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "workadventure.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-ejabberd
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotationsEjabbberd }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ejabberdDomain }}
+      secretName: {{ .Values.ingress.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ejabberdDomain }}
+      http:
+        paths:
+          - path: /
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "workadventure.fullname" . }}-ejabberd
+                port:
+                  number: {{ .Values.ejabberd.service.port }}
+{{- end }}

--- a/contrib/helm/workadventure-k8s/templates/ingress-path.yaml
+++ b/contrib/helm/workadventure-k8s/templates/ingress-path.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "workadventure.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-path
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotationsPath }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.domainName }}
+      secretName: {{ .Values.ingress.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.domainName }}
+      http:
+        paths:
+          - path: /chat{{ .Values.ingress.rewritePathSuffix }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "workadventure.fullname" . }}-chat
+                port:
+                  number: {{ .Values.chat.service.port }}
+          - path: /api{{ .Values.ingress.rewritePathSuffix }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "workadventure.fullname" . }}-back
+                port:
+                  number: {{ .Values.back.service.port }}
+          - path: /uploader{{ .Values.ingress.rewritePathSuffix }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "workadventure.fullname" . }}-uploader
+                port:
+                  number: {{ .Values.uploader.service.port }}
+          - path: /icon{{ .Values.ingress.rewritePathSuffix }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "workadventure.fullname" . }}-icon
+                port:
+                  number: {{ .Values.icon.service.port }}
+          - path: /xmpp{{ .Values.ingress.rewritePathSuffix }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "workadventure.fullname" . }}-ejabberd
+                port:
+                  number: {{ .Values.ejabberd.service.port }}
+          - path: /map-storage{{ .Values.ingress.rewritePathSuffix }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "workadventure.fullname" . }}-mapstorage
+                port:
+                  number: {{ .Values.mapstorage.service.port }}
+{{- end }}

--- a/contrib/helm/workadventure-k8s/templates/ingress-root.yaml
+++ b/contrib/helm/workadventure-k8s/templates/ingress-root.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "workadventure.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-root
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotationsRoot }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.domainName }}
+      secretName: {{ .Values.ingress.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.domainName }}
+      http:
+        paths:
+          - path: /
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "workadventure.fullname" . }}-play
+                port:
+                  number: {{ .Values.play.service.port }}
+{{- end }}

--- a/contrib/helm/workadventure-k8s/templates/mapstorage-deployment.yaml
+++ b/contrib/helm/workadventure-k8s/templates/mapstorage-deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workadventure.fullname" . }}-mapstorage
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: mapstorage
+spec:
+  replicas: {{ .Values.mapstorage.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "workadventure.selectorLabels" . | nindent 6 }}
+      role: mapstorage
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/mapstorage-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/mapstorage-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.mapstorage.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "workadventure.selectorLabels" . | nindent 8 }}
+        role: mapstorage
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.mapstorage.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: mapstorage
+          {{- if .Values.mapstorage.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "workadventure.fullname" . }}-mapstorage
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      initContainers:
+        - name: mapstorage-init
+          image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              chown -R 1000:1000 /maps
+          volumeMounts:
+            - name: mapstorage
+              mountPath: /maps
+      containers:
+        - name: {{ .Chart.Name }}-mapstorage
+          securityContext:
+            {{- toYaml .Values.mapstorage.securityContext | nindent 12 }}
+          image: "{{ .Values.mapstorage.image.repository }}:{{ .Values.mapstorage.image.tag | default .Values.appVersion }}"
+          imagePullPolicy: {{ .Values.mapstorage.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "workadventure.fullname" . }}-env-mapstorage
+            - secretRef:
+                name: {{ include "workadventure.fullname" . }}-secret-env-mapstorage
+          ports:
+            - name: http
+              containerPort: {{ .Values.mapstorage.service.port }}
+              protocol: TCP
+            - name: grpc
+              containerPort: 50053
+              protocol: TCP
+          # livenessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          # readinessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          volumeMounts:
+            - name: mapstorage
+              mountPath: /maps
+          resources:
+            {{- toYaml .Values.mapstorage.resources | nindent 12 }}
+          # lifecycle:
+          #   postStart:
+          #     exec:
+          #       command:
+          #         - sh
+          #         - -c
+          #         - |
+          #           chown -R node:node /maps
+
+      {{- with .Values.mapstorage.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mapstorage.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mapstorage.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/mapstorage-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/mapstorage-env.yaml
@@ -1,0 +1,18 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-env-mapstorage
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+data:
+  API_URL: {{ include "workadventure.fullname" . }}-back:50051
+  PATH_PREFIX: "/map-storage"
+
+  {{- range $key, $val := .Values.commonEnv }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.mapstorage.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/mapstorage-pvc.yaml
+++ b/contrib/helm/workadventure-k8s/templates/mapstorage-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.mapstorage.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-mapstorage
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+
+  annotations:
+    helm.sh/resource-policy: "keep"
+
+spec:
+  accessModes:
+    - {{ .Values.mapstorage.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.mapstorage.persistence.storageSize }}
+  {{- with .Values.mapstorage.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/contrib/helm/workadventure-k8s/templates/mapstorage-secret-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/mapstorage-secret-env.yaml
@@ -1,0 +1,16 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-secret-env-mapstorage
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $val := .Values.commonSecretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.mapstorage.secretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/mapstorage-service.yaml
+++ b/contrib/helm/workadventure-k8s/templates/mapstorage-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workadventure.fullname" . }}-mapstorage
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: mapstorage
+spec:
+  type: {{ .Values.mapstorage.service.type }}
+  ports:
+    - port: {{ .Values.mapstorage.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 50053
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "workadventure.selectorLabels" . | nindent 4 }}
+    role: mapstorage

--- a/contrib/helm/workadventure-k8s/templates/play-deployment.yaml
+++ b/contrib/helm/workadventure-k8s/templates/play-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workadventure.fullname" . }}-play
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: play
+spec:
+  {{- if not .Values.play.autoscaling.enabled }}
+  replicas: {{ .Values.play.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "workadventure.selectorLabels" . | nindent 6 }}
+      role: play
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/play-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/play-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.play.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "workadventure.selectorLabels" . | nindent 8 }}
+        role: play
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.play.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-play
+          securityContext:
+            {{- toYaml .Values.play.securityContext | nindent 12 }}
+          image: "{{ .Values.play.image.repository }}:{{ .Values.play.image.tag | default .Values.appVersion }}"
+          imagePullPolicy: {{ .Values.play.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "workadventure.fullname" . }}-env-play
+            - secretRef:
+                name: {{ include "workadventure.fullname" . }}-secret-env-play
+          ports:
+            - name: http
+              containerPort: {{ .Values.play.service.port }}
+              protocol: TCP
+            - name: grpc
+              containerPort: 50051
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.play.resources | nindent 12 }}
+      {{- with .Values.play.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.play.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.play.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/play-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/play-env.yaml
@@ -1,0 +1,29 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-env-play
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+data:
+  API_URL: {{ range $replica, $f := until (int .Values.back.replicaCount) }}{{ include "workadventure.fullname" $ }}-back-{{ $replica }}:50051{{ if ne $replica (sub (int $.Values.back.replicaCount) 1)  }}{{ "," }}{{ end }}{{ end }}
+  CHAT_URL: /chat/
+  ICON_URL: /icon
+  UPLOADER_URL: /uploader
+  PUSHER_URL: /
+  FRONT_URL: /
+  PUBLIC_MAP_STORAGE_URL: https://{{ .Values.domainName }}/map-storage
+  EJABBERD_API_URI: {{ include "workadventure.fullname" . }}-back:{{ .Values.ejabberd.service.port }}
+  ENABLE_OPENAPI_ENDPOINT: "true"
+  ROOM_API_PORT: "50051"
+  MAP_STORAGE_PATH_PREFIX: /map-storage
+  EJABBERD_DOMAIN: {{ .Values.ejabberdDomain }}
+
+
+  {{- range $key, $val := .Values.commonEnv }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.play.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/play-secret-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/play-secret-env.yaml
@@ -1,0 +1,19 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-secret-env-play
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+type: Opaque
+data:
+  SECRET_KEY: "{{ .Values.secretKey | b64enc }}"
+  EJABBERD_JWT_SECRET: "{{ .Values.ejabberdJwtSecret | b64enc }}"
+
+  {{- range $key, $val := .Values.commonSecretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.play.secretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/play-service.yaml
+++ b/contrib/helm/workadventure-k8s/templates/play-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workadventure.fullname" . }}-play
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: play
+spec:
+  type: {{ .Values.play.service.type }}
+  ports:
+    - port: {{ .Values.play.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 50051
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "workadventure.selectorLabels" . | nindent 4 }}
+    role: play

--- a/contrib/helm/workadventure-k8s/templates/serviceaccount.yaml
+++ b/contrib/helm/workadventure-k8s/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "workadventure.serviceAccountName" . }}
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/contrib/helm/workadventure-k8s/templates/uploader-deployment.yaml
+++ b/contrib/helm/workadventure-k8s/templates/uploader-deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workadventure.fullname" . }}-uploader
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: uploader
+spec:
+  {{- if not .Values.uploader.autoscaling.enabled }}
+  replicas: {{ .Values.uploader.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "workadventure.selectorLabels" . | nindent 6 }}
+      role: uploader
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/uploader-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/uploader-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.uploader.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "workadventure.selectorLabels" . | nindent 8 }}
+        role: uploader
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.uploader.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-uploader
+          securityContext:
+            {{- toYaml .Values.uploader.securityContext | nindent 12 }}
+          image: "{{ .Values.uploader.image.repository }}:{{ .Values.uploader.image.tag | default .Values.appVersion }}"
+          imagePullPolicy: {{ .Values.uploader.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "workadventure.fullname" . }}-env-uploader
+            - secretRef:
+                name: {{ include "workadventure.fullname" . }}-secret-env-uploader
+          ports:
+            - name: http
+              containerPort: {{ .Values.uploader.service.port }}
+              protocol: TCP
+          # livenessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          # readinessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          resources:
+            {{- toYaml .Values.uploader.resources | nindent 12 }}
+      {{- with .Values.uploader.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uploader.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uploader.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/uploader-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/uploader-env.yaml
@@ -1,0 +1,17 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-env-uploader
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+data:
+  UPLOADER_URL: https://{{ .Values.domainName }}/uploader
+
+  {{- range $key, $val := .Values.commonEnv }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.uploader.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/uploader-secret-env.yaml
+++ b/contrib/helm/workadventure-k8s/templates/uploader-secret-env.yaml
@@ -1,0 +1,16 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "workadventure.fullname" . }}-secret-env-uploader
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $val := .Values.commonSecretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+
+  {{- range $key, $val := .Values.uploader.secretEnv }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}

--- a/contrib/helm/workadventure-k8s/templates/uploader-service.yaml
+++ b/contrib/helm/workadventure-k8s/templates/uploader-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workadventure.fullname" . }}-uploader
+  labels:
+    {{- include "workadventure.labels" . | nindent 4 }}
+    role: uploader
+spec:
+  type: {{ .Values.uploader.service.type }}
+  ports:
+    - port: {{ .Values.uploader.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "workadventure.selectorLabels" . | nindent 4 }}
+    role: uploader

--- a/contrib/helm/workadventure-k8s/values.yaml
+++ b/contrib/helm/workadventure-k8s/values.yaml
@@ -1,0 +1,488 @@
+# Default values for workadventure.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+appVersion: "v1.17.7"
+domainName: wa.example.com
+ejabberdDomain: ejabberd.example.com
+
+secretKey: mySecretKey
+ejabberdJwtSecret: myEjabberdJwtSecret
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+commonEnv:
+  ENABLE_MAP_EDITOR: "true"
+  JITSI_URL: https://meet.jit.si
+  MAX_PER_GROUP: 4
+  EJABBERD_USER: admin
+  ENABLE_CHAT: "true"
+  ENABLE_CHAT_UPLOAD: "true"
+  UPLOAD_MAX_FILESIZE: 10485760
+
+commonSecretEnv:
+  EJABBERD_PASSWORD: mySecretPassword
+
+# #########################################################
+# play service
+# #########################################################
+play:
+  replicaCount: 1
+
+  image:
+    repository: thecodingmachine/workadventure-play
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
+  env:
+    JITSI_PRIVATE_MODE: "false"
+    START_ROOM_URL: /_/global/raw.githubusercontent.com/workadventure/map-starter-kit/master/map.tmj
+    ENABLE_CHAT_ONLINE_LIST: "true"
+    ENABLE_CHAT_DISCONNECTED_LIST: "true"
+    MAX_HISTORY_CHAT: 0
+    ENABLE_REPORT_ISSUES_MENU: "false"
+    GRPC_VERBOSITY: DEBUG
+    GRPC_TRACE: all
+    MAX_USERNAME_LENGTH: 10
+    DISABLE_ANONYMOUS: "false"
+    DISABLE_NOTIFICATIONS: "false"
+
+  secretEnv:
+    ROOM_API_SECRET_KEY: myRoomApiSecretKey
+
+# #########################################################
+# chat service
+# #########################################################
+chat:
+  replicaCount: 1
+
+  image:
+    repository: thecodingmachine/workadventure-chat
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
+  env: {}
+
+  secretEnv: {}
+
+# #########################################################
+# back service
+# #########################################################
+back:
+  replicaCount: 1
+
+  image:
+    repository: thecodingmachine/workadventure-back
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
+  env:
+    STORE_VARIABLES_FOR_LOCAL_MAPS: "true"
+
+  secretEnv: {}
+
+# #########################################################
+# uploader service
+# #########################################################
+uploader:
+  replicaCount: 1
+
+  image:
+    repository: thecodingmachine/workadventure-uploader
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
+  env: {}
+    # AWS_DEFAULT_REGION:
+    # AWS_BUCKET:
+    # AWS_URL:
+    # AWS_ENDPOINT:
+    # # or
+    # REDIS_HOST:
+    # REDIS_PORT:
+
+  secretEnv: {}
+    # AWS_ACCESS_KEY_ID:
+    # AWS_SECRET_ACCESS_KEY:
+
+# #########################################################
+# icon service
+# #########################################################
+icon:
+  replicaCount: 1
+
+  image:
+    repository: matthiasluedtke/iconserver
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is appVersion.
+    tag: "v3.16.0"
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+
+# #########################################################
+# ejabberd service
+# #########################################################
+ejabberd:
+  replicaCount: 1
+
+  image:
+    repository: thecodingmachine/workadventure-ejabberd
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 5443
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
+  env: {}
+
+  secretEnv: {}
+
+# #########################################################
+# mapstorage service
+# #########################################################
+mapstorage:
+  replicaCount: 1
+
+  image:
+    repository: thecodingmachine/workadventure-map-storage
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: "3000"
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  persistence:
+    enabled: false
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    storageSize: 1Gi
+
+  # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
+  env:
+    AUTHENTICATION_STRATEGY: Basic
+    AUTHENTICATION_USER: admin
+
+  secretEnv:
+    AUTHENTICATION_PASSWORD: myMapStoragePassword
+
+ingress:
+  enabled: false
+  className: ""
+  secretName: ""
+  pathType: ImplementationSpecific
+  annotationsPath:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  annotationsMapstoragePath:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+
+  rewritePathSuffix: "(/|$)(.*)"
+
+redis:
+  architecture: standalone
+
+  auth:
+    enabled: false


### PR DESCRIPTION
Helm chart contribution as discussed here: https://github.com/klauserber/workadventure-k8s/issues/1

The last PR for backend server scaling is already included.

The helm release workflow uses the chart-releaser-action which needs a gh-pages setup in the project as described here: https://github.com/helm/chart-releaser-action

Would be nice to see the helm chart on artifacthub.io like this: https://artifacthub.io/packages/helm/workadventure/workadventure
To setup a synchronization is pretty easy.