### PR TITLE
Fixing path to missing tileset when a loading problem occurs

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -413,7 +413,7 @@ export class GameScene extends DirtyScene {
                         code: "NETWORK_ERROR",
                         title: "Network error",
                         subtitle: "An error occurred while loading a resource",
-                        details: 'Cannot load "' + (this.originalMapUrl ?? file.src) + '"',
+                        details: 'Cannot load "' + (file?.src ?? this.originalMapUrl) + '"',
                     })
                 );
                 this.cleanupClosingScene();


### PR DESCRIPTION
Previously, when a tileset failed to load, we would display a problem on the map URL instead of the tileset URL.