### PR TITLE
Configuring the base URL of E2E tests in config file

### DIFF
--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -39,7 +39,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 20_000,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: process.env.PLAY_URL ?? 'http://play.workadventure.localhost/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',

--- a/tests/tests/api_players.spec.ts
+++ b/tests/tests/api_players.spec.ts
@@ -11,7 +11,7 @@ import {RENDERER_MODE} from "./utils/environment";
 test.describe('API WA.players', () => {
   test('enter leave events are received', async ({ page, browser }) => {
     await page.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/RemotePlayers/remote_players.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/RemotePlayers/remote_players.json?phaserMode=${RENDERER_MODE}`
     );
     await login(page, 'Alice');
 
@@ -19,7 +19,7 @@ test.describe('API WA.players', () => {
     const page2 = await newBrowser.newPage();
 
     await page2.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/RemotePlayers/remote_players.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/RemotePlayers/remote_players.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page2, 'Bob');
@@ -54,7 +54,7 @@ test.describe('API WA.players', () => {
 
   test('exception if we forget to call WA.players.configureTracking', async ({ page }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/RemotePlayers/remote_players_no_init.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/RemotePlayers/remote_players_no_init.json?phaserMode=${RENDERER_MODE}`
     );
     await login(page);
 
@@ -64,7 +64,7 @@ test.describe('API WA.players', () => {
 
   test('Test that player B arriving after player A set his variables can read the variable.', async ({ page, browser }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page, "Alice");
@@ -83,7 +83,7 @@ test.describe('API WA.players', () => {
     const page2 = await newBrowser.newPage();
 
     await page2.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page2, 'Bob');
@@ -184,7 +184,7 @@ test.describe('API WA.players', () => {
     const page2 = await newBrowser.newPage();
 
     await page2.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page2, 'Bob');
@@ -277,7 +277,7 @@ test.describe('API WA.players', () => {
 
   test('Test variable persistence for anonymous users.', async ({ page, browser }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page, "Alice");
@@ -288,7 +288,7 @@ test.describe('API WA.players', () => {
   test('Test variable persistence for logged users. @oidc', async ({ page, browser }) => {
     test.setTimeout(120_000); // Fix Webkit that can take more than 60s
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page, "Alice");
@@ -302,7 +302,7 @@ test.describe('API WA.players', () => {
 
   test('Test variables are sent across frames.', async ({ page }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty_2_frames.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty_2_frames.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page, "Alice");
@@ -338,7 +338,7 @@ test.describe('API WA.players', () => {
   // All players with same UUID should share the same state (public or private as long as it is persisted)
   test('Test that 2 players sharing the same UUID are notified of persisted private variable changes.', async ({ page, context }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page, "Alice");
@@ -352,7 +352,7 @@ test.describe('API WA.players', () => {
     const page2 = await context.newPage();
 
     await page2.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     /*console.log("PAGE 2 MY ID", await evaluateScript(page2, async () => {
@@ -415,7 +415,7 @@ test.describe('API WA.players', () => {
 
   test('Test that a variable changed can be listened to locally.', async ({ page, browser }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page, "Alice");

--- a/tests/tests/areas.spec.ts
+++ b/tests/tests/areas.spec.ts
@@ -13,7 +13,7 @@ test.describe('Areas', () => {
         // We check the silent zone applies to the Woka.
 
         await page.goto(
-            `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Areas/AreaFromTiledMap/map.json?phaserMode=${RENDERER_MODE}`
+            `/_/global/maps.workadventure.localhost/tests/Areas/AreaFromTiledMap/map.json?phaserMode=${RENDERER_MODE}`
         );
         await login(page, 'Alice');
 

--- a/tests/tests/banner_script.spec.ts
+++ b/tests/tests/banner_script.spec.ts
@@ -8,7 +8,7 @@ test.describe('Modal', () => {
     test('test', async ({ page }) => {
         // Go to
         await page.goto(
-            `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+            `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
         );
 
         // Connection with Alice

--- a/tests/tests/buttonactionbar_script.spec.ts
+++ b/tests/tests/buttonactionbar_script.spec.ts
@@ -7,7 +7,7 @@ test.describe('Button in action bar', () => {
     test('test', async ({ page }) => {
         // Go to WorkAdventure platform
         await page.goto(
-            `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+            `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
         );
 
         // Login Alice
@@ -36,7 +36,7 @@ test.describe('Action button in action bar', () => {
     test('test', async ({ page }) => {
         // Go to WorkAdventure platform
         await page.goto(
-            `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+            `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
         );
 
         // Login Alice

--- a/tests/tests/chat.spec.ts
+++ b/tests/tests/chat.spec.ts
@@ -22,7 +22,7 @@ test.describe('Chat', () => {
 
 
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/livezone.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/livezone.json?phaserMode=${RENDERER_MODE}`
     );
     const nickname = getUniqueNickname('A');
     await login(page, nickname, 2);
@@ -44,7 +44,7 @@ test.describe('Chat', () => {
       const newBrowser = await browser.browserType().launch();
       const page2 = await newBrowser.newPage();
       await page2.goto(
-          `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/livezone.json?phaserMode=${RENDERER_MODE}`
+          `/_/global/maps.workadventure.localhost/tests/E2E/livezone.json?phaserMode=${RENDERER_MODE}`
       );
       const nickname2 = getUniqueNickname('B');
       await login(page2, nickname2, 3);
@@ -205,7 +205,7 @@ test.describe('Use application into TimeLine', () => {
   test('main', async ({ page, browser, browserName }) => {
 
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/livezone.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/livezone.json?phaserMode=${RENDERER_MODE}`
     );
     const nickname = getUniqueNickname('A');
     await login(page, nickname, 2);

--- a/tests/tests/error_pages.spec.ts
+++ b/tests/tests/error_pages.spec.ts
@@ -4,7 +4,7 @@ import {RENDERER_MODE} from "./utils/environment";
 test.describe('Error pages', () => {
   test('successfully displayed for unsupported URLs', async ({ page }) => {
     await page.goto(
-      `http://play.workadventure.localhost/@/not/supported?phaserMode=${RENDERER_MODE}`
+      `/@/not/supported?phaserMode=${RENDERER_MODE}`
     );
 
     await expect(page.getByText('Unsupported URL format')).toBeVisible();
@@ -12,7 +12,7 @@ test.describe('Error pages', () => {
 
   test('successfully displayed for not found pages', async ({ page }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/does/not/exist?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/does/not/exist?phaserMode=${RENDERER_MODE}`
     );
 
     await page.fill('input[name="loginSceneName"]', 'Alice');

--- a/tests/tests/iframe_script.spec.ts
+++ b/tests/tests/iframe_script.spec.ts
@@ -9,7 +9,7 @@ test.describe('Iframe API', () => {
     page,
   }) => {
     await page.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Metadata/cowebsiteAllowApi.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/Metadata/cowebsiteAllowApi.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page);
@@ -22,7 +22,7 @@ test.describe('Iframe API', () => {
     page
   }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page);
@@ -83,7 +83,7 @@ test.describe('Iframe API', () => {
                                                           page
                                                         }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}#foo=bar`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}#foo=bar`
     );
 
     await login(page);

--- a/tests/tests/map_editor.spec.ts
+++ b/tests/tests/map_editor.spec.ts
@@ -10,10 +10,11 @@ import Map from "./utils/map";
 import ConfigureMyRoom from "./utils/map-editor/configureMyRoom";
 import {resetWamMaps} from "./utils/map-editor/uploader";
 import {evaluateScript} from "./utils/scripting";
+import {map_storage_url} from "./utils/urls";
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
-  baseURL: (process.env.MAP_STORAGE_PROTOCOL ?? "http") + "://john.doe:password@" + (process.env.MAP_STORAGE_ENDPOINT ?? 'map-storage.workadventure.localhost'),
+  baseURL: map_storage_url,
 })
 test.describe('Map editor', () => {
   test('Successfully set the megaphone feature', async ({ page, browser, request, browserName }) => {

--- a/tests/tests/map_storage_upload.spec.ts
+++ b/tests/tests/map_storage_upload.spec.ts
@@ -4,9 +4,10 @@ import { login } from './utils/roles';
 import {createZipFromDirectory} from "./utils/zip";
 import { gotoWait200 } from "./utils/containers";
 import {RENDERER_MODE} from "./utils/environment";
+import {map_storage_url} from "./utils/urls";
 
 test.use({
-    baseURL: (process.env.MAP_STORAGE_PROTOCOL ?? "http") + "://john.doe:password@" + (process.env.MAP_STORAGE_ENDPOINT ?? 'map-storage.workadventure.localhost'),
+    baseURL: map_storage_url,
 })
 
 test.describe('Map-storage Upload API', () => {
@@ -47,12 +48,12 @@ test.describe('Map-storage Upload API', () => {
         });
         await expect(uploadFile2.ok()).toBeTruthy();
 
-        await gotoWait200(page, `http://play.workadventure.localhost/~/map1.wam?phaserMode=${RENDERER_MODE}`);
+        await gotoWait200(page, `/~/map1.wam?phaserMode=${RENDERER_MODE}`);
         await login(page, 'Alice');
 
         const newBrowser = await browser.browserType().launch();
         const page2 = await newBrowser.newPage();
-        await gotoWait200(page2, `http://play.workadventure.localhost/~/map2.wam?phaserMode=${RENDERER_MODE}`);
+        await gotoWait200(page2, `/~/map2.wam?phaserMode=${RENDERER_MODE}`);
         await login(page2, 'Bob');
 
         // Let's trigger a reload of map 1 only

--- a/tests/tests/meeting.spec.ts
+++ b/tests/tests/meeting.spec.ts
@@ -6,10 +6,6 @@ import Menu from "./utils/menu";
 import MapEditor from "./utils/mapeditor";
 import AreaEditor from "./utils/map-editor/areaEditor";
 
-test.use({
-  baseURL: (process.env.MAP_STORAGE_PROTOCOL ?? "http") + "://john.doe:password@" + (process.env.MAP_STORAGE_ENDPOINT ?? 'map-storage.workadventure.localhost'),
-})
-
 test.describe('Meeting actions test', () => {
   test('Meeting action to mute microphone & video', async ({page, browser}) => {
     // Because webkit in playwright does not support Camera/Microphone Permission by settings
@@ -20,7 +16,7 @@ test.describe('Meeting actions test', () => {
     }
 
     // Go to the empty map
-    await page.goto(`http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json`);
+    await page.goto(`/_/global/maps.workadventure.localhost/tests/E2E/empty.json`);
     // Login user "Alice"
     await login(page, 'Alice');
 
@@ -30,7 +26,7 @@ test.describe('Meeting actions test', () => {
     const newBrowser = await browser.browserType().launch();
     const userBob = await newBrowser.newPage();
     // Go to the empty map
-    await userBob.goto(`http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json`);
+    await userBob.goto(`/_/global/maps.workadventure.localhost/tests/E2E/empty.json`);
     // Login user "Bob"
     await login(userBob, 'Bob');
     // Move user

--- a/tests/tests/metadata.spec.ts
+++ b/tests/tests/metadata.spec.ts
@@ -1,17 +1,15 @@
 import { expect, test } from '@playwright/test';
-import axios from "axios";
 
 test.describe('Meta tags', () => {
   test('check they are populated when the user-agent is a bot. @selfsigned', async ({
-    page,
+      request,
   }) => {
-    const data: string = (await axios({
-      url: 'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Properties/mapProperties.json',
-      method: 'get',
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; adidxbot/2.0; +http://www.bing.com/bingbot.htm)'
-      }
-    })).data;
+    const result = await request.get('/_/global/maps.workadventure.localhost/tests/Properties/mapProperties.json', {
+        headers: {
+            'User-Agent': 'Mozilla/5.0 (compatible; adidxbot/2.0; +http://www.bing.com/bingbot.htm)',
+        }
+    });
+    const data = await result.text();
 
     // Validate the name can be found
     await expect(data).toContain('MAP NAME');
@@ -19,13 +17,12 @@ test.describe('Meta tags', () => {
     await expect(data).toContain('Cette carte est tr');
 
     // But if we scan with a normal browser, we don't get the metadata:
-    const data2: string = (await axios({
-      url: 'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Properties/mapProperties.json',
-      method: 'get',
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:106.0) Gecko/20100101 Firefox/106.0'
-      }
-    })).data;
+    const result2 = await request.get('/_/global/maps.workadventure.localhost/tests/Properties/mapProperties.json', {
+        headers: {
+            'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:106.0) Gecko/20100101 Firefox/106.0',
+        }
+    });
+    const data2 = await result2.text();
 
     // Validate the name can be found
     await expect(data2).not.toContain('MAP NAME');
@@ -37,7 +34,7 @@ test.describe('Meta tags', () => {
                                                                           request,
                                                                         }) => {
 
-    const result = await request.get(`http://play.workadventure.localhost/_/global/`, {
+    const result = await request.get(`/_/global/`, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (compatible; adidxbot/2.0; +http://www.bing.com/bingbot.htm)',
       }

--- a/tests/tests/modal_script.spec.ts
+++ b/tests/tests/modal_script.spec.ts
@@ -8,7 +8,7 @@ test.describe('Modal', () => {
     test('test', async ({ page }) => {
         // Go to 
         await page.goto(
-            `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+            `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
         );
         await login(page, "Alice");
         await evaluateScript(page, async () => {

--- a/tests/tests/modules.spec.ts
+++ b/tests/tests/modules.spec.ts
@@ -7,7 +7,7 @@ test.describe('Module', () => {
   test('loading should work out of the box', async ({ page }) => {
     startRecordLogs(page);
     await page.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Modules/with_modules.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/Modules/with_modules.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page, 'Alice', 2);

--- a/tests/tests/oidc.spec.ts
+++ b/tests/tests/oidc.spec.ts
@@ -9,7 +9,7 @@ test.describe('OpenID connect @oidc', () => {
     page,
   }) => {
     await page.goto(
-        `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+        `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page);

--- a/tests/tests/reconnect.spec.ts
+++ b/tests/tests/reconnect.spec.ts
@@ -7,7 +7,7 @@ test.setTimeout(180_000);
 test.describe('Connection', () => {
   test('can succeed even if WorkAdventure starts while pusher is down @docker', async ({ page }) => {
     await page.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/mousewheel.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page);
@@ -19,13 +19,13 @@ test.describe('Connection', () => {
     await expect(page.locator('.errorScreen p.code')).toContainText('CONNECTION_');
     //await expect(page.locator('.error-div')).toContainText('Unable to connect to WorkAdventure');
 
-    //await page.goto('http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json');
+    //await page.goto('/_/global/maps.workadventure.localhost/tests/mousewheel.json');
     //await expect(page.locator('.error-div')).toContainText('Unable to connect to WorkAdventure');
     //await expect(page.locator('.errorScreen p.code')).toContainText('HTTP_ERROR');
 
     await rebootPlay();
 
-    //await page.goto('http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json');
+    //await page.goto('/_/global/maps.workadventure.localhost/tests/mousewheel.json');
     await expect(page.locator("button#menuIcon")).toBeVisible({
       timeout: 180_000
     });

--- a/tests/tests/scripting_chat.spec.ts
+++ b/tests/tests/scripting_chat.spec.ts
@@ -9,7 +9,7 @@ import {RENDERER_MODE} from "./utils/environment";
 test.describe('Scripting chat functions', () => {
     test('can open / close chat + start / stop typing', async ({ page}) => {
         await page.goto(
-            `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+            `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
         );
 
         await login(page);
@@ -79,7 +79,7 @@ test.describe('Scripting chat functions', () => {
         }
 
         await page.goto(
-            `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+            `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
         );
 
         await login(page);
@@ -87,7 +87,7 @@ test.describe('Scripting chat functions', () => {
 
         const newBrowser = await browser.browserType().launch();
         const page2 = await newBrowser.newPage();
-        await page2.goto(`http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`);
+        await page2.goto(`/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`);
 
 
         await evaluateScript(page, async () => {

--- a/tests/tests/scripting_events.spec.ts
+++ b/tests/tests/scripting_events.spec.ts
@@ -7,7 +7,7 @@ test.describe('Scripting API Events', () => {
     test('test events', async ({ page, browser, request }) => {
         // Go to 
         await page.goto(
-            `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+            `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
         );
         await login(page, "Alice");
 
@@ -48,7 +48,7 @@ test.describe('Scripting API Events', () => {
         const page2 = await newBrowser.newPage();
 
         await page2.goto(
-            `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
+            `/_/global/maps.workadventure.localhost/tests/E2E/empty.json?phaserMode=${RENDERER_MODE}`
         );
 
         await login(page2, 'Bob');
@@ -143,7 +143,7 @@ test.describe('Scripting API Events', () => {
             });
         });
 
-        const result = await request.post("http://play.workadventure.localhost/global/event", {
+        const result = await request.post("/global/event", {
             headers: {
                 "Authorization": process.env.ADMIN_API_TOKEN,
             },

--- a/tests/tests/swagger_doc.spec.ts
+++ b/tests/tests/swagger_doc.spec.ts
@@ -3,7 +3,7 @@ import {expect, test} from '@playwright/test';
 test.describe('Swagger documentation', () => {
     test('Admin -> External Admin', async ({page}) => {
         await page.goto(
-            `http://play.workadventure.localhost/swagger-ui/?urls.primaryName=Admin%20->%20External%20Admin`
+            `/swagger-ui/?urls.primaryName=Admin%20->%20External%20Admin`
         );
 
         // Test if the component "operations-ExternalAdminAPI-get_api_mapinformation" is visible
@@ -36,7 +36,7 @@ test.describe('Swagger documentation', () => {
 
     test('Pusher -> Admin', async ({page}) => {
         await page.goto(
-            `http://play.workadventure.localhost/swagger-ui/?urls.primaryName=Pusher%20->%20Admin`
+            `/swagger-ui/?urls.primaryName=Pusher%20->%20Admin`
         );
 
         // Test if the component "model-AdminApiData" is visible

--- a/tests/tests/translate.spec.ts
+++ b/tests/tests/translate.spec.ts
@@ -7,7 +7,7 @@ test.describe('Translation', () => {
     page,
   }) => {
     await page.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/mousewheel.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page);

--- a/tests/tests/utils/containers.ts
+++ b/tests/tests/utils/containers.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import { Page } from '@playwright/test';
 import Dockerode from 'dockerode';
+import {play_url} from "./urls";
 
 /**
  * Execute Docker compose, passing the correct host directory
@@ -70,7 +71,8 @@ export async function upMapStorage(): Promise<void> {
 export async function gotoWait200(page: Page, url: string): Promise<void> {
     // eslint-disable-next-line no-constant-condition
     while (true) {
-        const response = await page.goto(url);
+        const targetUrl = new URL(url, play_url).toString();
+        const response = await page.goto(targetUrl);
         // Because we just rebooted play, we might get HTTP 502 errors from Traefik.
         // Let's wait for a correct answer.
         if (response.ok()) {

--- a/tests/tests/utils/debug.ts
+++ b/tests/tests/utils/debug.ts
@@ -1,11 +1,12 @@
 import fs from 'fs';
 import axios from "axios";
 import {APIRequestContext, APIResponse} from "@playwright/test";
+import {play_url} from "./urls";
 
 const ADMIN_API_TOKEN = process.env.ADMIN_API_TOKEN;
 
 export async function getPusherDump(): Promise<Record<string, unknown>> {
-    let url = 'http://play.workadventure.localhost/dump?token='+ADMIN_API_TOKEN;
+    let url = new URL('/dump?token='+ADMIN_API_TOKEN, play_url).toString();
     if (fs.existsSync('/project')) {
         // We are inside a container. Let's use a direct route
         url = 'http://play:3000/dump?token='+ADMIN_API_TOKEN;
@@ -31,7 +32,7 @@ export async function getBackDump(): Promise<Array<{roomUrl: string}>> {
 }
 
 export async function getPusherRooms(request: APIRequestContext): Promise<APIResponse> {
-    let url = 'http://play.workadventure.localhost/rooms';
+    let url = '/rooms';
     if (fs.existsSync('/project')) {
         // We are inside a container. Let's use a direct route
         url = 'http://play:3000/rooms';

--- a/tests/tests/utils/map-editor/uploader.ts
+++ b/tests/tests/utils/map-editor/uploader.ts
@@ -1,11 +1,13 @@
 import fs from "fs";
 import {APIRequestContext, expect} from "@playwright/test";
+import {map_storage_url} from "../urls";
 
 /**
  * Reset the map storage to the default WAM maps
  */
 export async function resetWamMaps(request: APIRequestContext) {
-    const uploadFile1 = await request.post("upload", {
+
+    const uploadFile1 = await request.post(new URL("upload", map_storage_url).toString(), {
         multipart: {
             file: fs.createReadStream("../map-storage/tests/assets.zip"),
         }

--- a/tests/tests/utils/urls.ts
+++ b/tests/tests/utils/urls.ts
@@ -1,0 +1,2 @@
+export const play_url = process.env.PLAY_URL ?? 'http://play.workadventure.localhost';
+export const map_storage_url = (process.env.MAP_STORAGE_PROTOCOL ?? "http") + "://john.doe:password@" + (process.env.MAP_STORAGE_ENDPOINT ?? 'map-storage.workadventure.localhost');

--- a/tests/tests/variables.spec.ts
+++ b/tests/tests/variables.spec.ts
@@ -13,6 +13,7 @@ import {getBackDump, getPusherDump, getPusherRooms} from './utils/debug';
 import {assertLogMessage, startRecordLogs} from './utils/log';
 import { login } from './utils/roles';
 import {RENDERER_MODE} from "./utils/environment";
+import {play_url} from "./utils/urls";
 
 test.setTimeout(360000);
 test.describe('Variables', () => {
@@ -23,7 +24,7 @@ test.describe('Variables', () => {
 
     await Promise.all([rebootBack(), rebootPlay()]);
 
-    await gotoWait200(page, `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?somerandomparam=1&phaserMode=${RENDERER_MODE}`);
+    await gotoWait200(page, `/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?somerandomparam=1&phaserMode=${RENDERER_MODE}`);
 
     await login(page);
 
@@ -36,7 +37,7 @@ test.describe('Variables', () => {
     await textField.press('Tab');
 
     await page.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
     );
     await expect(textField).toHaveValue('new value');
 
@@ -65,7 +66,7 @@ test.describe('Variables', () => {
     for (const room of backDump) {
       if (
         room.roomUrl ===
-        'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json'
+        new URL('/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json', play_url).toString()
       ) {
         throw new Error('Room still found in back');
       }
@@ -75,13 +76,13 @@ test.describe('Variables', () => {
     //console.log('pusherDump', pusherDump);
     await expect(
       pusherDump[
-        'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json'
+        new URL('/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json', play_url).toString()
       ]
     ).toBe(undefined);
 
     await gotoWait200(
         page,
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
     );
     // Redis will reconnect automatically and will store the variable on reconnect!
     // So we should see the new value.
@@ -94,7 +95,7 @@ test.describe('Variables', () => {
 
     await gotoWait200(
         page,
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
     );
     await expect(textField).toHaveValue('value set while Redis stopped', {
       timeout: 60000,
@@ -104,7 +105,7 @@ test.describe('Variables', () => {
     await textField.press('Tab');
 
     await page.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
     );
     // Redis will reconnect automatically and will store the variable on reconnect!
     // So we should see the new value.
@@ -113,7 +114,7 @@ test.describe('Variables', () => {
     // Now, let's try to kill / reboot the back
     await rebootPlay();
 
-    await gotoWait200(page, `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`);
+    await gotoWait200(page, `/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`);
 
     await expect(textField).toHaveValue('value set after back restart', {
       timeout: 60000,
@@ -123,7 +124,7 @@ test.describe('Variables', () => {
     await textField.press('Tab');
 
     await page.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json?phaserMode=${RENDERER_MODE}`
     );
     // Redis will reconnect automatically and will store the variable on reconnect!
     // So we should see the new value.
@@ -143,7 +144,7 @@ test.describe('Variables', () => {
     );
 
     await page.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page, 'Alice', 2);
@@ -164,7 +165,7 @@ test.describe('Variables', () => {
     startRecordLogs(page2);
 
     await page2.goto(
-      `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json?phaserMode=${RENDERER_MODE}`
+      `/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json?phaserMode=${RENDERER_MODE}`
     );
 
     await login(page2, 'Chapelier', 3);

--- a/tests/tests/xmpp.ts
+++ b/tests/tests/xmpp.ts
@@ -18,25 +18,25 @@
 // import {getBackDump, getPusherDump} from "./utils/debug";
 //
 // fixture `XMPP`
-//     .page `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json`;
+//     .page `/_/global/maps.workadventure.localhost/tests/mousewheel.json`;
 //
 // test("Test that XMPP server works", async (t: TestController) => {
 //
 //     const userListBtn = Selector('.user-list-btn');
 //     const userList = Selector('.roomsList');
 //
-//     await login(t, 'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json');
+//     await login(t, '/_/global/maps.workadventure.localhost/tests/mousewheel.json');
 //
 //     await t
 //         .click(userListBtn)
 //         .expect(userList.innerText).contains('Alice');
 //
 //     const aliceWindow = await t.getCurrentWindow();
-//     const bobWindow = await t.openWindow('http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json');
+//     const bobWindow = await t.openWindow('/_/global/maps.workadventure.localhost/tests/mousewheel.json');
 //
 //     await t.resizeWindow(960, 800);
 //
-//     await login(t, 'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json', 'Bob', 3);
+//     await login(t, '/_/global/maps.workadventure.localhost/tests/mousewheel.json', 'Bob', 3);
 //
 //     await t
 //         .click(userListBtn)
@@ -74,7 +74,7 @@
 //     const chatWindow = Selector('.chatWindow');
 //     const errorDiv = Selector('.error-div');
 //
-//     await login(t, 'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json');
+//     await login(t, '/_/global/maps.workadventure.localhost/tests/mousewheel.json');
 //
 //     await t
 //         .click(userListBtn)


### PR DESCRIPTION
This will allow us to change the base URL easily to run tests remotely in the future (for testing Helm charts deployments)