### PR TITLE
Fix trigger map properties

### DIFF
--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -1014,7 +1014,8 @@ export class GameMapFrontWrapper {
     }
 
     public triggerAllProperties(): void {
-        const newProps = this.getProperties(this.key ?? 0);
+        if (this.key === undefined) return;
+        const newProps = this.getProperties(this.key);
         const oldProps = this.lastProperties;
         this.lastProperties = newProps;
 


### PR DESCRIPTION
**Issue:**
the map has "jitsiRoom" properties. When user spawns on the map, the trigger of the properties is called but callback (create Jitsi Cowebiste) is not initialized. This property is call in second time but the callback will not apply because the value of properties was saved in "lastProperties" so we detect that there are not new value of this property and not apply callback associated.

**The fix proposed**
Remove the "key" value default to 0 and return if the "key" is undefined.

**More details:**
If the layer has the first tile not set (== 0), it will not saved in the list of properties triggerable. But the first tile could be set to one specific map. So in this case if the user spawns in the layer, the property like "silent" or "jitsi" will never apply 😭

![Screenshot 2024-03-27 at 13 31 41](https://github.com/workadventure/workadventure/assets/23724509/a8c2e5ee-bf7d-4aee-a4ef-87eb08b6895f)
https://github.com/workadventure/workadventure/pull/3819/files#diff-6470707e594d5b01693f32671d3d270355a6cead9c284ca60e49ffbf85e59dc8L1096-L1098
