### PR TITLE
Preventing caching of WAM files

### DIFF
--- a/map-storage/src/MapsManager.ts
+++ b/map-storage/src/MapsManager.ts
@@ -67,7 +67,13 @@ class MapsManager {
                 return queue;
             }
             const commandIndex = queue.findIndex((command) => command.id === commandId);
-            return queue.slice(commandIndex !== -1 ? commandIndex + 1 : 0);
+            if (commandIndex === -1) {
+                // Most of the time, the last command id of the map will not be part of the queue
+                // This is always true unless the last change was done less that 30 seconds ago.
+                // In this case, let's apply the whole queue.
+                return queue;
+            }
+            return queue.slice(commandIndex + 1);
         }
         return [];
     }
@@ -111,14 +117,13 @@ class MapsManager {
     }
 
     public addCommandToQueue(mapKey: string, message: EditMapCommandMessage): void {
-        if (!this.loadedMapsCommandsQueue.has(mapKey)) {
-            this.loadedMapsCommandsQueue.set(mapKey, []);
+        let queue = this.loadedMapsCommandsQueue.get(mapKey);
+        if (queue === undefined) {
+            queue = [];
+            this.loadedMapsCommandsQueue.set(mapKey, queue);
         }
-        const queue = this.loadedMapsCommandsQueue.get(mapKey);
-        if (queue !== undefined) {
-            queue.push(message);
-            this.setCommandDeletionTimeout(mapKey, message.id);
-        }
+        queue.push(message);
+        this.setCommandDeletionTimeout(mapKey, message.id);
         this.loadedMaps.get(mapKey)?.updateLastCommandIdProperty(message.id);
     }
 
@@ -150,6 +155,13 @@ class MapsManager {
             }
             if (queue[0].id === commandId) {
                 queue.splice(0, 1);
+            } else {
+                console.error(
+                    `Command with id ${commandId} that is scheduled from removal in the queue is not the first command. This should never happen (unless the queue was purged and recreated within 30 seconds... unlikely.`
+                );
+                Sentry.captureMessage(
+                    `Command with id ${commandId} that is scheduled from removal in the queue is not the first command. This should never happen (unless the queue was purged and recreated within 30 seconds... unlikely.`
+                );
             }
         }, this.COMMAND_TIME_IN_QUEUE_MS);
     }

--- a/map-storage/src/index.ts
+++ b/map-storage/src/index.ts
@@ -87,6 +87,12 @@ app.get("*.wam", (req, res, next) => {
 
         const gameMap = await mapsManager.loadWAMToMemory(key);
 
+        res.setHeader("Content-Type", "application/json");
+        // Let's disable any kind of cache (we allow for a 5 seconds cache just to avoid spamming the server and
+        // to allow a CDN to take over the load). 5 seconds is ok, because it is lower than the 30 seconds of
+        // the command queue.
+        res.setHeader("Cache-Control", "max-age=5");
+
         res.send(gameMap.getWam());
     })().catch((e) => next());
 });

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -211,13 +211,13 @@ export class MapEditorModeManager {
      * are applied locally and are not being send further.
      */
     public async updateMapToNewest(commands: EditMapCommandMessage[]): Promise<void> {
-        if (!commands) {
-            return;
-        }
-        for (const command of commands) {
-            for (const tool of Object.values(this.editorTools)) {
-                //eslint-disable-next-line no-await-in-loop
-                await tool.handleIncomingCommandMessage(command);
+        if (commands.length !== 0) {
+            logger(`Map is not up to date. Updating by applying ${commands.length} missing commands.`);
+            for (const command of commands) {
+                for (const tool of Object.values(this.editorTools)) {
+                    //eslint-disable-next-line no-await-in-loop
+                    await tool.handleIncomingCommandMessage(command);
+                }
             }
         }
     }


### PR DESCRIPTION
Browsers / CDN could cache WAM files. The WAM file served would not be freshed after editing.
We use a 5 seconds cache max that is acceptable because we keep a backlog of 30 seconds from previously applied commands that we can reapply on stale WAM files.