### PR TITLE
Fixing disabling the Invite button from Admin API.

### DIFF
--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -488,7 +488,7 @@ export class IoSocketController {
                             userRoomToken: memberUserRoomToken,
                             jabberId: userData.jabberId,
                             jabberPassword: userData.jabberPassword,
-                            activatedInviteUser: userData.activatedInviteUser || undefined,
+                            activatedInviteUser: userData.activatedInviteUser ?? undefined,
                             mucRooms: userData.mucRooms || [],
                             applications: userData.applications,
                             canEdit: userData.canEdit ?? false,


### PR DESCRIPTION
When the AdminAPI was returning "false" for activatedInviteUser, this was cast to undefined in the pusher, and later, undefined was cast to true in the back. As a result, the Invite button would always show up, even when the admin was telling not to display it.