### PR TITLE
Smoothly slowing the camera velocity when user release click in explorer mode

### DIFF
--- a/play/src/front/Phaser/Game/CameraManager.ts
+++ b/play/src/front/Phaser/Game/CameraManager.ts
@@ -126,6 +126,7 @@ export class CameraManager extends Phaser.Events.EventEmitter {
             });
             return;
         }
+        this.stopPan();
         this.camera.pan(setTo.x, setTo.y, duration, Easing.SineEaseOut, true, (camera, progress, x, y) => {
             if (this.cameraMode === CameraMode.Positioned) {
                 this.waScaleManager.zoomModifier = currentZoomModifier + progress * zoomModifierChange;
@@ -167,6 +168,7 @@ export class CameraManager extends Phaser.Events.EventEmitter {
             this.emit(CameraManagerEvent.CameraUpdate, this.getCameraUpdateEventData());
             return;
         }
+        this.stopPan();
         this.camera.pan(focusOn.x, focusOn.y, duration, Easing.SineEaseOut, true, (camera, progress, x, y) => {
             this.waScaleManager.zoomModifier = currentZoomModifier + progress * zoomModifierChange;
             if (progress === 1) {
@@ -425,12 +427,23 @@ export class CameraManager extends Phaser.Events.EventEmitter {
         const { width: mapWidth, height: mapHeight } = this.getMapSize();
         const targetZoomModifier = this.waScaleManager.getTargetZoomModifierFor(mapWidth, mapHeight);
 
+        this.stopPan();
         this.camera.pan(mapWidth / 2, mapHeight / 2, 1000, Easing.SineEaseOut, true, (camera, progress, x, y) => {
             this.waScaleManager.zoomModifier =
                 (targetZoomModifier - currentZoomModifier) * progress + currentZoomModifier;
-            this.scene.markDirty();
             this.emit(CameraManagerEvent.CameraUpdate, this.getCameraUpdateEventData());
         });
+    }
+
+    public panTo(scrollX: number, scrollY: number, duration: number): void {
+        this.stopPan();
+        this.camera.pan(scrollX, scrollY, duration, Easing.SineEaseOut, true, () => {
+            this.emit(CameraManagerEvent.CameraUpdate, this.getCameraUpdateEventData());
+        });
+    }
+
+    public stopPan(): void {
+        this.camera.panEffect.reset();
     }
 
     public goToEntity(entity: Entity): void {

--- a/play/src/front/Phaser/Game/DirtyScene.ts
+++ b/play/src/front/Phaser/Game/DirtyScene.ts
@@ -13,6 +13,8 @@ export abstract class DirtyScene extends ResizableScene {
     protected dirty = true;
     private objectListChanged = true;
     private physicsEnabled = false;
+    private lastCameraOffsetX = 0;
+    private lastCameraOffsetY = 0;
 
     /**
      * Track all objects added to the scene and adds a callback each time an animation is added.
@@ -57,6 +59,15 @@ export abstract class DirtyScene extends ResizableScene {
             if (!objectMoving && this.physicsEnabled) {
                 this.physics.disableUpdate();
                 this.physicsEnabled = false;
+            }
+
+            if (
+                this.cameras.main.scrollX !== this.lastCameraOffsetX ||
+                this.cameras.main.scrollY !== this.lastCameraOffsetY
+            ) {
+                this.dirty = true;
+                this.lastCameraOffsetX = this.cameras.main.scrollX;
+                this.lastCameraOffsetY = this.cameras.main.scrollY;
             }
         });
     }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
@@ -88,7 +88,7 @@ export class ExplorerTool implements MapEditorTool {
 
         this.explorationMouseIsActive = true;
         this.scene.input.setDefaultCursor("grabbing");
-        this.scene.cameras.main.panEffect.reset();
+        this.scene.getCameraManager().stopPan();
     };
     private pointerMoveHandler = (pointer: Phaser.Input.Pointer) => {
         if (!this.explorationMouseIsActive) return;
@@ -114,13 +114,13 @@ export class ExplorerTool implements MapEditorTool {
         if (pointer.velocity) {
             // Let's compute the remaining velocity
             const camera = this.scene.cameras.main;
-            camera.pan(
-                camera.scrollX + camera.width / 2 - pointer.velocity.x * 10,
-                camera.scrollY + camera.height / 2 - pointer.velocity.y * 10,
-                Math.sqrt((pointer.velocity.length() * 20) / 1000) * 1000,
-                "Sine",
-                true
-            );
+            this.scene
+                .getCameraManager()
+                .panTo(
+                    camera.scrollX + camera.width / 2 - pointer.velocity.x * 10,
+                    camera.scrollY + camera.height / 2 - pointer.velocity.y * 10,
+                    Math.sqrt((pointer.velocity.length() * 20) / 1000) * 1000
+                );
         }
 
         this.scene.markDirty();


### PR DESCRIPTION
When the user moves the screen in explorer mode, the velocity is now kept and slowly decreased to the target location.
This adds a nice extra animation and is fun to play with.