### PR TITLE
Adding the ability to stop and track follows in Scripting API.

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -575,7 +575,7 @@ jobs:
           path: /tmp/ejabberd.tar.gz
 
   end-to-end-tests:
-    name: "End to end tests with ${{ matrix.browser }} (${{ matrix.shard }}/${{ matrix.nbShards }})"
+    name: "End to end tests with ${{ matrix.project }} (${{ matrix.shard }}/${{ matrix.nbShards }})"
     strategy:
       fail-fast: false
       matrix:
@@ -765,7 +765,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: playwright-report-${{ matrix.browser }}-${{ matrix.shard }}-${{ matrix.nbShards }}
+          name: playwright-report-${{ matrix.project }}-${{ matrix.shard }}-${{ matrix.nbShards }}
           path: tests/playwright-report/
           retention-days: 30
 

--- a/docs/developer/map-scripting/references/api-player.md
+++ b/docs/developer/map-scripting/references/api-player.md
@@ -442,8 +442,8 @@ browsers automatically).
 ## Detecting when the user enters/leaves a meeting
 
 ```ts
-WA.player.proximityMeeting.onJoin(): Subscription
-WA.player.proximityMeeting.onLeave(): Subscription
+WA.player.proximityMeeting.onJoin(): Subscription<RemotePlayerInterface[]>
+WA.player.proximityMeeting.onLeave(): Subscription<RemotePlayerInterface[]>
 ```
 
 The event is triggered when the user enters or leaves a proximity meeting.
@@ -463,8 +463,8 @@ WA.player.proximityMeeting.onLeave().subscribe(async () => {
 ## Detecting when a participant enters/leaves the current meeting
 
 ```ts
-WA.player.proximityMeeting.onParticipantJoin(): Subscription
-WA.player.proximityMeeting.onParticipantLeave(): Subscription
+WA.player.proximityMeeting.onParticipantJoin(): Subscription<RemotePlayerInterface>
+WA.player.proximityMeeting.onParticipantLeave(): Subscription<RemotePlayerInterface>
 ```
 
 The event is triggered when a user enters or leaves a proximity meeting.
@@ -473,11 +473,11 @@ Example:
 
 ```ts
 WA.player.proximityMeeting.onParticipantJoin().subscribe(async (player: RemotePlayerInterface) => {
-    WA.chat.sendChatMessage("A participant joined the proximity chat", "System");
+    WA.chat.sendChatMessage("A participant joined the proximity chat", { scope: 'local', author: 'System' });
 });
 
 WA.player.proximityMeeting.onParticipantLeave().subscribe(async (player: RemotePlayerInterface) => {
-    WA.chat.sendChatMessage("A participant left the proximity chat", "System");
+    WA.chat.sendChatMessage("A participant left the proximity chat", { scope: 'local', author: 'System' });
 });
 ```
 
@@ -515,3 +515,51 @@ WA.player.proximityMeeting.followMe(): Promise<void>
 The `followMe` function asks all the players in the same bubble to follow the player who called the function.
 Unlike the "follow" button in the UI, all the players in the bubble will be forced to follow the player who called the function.
 They can still stop following the player by clicking on the "stop following" button in the UI.
+
+## Stop leading users
+
+:::warning
+This feature is experimental. The signature of the function might change in the future.
+:::
+
+```ts
+WA.player.proximityMeeting.stopLeading(): Promise<void>
+```
+
+This function is the opposite of `followMe`. It ends the "follow" state for all the players in the bubble.
+
+Example:
+
+```ts
+// Start leading the users
+await WA.player.proximityMeeting.followMe();
+// Move everybody to (250, 250)
+await WA.player.moveTo(250, 250);
+// Stop leading the users
+await WA.player.proximityMeeting.stopLeading();
+```
+
+## Tracking who is following you
+
+:::warning
+This feature is experimental. The signature of the function might change in the future.
+:::
+
+```ts
+WA.player.proximityMeeting.onFollowed(): Subscription<RemotePlayerInterface>
+WA.player.proximityMeeting.onUnfollowed(): Subscription<RemotePlayerInterface>
+```
+
+You can be notified when a player starts following you or stops following you.
+
+Example:
+
+```ts
+WA.player.proximityMeeting.onFollowed().subscribe(async (player: RemotePlayerInterface) => {
+    WA.chat.sendChatMessage(`${player.name} is now following you`, { scope: 'local', author: 'System' });
+});
+
+WA.player.proximityMeeting.onUnfollowed().subscribe(async (player: RemotePlayerInterface) => {
+    WA.chat.sendChatMessage(`${player.name} stopped following you`, { scope: 'local', author: 'System' });
+});
+```

--- a/play/src/front/Api/Events/IframeEvent.ts
+++ b/play/src/front/Api/Events/IframeEvent.ts
@@ -387,6 +387,14 @@ export const isIframeResponseEvent = z.union([
         data: z.undefined(),
     }),
     z.object({
+        type: z.literal("onFollowed"),
+        data: isParticipantProximityMeetingEvent,
+    }),
+    z.object({
+        type: z.literal("onUnfollowed"),
+        data: isParticipantProximityMeetingEvent,
+    }),
+    z.object({
         type: z.literal("enterEvent"),
         data: isEnterLeaveEvent,
     }),
@@ -663,6 +671,10 @@ export const iframeQueryMapTypeGuards = {
         answer: z.undefined(),
     },
     followMe: {
+        query: z.undefined(),
+        answer: z.undefined(),
+    },
+    stopLeading: {
         query: z.undefined(),
         answer: z.undefined(),
     },

--- a/play/src/front/Api/Iframe/Player/ProximityMeeting.ts
+++ b/play/src/front/Api/Iframe/Player/ProximityMeeting.ts
@@ -9,6 +9,8 @@ import { apiCallback } from "../registeredCallbacks";
 let joinStream: Subject<RemotePlayer[]>;
 let participantJoinStream: Subject<RemotePlayer>;
 let participantLeaveStream: Subject<RemotePlayer>;
+let followedStream: Subject<RemotePlayer>;
+let unfollowedStream: Subject<RemotePlayer>;
 let leaveStream: Subject<void>;
 
 export class WorkadventureProximityMeetingCommands extends IframeApiContribution<WorkadventureProximityMeetingCommands> {
@@ -35,6 +37,18 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
             type: "leaveProximityMeetingEvent",
             callback: () => {
                 leaveStream?.next();
+            },
+        }),
+        apiCallback({
+            type: "onFollowed",
+            callback: (payloadData: ParticipantProximityMeetingEvent) => {
+                followedStream?.next(new RemotePlayer(payloadData.user));
+            },
+        }),
+        apiCallback({
+            type: "onUnfollowed",
+            callback: (payloadData: ParticipantProximityMeetingEvent) => {
+                unfollowedStream?.next(new RemotePlayer(payloadData.user));
             },
         }),
     ];
@@ -111,6 +125,33 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
             type: "followMe",
             data: undefined,
         });
+    }
+
+    async stopLeading(): Promise<void> {
+        await queryWorkadventure({
+            type: "stopLeading",
+            data: undefined,
+        });
+    }
+
+    /**
+     * Triggered when a player starts following us.
+     */
+    onFollowed(): Subject<RemotePlayer> {
+        if (followedStream === undefined) {
+            followedStream = new Subject<RemotePlayer>();
+        }
+        return followedStream;
+    }
+
+    /**
+     * Triggered when a player stops following us.
+     */
+    onUnfollowed(): Subject<RemotePlayer> {
+        if (unfollowedStream === undefined) {
+            unfollowedStream = new Subject<RemotePlayer>();
+        }
+        return unfollowedStream;
     }
 }
 

--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -751,6 +751,24 @@ class IframeListener {
         });
     }
 
+    sendFollowedEvent(follower: AddPlayerEvent) {
+        this.postMessage({
+            type: "onFollowed",
+            data: {
+                user: follower,
+            },
+        });
+    }
+
+    sendUnfollowedEvent(follower: AddPlayerEvent) {
+        this.postMessage({
+            type: "onUnfollowed",
+            data: {
+                user: follower,
+            },
+        });
+    }
+
     sendEnterEvent(name: string) {
         this.postMessage({
             type: "enterEvent",

--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -431,10 +431,19 @@
                     on:click={() => analyticsClient.follow()}
                     on:click={followClick}
                 >
-                    <Tooltip text={$LL.actionbar.follow()} />
+                    {#if $followStateStore === "active"}
+                        <Tooltip text={$LL.actionbar.unfollow()} />
+                    {:else}
+                        <Tooltip text={$LL.actionbar.follow()} />
+                    {/if}
 
                     <button class:border-top-light={$followStateStore === "active"}>
-                        <img draggable="false" src={followImg} style="padding: 2px" alt="Toggle follow" />
+                        <img
+                            draggable="false"
+                            src={followImg}
+                            style="padding: 2px"
+                            alt={$followStateStore === "active" ? $LL.actionbar.unfollow() : $LL.actionbar.follow()}
+                        />
                     </button>
                 </div>
 

--- a/play/src/front/Phaser/Game/FollowManager.ts
+++ b/play/src/front/Phaser/Game/FollowManager.ts
@@ -1,0 +1,101 @@
+import { Subscription } from "rxjs";
+import { get } from "svelte/store";
+import * as Sentry from "@sentry/svelte";
+import { availabilityStatusToJSON } from "@workadventure/messages";
+import { RoomConnection } from "../../Connection/RoomConnection";
+import { localUserStore } from "../../Connection/LocalUserStore";
+import { followRoleStore, followStateStore, followUsersStore } from "../../Stores/FollowStore";
+import { iframeListener } from "../../Api/IframeListener";
+import { RemotePlayersRepository } from "./RemotePlayersRepository";
+
+export class FollowManager {
+    private subscriptions: Subscription[] = [];
+
+    constructor(private connection: RoomConnection, private remotePlayersRepository: RemotePlayersRepository) {
+        this.subscriptions.push(
+            this.connection.followRequestMessageStream.subscribe((followRequestMessage) => {
+                if (!localUserStore.getIgnoreFollowRequests()) {
+                    if (followRequestMessage.forceFollow) {
+                        // If forceFollow, we emit directly back the followConfirmationMessage
+                        followUsersStore.addFollowRequest(followRequestMessage.leader);
+                        followStateStore.set("active");
+                        this.connection.emitFollowConfirmation(get(followUsersStore)[0]);
+                    } else {
+                        followUsersStore.addFollowRequest(followRequestMessage.leader);
+                    }
+                }
+            })
+        );
+
+        this.subscriptions.push(
+            this.connection.followConfirmationMessageStream.subscribe((followConfirmationMessage) => {
+                followUsersStore.addFollower(followConfirmationMessage.follower);
+                const remoteFollower = this.remotePlayersRepository
+                    .getPlayers()
+                    .get(followConfirmationMessage.follower);
+                if (remoteFollower) {
+                    iframeListener.sendFollowedEvent({
+                        playerId: followConfirmationMessage.follower,
+                        name: remoteFollower.name,
+                        position: remoteFollower.position,
+                        availabilityStatus: availabilityStatusToJSON(remoteFollower.availabilityStatus),
+                        outlineColor: remoteFollower.outlineColor,
+                        userUuid: remoteFollower.userUuid,
+                        variables: remoteFollower.variables,
+                    });
+                } else {
+                    console.warn(
+                        "Received followConfirmationMessage for unknown player",
+                        followConfirmationMessage.follower
+                    );
+                    Sentry.captureMessage("Received followConfirmationMessage for unknown player");
+                }
+            })
+        );
+
+        this.subscriptions.push(
+            this.connection.followAbortMessageStream.subscribe((followAbortMessage) => {
+                if (get(followRoleStore) === "follower") {
+                    followUsersStore.stopFollowing();
+                } else {
+                    followUsersStore.removeFollower(followAbortMessage.follower);
+                    const remoteFollower = this.remotePlayersRepository.getPlayers().get(followAbortMessage.follower);
+                    if (remoteFollower) {
+                        iframeListener.sendUnfollowedEvent({
+                            playerId: followAbortMessage.follower,
+                            name: remoteFollower.name,
+                            position: remoteFollower.position,
+                            availabilityStatus: availabilityStatusToJSON(remoteFollower.availabilityStatus),
+                            outlineColor: remoteFollower.outlineColor,
+                            userUuid: remoteFollower.userUuid,
+                            variables: remoteFollower.variables,
+                        });
+                    } else {
+                        console.warn("Received followAbortMessage for unknown player", followAbortMessage.follower);
+                        Sentry.captureMessage("Received followAbortMessage for unknown player");
+                    }
+                }
+            })
+        );
+
+        iframeListener.registerAnswerer("followMe", () => {
+            this.connection?.emitFollowRequest(true);
+        });
+
+        iframeListener.registerAnswerer("stopLeading", () => {
+            this.connection?.emitFollowAbort();
+            followUsersStore.stopFollowing();
+        });
+    }
+
+    public close() {
+        if (get(followStateStore) !== "off") {
+            this.connection?.emitFollowAbort();
+        }
+        this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+        iframeListener.unregisterAnswerer("followMe");
+        iframeListener.unregisterAnswerer("stopLeading");
+        followUsersStore.stopFollowing();
+        followStateStore.set("off");
+    }
+}

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -171,6 +171,7 @@ import { EntitiesCollectionsManager } from "./MapEditor/EntitiesCollectionsManag
 import { DEPTH_BUBBLE_CHAT_SPRITE } from "./DepthIndexes";
 import { ScriptingEventsManager } from "./ScriptingEventsManager";
 import { faviconManager } from "./../../WebRtc/FaviconManager";
+import { FollowManager } from "./FollowManager";
 import EVENT_TYPE = Phaser.Scenes.Events;
 import Texture = Phaser.Textures.Texture;
 import Sprite = Phaser.GameObjects.Sprite;
@@ -276,6 +277,7 @@ export class GameScene extends DirtyScene {
     private sharedVariablesManager!: SharedVariablesManager;
     private playerVariablesManager!: PlayerVariablesManager;
     private scriptingEventsManager!: ScriptingEventsManager;
+    private followManager!: FollowManager;
     private objectsByType = new Map<string, ITiledMapObject[]>();
     private embeddedWebsiteManager!: EmbeddedWebsiteManager;
     private areaManager!: DynamicAreaManager;
@@ -1126,6 +1128,9 @@ export class GameScene extends DirtyScene {
 
                 // Set up events manager
                 this.scriptingEventsManager = new ScriptingEventsManager(this.connection);
+
+                // Set up follow manager
+                this.followManager = new FollowManager(this.connection, this.remotePlayersRepository);
 
                 // Set up variables manager
                 this.sharedVariablesManager = new SharedVariablesManager(
@@ -2443,10 +2448,6 @@ ${escapedMessage}
             const soundUrl = new URL(message.url, this.mapUrlFile);
             await this.simplePeer.dispatchSound(soundUrl);
         });
-
-        iframeListener.registerAnswerer("followMe", () => {
-            this.connection?.emitFollowRequest(true);
-        });
     }
 
     private setPropertyLayer(
@@ -2618,6 +2619,7 @@ ${escapedMessage}
         this.playersEventDispatcher.cleanup();
         this.playersMovementEventDispatcher.cleanup();
         this.gameMapFrontWrapper?.close();
+        this.followManager?.close();
 
         //When we leave game, the camera is stop to be reopen after.
         // I think that we could keep camera status and the scene can manage camera setup

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -92,7 +92,7 @@ export class Player extends Character {
 
     public startFollowing() {
         followStateStore.set("active");
-        this.scene.connection?.emitFollowConfirmation();
+        this.scene.connection?.emitFollowConfirmation(get(followUsersStore)[0]);
     }
 
     public async setPathToFollow(

--- a/play/src/i18n/ca-ES/actionbar.ts
+++ b/play/src/i18n/ca-ES/actionbar.ts
@@ -2,7 +2,8 @@ import type { BaseTranslation } from "../i18n-types";
 
 const actionbar: BaseTranslation = {
     chat: "Open / Close chat",
-    follow: "Follow / Unfollow",
+    follow: "Follow",
+    unfollow: "Unfollow",
     lock: "Lock / Unlock discussion",
     screensharing: "Start / Stop sharing your screen",
     layout: "Toggle tile view",

--- a/play/src/i18n/de-DE/actionbar.ts
+++ b/play/src/i18n/de-DE/actionbar.ts
@@ -2,7 +2,8 @@ import type { BaseTranslation } from "../i18n-types";
 
 const actionbar: BaseTranslation = {
     chat: "Chat öffnen / schließen",
-    follow: "Folgen / Entfolgen",
+    follow: "Folgen",
+    unfollow: "Entfolgen",
     lock: "Konversation sperren / entsperren",
     screensharing: "Bildschirmfreigabe ein-/ausschalten",
     layout: "Kachelansicht ein-/ausschalten",

--- a/play/src/i18n/dsb-DE/actionbar.ts
+++ b/play/src/i18n/dsb-DE/actionbar.ts
@@ -2,7 +2,8 @@ import type { BaseTranslation } from "../i18n-types";
 
 const actionbar: BaseTranslation = {
     chat: "Chat wótcyniś / zacyniś",
-    follow: "Folgen / Entfolgen",
+    follow: "Folgen",
+    unfollow: "Entfolgen",
     lock: "Diskusiju blokěrowaś / naspjet aktiwěrowaś",
     screensharing: "Pśenosowanje wobrazowki aktiwěrowaś/deaktiwěrowaś",
     layout: "Kachlowy naglěd aktiwěrowaś/deaktiwěrowaś",

--- a/play/src/i18n/en-US/actionbar.ts
+++ b/play/src/i18n/en-US/actionbar.ts
@@ -2,7 +2,8 @@ import type { BaseTranslation } from "../i18n-types";
 
 const actionbar: BaseTranslation = {
     chat: "Open / Close chat",
-    follow: "Follow / Unfollow",
+    follow: "Follow",
+    unfollow: "Unfollow",
     lock: "Lock / Unlock discussion",
     screensharing: "Start / Stop sharing your screen",
     layout: "Toggle tile view",

--- a/play/src/i18n/es-ES/actionbar.ts
+++ b/play/src/i18n/es-ES/actionbar.ts
@@ -2,7 +2,8 @@ import type { BaseTranslation } from "../i18n-types";
 
 const actionbar: BaseTranslation = {
     chat: "Open / Close chat",
-    follow: "Follow / Unfollow",
+    follow: "Follow",
+    unfollow: "Unfollow",
     lock: "Lock / Unlock discussion",
     screensharing: "Start / Stop sharing your screen",
     layout: "Toggle tile view",

--- a/play/src/i18n/fr-FR/actionbar.ts
+++ b/play/src/i18n/fr-FR/actionbar.ts
@@ -2,7 +2,8 @@ import type { BaseTranslation } from "../i18n-types";
 
 const actionbar: BaseTranslation = {
     chat: "Ouvrir / Fermer le chat",
-    follow: "Suivre / ne plus suivre",
+    follow: "Suivre",
+    unfollow: "Ne plus suivre",
     lock: "Verrouiller / Déverrouiller la discussion",
     screensharing: "Démarrer / Arrêter le partage d'écran",
     layout: "Changer l'affichage",

--- a/play/src/i18n/hsb-DE/actionbar.ts
+++ b/play/src/i18n/hsb-DE/actionbar.ts
@@ -2,7 +2,8 @@ import type { BaseTranslation } from "../i18n-types";
 
 const actionbar: BaseTranslation = {
     chat: "chat wočinić/začinić",
-    follow: "sćěhować/nic wjac sćěhować",
+    follow: "sćěhować",
+    unfollow: "nic wjac sćěhować",
     lock: "diskusiju zawrěć/wotewrić",
     screensharing: "přenošowanje wobrazowki startować/skónčić",
     layout: "napohlad kachlow přešaltować",

--- a/play/src/i18n/pt-BR/actionbar.ts
+++ b/play/src/i18n/pt-BR/actionbar.ts
@@ -2,7 +2,8 @@ import type { BaseTranslation } from "../i18n-types";
 
 const actionbar: BaseTranslation = {
     chat: "Open / Close chat",
-    follow: "Follow / Unfollow",
+    follow: "Follow",
+    unfollow: "Unfollow",
     lock: "Lock / Unlock discussion",
     screensharing: "Start / Stop sharing your screen",
     layout: "Toggle tile view",

--- a/play/src/i18n/zh-CN/actionbar.ts
+++ b/play/src/i18n/zh-CN/actionbar.ts
@@ -2,7 +2,8 @@ import type { BaseTranslation } from "../i18n-types";
 
 const actionbar: BaseTranslation = {
     chat: "Open / Close chat",
-    follow: "Follow / Unfollow",
+    follow: "Follow",
+    unfollow: "Unfollow",
     lock: "Lock / Unlock discussion",
     screensharing: "Start / Stop sharing your screen",
     layout: "Toggle tile view",

--- a/tests/package.json
+++ b/tests/package.json
@@ -28,7 +28,8 @@
     "test-prod-like": "OVERRIDE_DOCKER_COMPOSE=docker-compose.e2e.yml npm run test -- ",
     "test-single-domain-install": "NODE_TLS_REJECT_UNAUTHORIZED=0 ROOM_API_HOSTNAME=https://play.workadventure.localhost ROOM_API_PORT=50051 MAP_STORAGE_PROTOCOL=https MAP_STORAGE_ENDPOINT=play.workadventure.localhost/map-storage/ dotenv -e ../contrib/docker/.env -- playwright test --project=chromium --grep-invert \"@docker|@oidc|@selfsigned\"",
     "test-helm-install": "NODE_TLS_REJECT_UNAUTHORIZED=0 ROOM_API_PORT=443 MAP_STORAGE_PROTOCOL=https playwright test --project=chromium --grep-invert \"@docker|@oidc|@selfsigned|@local|@chat\"",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "ui": "dotenv -e ../.env -- playwright test --ui"
   },
   "lint-staged": {
     "*.ts": [

--- a/tests/tests/utils/map.ts
+++ b/tests/tests/utils/map.ts
@@ -40,6 +40,13 @@ class Map {
         });
     }
 
+    async getPosition(page: Page){
+        return await evaluateScript(page, async () => {
+            await WA.onInit();
+            return await WA.player.getPosition();
+        });
+    }
+
     url(end: string){
         return `${play_url}/~/maps/${end}.wam?phaserMode=${RENDERER_MODE}`;
     }


### PR DESCRIPTION
The `WA.player.proximityMeeting.stopLeading()` function stops leading users.

A leader can now track who is following or stops following using the `WA.player.proximityMeeting.onFollowed()` and `WA.player.proximityMeeting.onUnfollowed()` RxJS subscriptions.