### PR TITLE
Create new Jitsi map property

### DIFF
--- a/docs/map-building/tiled-editor/meeting-rooms.md
+++ b/docs/map-building/tiled-editor/meeting-rooms.md
@@ -19,6 +19,7 @@ In order to create Jitsi meet zones:
 * Object must be of class "`area`"
 * In object properties, you MUST add a "`jitsiRoom`" property (of type "`string`"). The value of the property is the name of the room in Jitsi. Note: the name of the room will be "slugified" and prepended with a hash of the room URL
 * You may also use "jitsiWidth" property (of type "number" between 0 and 100) to control the width of the iframe containing the meeting room.
+* You may also use "jitsiClosable" property (of type "boolean" true or false) to control the close button of the iframe containing the meeting room.
 
 You can have this object (i.e. your meeting area) to be selectable as the precise location for your meeting using the [Google Calendar integration for Work Adventure](/integrations/google-calendar). To do so, you must set the `meetingRoomLabel` property. You can provide any name that you would like your meeting room to have (as a string).
 

--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -340,6 +340,7 @@ export enum GameMapProperties {
     JITSI_URL = "jitsiUrl",
     JITSI_WIDTH = "jitsiWidth",
     JITSI_NO_PREFIX = "jitsiNoPrefix",
+    JITSI_CLOSABLE = "jitsiClosable",
     LISTENER_MEGAPHONE = "listenerMegaphone",
     NAME = "name",
     OPEN_TAB = "openTab",

--- a/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
@@ -134,9 +134,6 @@ export class GameMapPropertiesListener {
 
                 inJitsiStore.set(true);
 
-                // TODO create new property to allow to close the jitsi room
-                //const closable = allProps.get(GameMapProperties.OPEN_WEBSITE_CLOSABLE) as boolean | undefined;
-
                 const isJitsiConfig = z.string().optional().safeParse(allProps.get(GameMapProperties.JITSI_CONFIG));
                 const isJitsiInterfaceConfig = z
                     .string()
@@ -153,10 +150,16 @@ export class GameMapPropertiesListener {
                     GameMapProperties.JITSI_INTERFACE_CONFIG
                 );
 
+                const isJitsiClosable = z
+                    .boolean()
+                    .optional()
+                    .safeParse(allProps.get(GameMapProperties.JITSI_CLOSABLE));
+                const jitsiClosable = isJitsiClosable.success ? isJitsiClosable.data : true;
+
                 const coWebsite = new JitsiCoWebsite(
                     new URL(domain),
                     jitsiWidth,
-                    true,
+                    jitsiClosable,
                     roomName,
                     gameManager.getPlayerName() ?? "unknown",
                     jwt,


### PR DESCRIPTION
Create Jitsi closable map property to control the close button displayed in the CoWebsite and also ask to not close the Jitsi meeting.