### PR TITLE
Adding extraEnvVars in Helm Charts

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -30,7 +30,6 @@ jobs:
                 echo "GITHUB_REF is not set. Exiting."
                 exit 1
             fi
-            # Remove the helm-chart branch check when it is merged
             if [ "$GITHUB_REF" != "refs/heads/master" ]; then
                 echo "Setting version to $GITHUB_REF"
                 sed -i "s/version: 0.0.9-dev1/version: $GITHUB_REF/g" Chart.yaml

--- a/contrib/helm/Chart.lock
+++ b/contrib/helm/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 17.11.7
-digest: sha256:f8fbedf1dc26337563f281f9ce328e32670c7c5fb0f06cb3f45bf1e20adaf4df
-generated: "2023-07-09T07:47:55.015555868Z"
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.16.1
+digest: sha256:703dcd72c9369b53c50235892b96d15ab0d8e8fe4d31e2230f45d9cdd7f59546
+generated: "2024-03-01T09:26:19.339504712+01:00"

--- a/contrib/helm/Chart.yaml
+++ b/contrib/helm/Chart.yaml
@@ -27,3 +27,6 @@ dependencies:
   - name: redis
     version: 17.11.7
     repository: https://charts.bitnami.com/bitnami
+  - name: common
+    version: 2.x.x
+    repository: oci://registry-1.docker.io/bitnamicharts

--- a/contrib/helm/templates/back-statefulset.yaml
+++ b/contrib/helm/templates/back-statefulset.yaml
@@ -66,6 +66,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "workadventure.fullname" . }}-secret-env-shared
                   key: SECRET_KEY
+            {{- if .Values.back.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.back.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.back.service.port }}

--- a/contrib/helm/templates/chat-deployment.yaml
+++ b/contrib/helm/templates/chat-deployment.yaml
@@ -54,6 +54,10 @@ spec:
             - secretRef:
                 name: {{ .Values.chat.externalSecretName }}
             {{- end }}
+          {{- if .Values.chat.extraEnvVars }}
+          env:
+            {{- include "common.tplvalues.render" (dict "value" .Values.chat.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.chat.service.port }}

--- a/contrib/helm/templates/ejabberd-deployment.yaml
+++ b/contrib/helm/templates/ejabberd-deployment.yaml
@@ -63,6 +63,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "workadventure.fullname" . }}-secret-env-shared
                   key: EJABBERD_JWT_SECRET
+            {{- if .Values.ejabberd.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.ejabberd.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.ejabberd.service.port }}

--- a/contrib/helm/templates/maps-deployment.yaml
+++ b/contrib/helm/templates/maps-deployment.yaml
@@ -55,6 +55,10 @@ spec:
             - secretRef:
                 name: {{ .Values.maps.externalSecretName }}
             {{- end }}
+          {{- if .Values.maps.extraEnvVars }}
+          env:
+            {{- include "common.tplvalues.render" (dict "value" .Values.maps.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.maps.service.port }}

--- a/contrib/helm/templates/mapstorage-deployment.yaml
+++ b/contrib/helm/templates/mapstorage-deployment.yaml
@@ -72,6 +72,10 @@ spec:
             - secretRef:
                 name: {{ .Values.mapstorage.externalSecretName }}
             {{- end }}
+          {{- if .Values.mapstorage.extraEnvVars }}
+          env:
+            {{- include "common.tplvalues.render" (dict "value" .Values.mapstorage.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.mapstorage.service.port }}

--- a/contrib/helm/templates/play-deployment.yaml
+++ b/contrib/helm/templates/play-deployment.yaml
@@ -66,6 +66,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "workadventure.fullname" . }}-secret-env-shared
                   key: EJABBERD_JWT_SECRET
+            {{- if .Values.play.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.play.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.play.service.port }}

--- a/contrib/helm/templates/uploader-deployment.yaml
+++ b/contrib/helm/templates/uploader-deployment.yaml
@@ -54,6 +54,10 @@ spec:
             - secretRef:
                 name: {{ .Values.uploader.externalSecretName }}
             {{- end }}
+          {{- if .Values.uploader.extraEnvVars }}
+          env:
+            {{- include "common.tplvalues.render" (dict "value" .Values.uploader.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.uploader.service.port }}

--- a/contrib/helm/values.yaml
+++ b/contrib/helm/values.yaml
@@ -130,6 +130,9 @@ play:
     DISABLE_ANONYMOUS: "false"
     DISABLE_NOTIFICATIONS: "false"
 
+  # Those environment variables should be added in "Kubernetes" format (e.g. [name: "...", valueFrom: {...}]).
+  extraEnvVars: {}
+
   secretEnv:
     ROOM_API_SECRET_KEY: myRoomApiSecretKey
 
@@ -218,6 +221,9 @@ chat:
   # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
   env: {}
 
+  # Those environment variables should be added in "Kubernetes" format (e.g. [name: "...", valueFrom: {...}]).
+  extraEnvVars: {}
+
   secretEnv: {}
 
   # The name of a configMap that should be added to the service.
@@ -290,6 +296,9 @@ back:
     STORE_VARIABLES_FOR_LOCAL_MAPS: "true"
     PLAYER_VARIABLES_MAX_TTL: "-1"
 
+  # Those environment variables should be added in "Kubernetes" format (e.g. [name: "...", valueFrom: {...}]).
+  extraEnvVars: {}
+
   secretEnv: {}
 
   # The name of a configMap that should be added to the service.
@@ -360,6 +369,9 @@ uploader:
     # # or
     # REDIS_HOST:
     # REDIS_PORT:
+
+  # Those environment variables should be added in "Kubernetes" format (e.g. [name: "...", valueFrom: {...}]).
+  extraEnvVars: {}
 
   secretEnv: {}
     # AWS_ACCESS_KEY_ID:
@@ -448,6 +460,9 @@ maps:
     # # or
     # REDIS_HOST:
   # REDIS_PORT:
+
+  # Those environment variables should be added in "Kubernetes" format (e.g. [name: "...", valueFrom: {...}]).
+  extraEnvVars: {}
 
   secretEnv: {}
     # AWS_ACCESS_KEY_ID:
@@ -588,6 +603,9 @@ ejabberd:
   # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
   env: {}
 
+  # Those environment variables should be added in "Kubernetes" format (e.g. [name: "...", valueFrom: {...}]).
+  extraEnvVars: {}
+
   secretEnv: {}
 
   # The name of a configMap that should be added to the service.
@@ -691,6 +709,8 @@ mapstorage:
     AUTHENTICATION_VALIDATOR_URL: ""
     ENABLE_DIGEST_AUTHENTICATION: "false"
 
+  # Those environment variables should be added in "Kubernetes" format (e.g. [name: "...", valueFrom: {...}]).
+  extraEnvVars: {}
 
   secretEnv:
     AUTHENTICATION_PASSWORD: ""


### PR DESCRIPTION
This new entry allows to add any kind of env vars to any container (even env vars from a secret or a configmap...)
Really useful to fetch secrets / env vars from outside the chart. Inspired by Bitnami's charts (and relies on Bitnami common)