### PR TITLE
Fixing white page when no URL specified in open website

### DIFF
--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -256,9 +256,13 @@ export class AreasPropertiesListener {
     }
 
     private handleOpenWebsitePropertyOnEnter(property: OpenWebsitePropertyData): void {
+        if (!property.link) {
+            return;
+        }
+
         const actionId = "openWebsite-" + (Math.random() + 1).toString(36).substring(7);
 
-        if (property.newTab && property.link != undefined) {
+        if (property.newTab) {
             const forceTrigger = localUserStore.getForceCowebsiteTrigger();
             if (forceTrigger || property.trigger === ON_ACTION_TRIGGER_BUTTON) {
                 this.coWebsitesActionTriggers.set(property.id, actionId);


### PR DESCRIPTION
In the map editor, an empty URL to open a cowebsite would lead to opening a blank page that downloads the TMJ file. Now, if no URL is specified, nothing happens.