### PR TITLE
Zooming out to max level when explorer mode is enabled

### DIFF
--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -95,7 +95,7 @@ export class MapEditorModeManager {
             [EditorToolName.FloorEditor]: new FloorEditorTool(this),
             [EditorToolName.WAMSettingsEditor]: new WAMSettingsEditorTool(this),
             [EditorToolName.TrashEditor]: new TrashEditorTool(this),
-            [EditorToolName.ExploreTheRoom]: new ExplorerTool(this),
+            [EditorToolName.ExploreTheRoom]: new ExplorerTool(this, this.scene),
             [EditorToolName.CloseMapEditor]: new CloseTool(),
         };
         this.activeTool = undefined;

--- a/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
@@ -17,17 +17,12 @@ import { Entity } from "../../../ECS/Entity";
 import { MapEditorModeManager } from "../MapEditorModeManager";
 import { EntitiesManager } from "../../GameMap/EntitiesManager";
 import { AreaPreview } from "../../../Components/MapEditor/AreaPreview";
-import {
-    INITIAL_ZOOM_OUT_EXPLORER_MODE,
-    MAX_ZOOM_OUT_EXPLORER_MODE,
-    waScaleManager,
-} from "../../../Services/WaScaleManager";
+import { INITIAL_ZOOM_OUT_EXPLORER_MODE, waScaleManager } from "../../../Services/WaScaleManager";
 import { MapEditorTool } from "./MapEditorTool";
 
 const logger = debug("explorer-tool");
 
 export class ExplorerTool implements MapEditorTool {
-    private scene: GameScene;
     private downIsPressed = false;
     private upIsPressed = false;
     private leftIsPressed = false;
@@ -37,6 +32,7 @@ export class ExplorerTool implements MapEditorTool {
     private lastCameraCenterXToZoom = 0;
     private lastCameraCenterYToZoom = 0;
     private mapExplorationEntitiesSubscribe: Unsubscriber | undefined;
+    private zoomLevelBeforeExplorerMode: number | undefined;
 
     private keyDownHandler = (event: KeyboardEvent) => {
         if (event.key === "ArrowDown" || event.key === "s") {
@@ -110,8 +106,7 @@ export class ExplorerTool implements MapEditorTool {
         this.scene.markDirty();
     };
 
-    constructor(private mapEditorModeManager: MapEditorModeManager) {
-        this.scene = gameManager.getCurrentGameScene();
+    constructor(private mapEditorModeManager: MapEditorModeManager, private readonly scene: GameScene) {
         this.entitiesManager = this.scene.getGameMapFrontWrapper().getEntitiesManager();
     }
 
@@ -155,7 +150,9 @@ export class ExplorerTool implements MapEditorTool {
         // Restore focus target
         waScaleManager.setFocusTarget(undefined);
         // Restore camera mode
-        this.scene.getCameraManager().startFollowPlayer(this.scene.CurrentPlayer, 1000);
+        this.scene
+            .getCameraManager()
+            .startFollowPlayer(this.scene.CurrentPlayer, 1000, this.zoomLevelBeforeExplorerMode);
 
         // Restore entities
         this.entitiesManager.removeAllEntitiesPointedToEditColor();
@@ -220,13 +217,9 @@ export class ExplorerTool implements MapEditorTool {
         this.scene.input.on(Phaser.Input.Events.GAME_OUT, this.pointerUpHandler);
 
         // Define new camera mode
-        this.scene.getCameraManager().setExplorationMode();
+        //this.scene.getCameraManager().setExplorationMode();
 
-        // Rules: if the user click on the action bar to open the explorater mode, we define new zoom
-        if (waScaleManager.zoomModifier > MAX_ZOOM_OUT_EXPLORER_MODE) this.scene.zoomByFactor(0.5);
-
-        // Define new zoom max
-        waScaleManager.maxZoomOut = MAX_ZOOM_OUT_EXPLORER_MODE;
+        this.zoomLevelBeforeExplorerMode = waScaleManager.zoomModifier;
 
         // Make all entities interactive
         this.entitiesManager.makeAllEntitiesInteractive();
@@ -327,6 +320,6 @@ export class ExplorerTool implements MapEditorTool {
                 this.lastCameraCenterYToZoom = cameraCenterYToZoom;
             }
             this.defineZoomToCenterCameraPositionTimeOut = undefined;
-        }, 100);
+        }, 0);
     }
 }

--- a/play/src/front/Phaser/Services/WaScaleManager.ts
+++ b/play/src/front/Phaser/Services/WaScaleManager.ts
@@ -5,7 +5,6 @@ import { HtmlUtils } from "../../WebRtc/HtmlUtils";
 import { HdpiManager } from "./HdpiManager";
 import ScaleManager = Phaser.Scale.ScaleManager;
 
-export const MAX_ZOOM_OUT_EXPLORER_MODE = 0.4;
 export const INITIAL_ZOOM_OUT_EXPLORER_MODE = 1;
 
 export enum WaScaleManagerEvent {
@@ -121,7 +120,15 @@ export class WaScaleManager {
     }
 
     public set zoomModifier(zoomModifier: number) {
-        this.setZoomModifier(zoomModifier);
+        let camera = undefined;
+        // Let's attempt to get the camera
+        for (const scene of this.game.scene.getScenes(true)) {
+            if (scene.cameras.main) {
+                camera = scene.cameras.main;
+            }
+        }
+
+        this.setZoomModifier(zoomModifier, camera);
     }
 
     public setZoomModifier(zoomModifier: number, camera?: Phaser.Cameras.Scene2D.Camera): void {
@@ -133,7 +140,7 @@ export class WaScaleManager {
         if (zoomFactor > 1 && this.zoomModifier * zoomFactor - this.zoomModifier > 0.1)
             this.setZoomModifier(this.zoomModifier * 1.1, camera);
         else if (zoomFactor < 1 && this.zoomModifier - this.zoomModifier * zoomFactor > 0.1)
-            this.setZoomModifier(this.zoomModifier * 0.9, camera);
+            this.setZoomModifier(this.zoomModifier / 1.1, camera);
         else this.setZoomModifier(this.zoomModifier * zoomFactor, camera);
 
         if (this.focusTarget) {


### PR DESCRIPTION
We now zoom out automatically so that the map width = the screen width when explorer mode is enabled (to have a global overview of the map)