### PR TITLE
Setting up a resistance "wall" for zoom in-out.

### DIFF
--- a/play/src/front/Components/MapEditor/MapEditorSideBar.svelte
+++ b/play/src/front/Components/MapEditor/MapEditorSideBar.svelte
@@ -86,7 +86,7 @@
         <img
             src={CloseImg}
             class="tw-h-4 tw-ml-4 tw-pointer-events-auto tw-cursor-pointer"
-            alt="Map Editor mode activated"
+            alt={$LL.mapEditor.sideBar.closeMapEditor()}
             on:click|preventDefault={() => switchTool(EditorToolName.CloseMapEditor)}
         />
     </div>

--- a/play/src/front/Components/MapEditor/PropertyEditor/ExitPropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/ExitPropertyEditor.svelte
@@ -112,9 +112,6 @@
                     {#each startAreas as areaName (areaName)}
                         <option value={areaName} selected={areaName === property.areaName}>{areaName}</option>
                     {/each}
-                    {#if startAreas.length === 0}
-                        <option value={""} selected>No start area found</option>
-                    {/if}
                 </select>
             </div>
         {/if}

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -131,7 +131,7 @@ import {
     cameraResistanceModeStore,
 } from "../../Stores/MapEditorStore";
 import { refreshPromptStore } from "../../Stores/RefreshPromptStore";
-import { debugAddPlayer, debugRemovePlayer, debugUpdatePlayer } from "../../Utils/Debuggers";
+import { debugAddPlayer, debugRemovePlayer, debugUpdatePlayer, debugZoom } from "../../Utils/Debuggers";
 import { checkCoturnServer } from "../../Components/Video/utils";
 import { BroadcastService } from "../../Streaming/BroadcastService";
 import { megaphoneCanBeUsedStore, liveStreamingEnabledStore } from "../../Stores/MegaphoneStore";
@@ -3427,6 +3427,22 @@ ${escapedMessage}
                 throw new Error("Scene destroyed without cleanup!");
             }
         });
+    }
+
+    handleMouseWheel(deltaY: number) {
+        // Calculate the velocity of the zoom
+        //const velocity = deltaY / 30;
+
+        // Calculate the zoom factor
+        //const zoomFactor = 1 - velocity * 0.1;
+
+        // Explanation of the formula: to Zoom x 2, we need a delta of 300
+        const zoomFactor = Math.exp((-deltaY * Math.log(2)) / 200);
+
+        debugZoom("DeltaY: ", deltaY, "Zoom factor", zoomFactor);
+
+        // Apply the zoom
+        this.zoomByFactor(zoomFactor, true);
     }
 
     zoomByFactor(zoomFactor: number, smooth: boolean) {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3563,16 +3563,32 @@ ${escapedMessage}
     }
 
     private configureResistanceToZoomOut(): void {
-        this.cameraManager.setResistanceZone(0.6, 0.3, 1, () => {
-            mapEditorModeStore.switchMode(true);
-            this.mapEditorModeManager.equipTool(EditorToolName.ExploreTheRoom);
-        });
+        this.cameraManager.setResistanceZone(
+            0.6,
+            0.3,
+            1,
+            () => {
+                mapEditorModeStore.switchMode(true);
+                this.mapEditorModeManager.equipTool(EditorToolName.ExploreTheRoom);
+            },
+            true,
+            undefined,
+            this.CurrentPlayer
+        );
     }
 
     private configureResistanceToZoomIn(): void {
-        this.cameraManager.setResistanceZone(0.3, 0.6, 1, () => {
-            mapEditorModeStore.switchMode(false);
-        });
+        this.cameraManager.setResistanceZone(
+            0.3,
+            0.6,
+            1,
+            () => {
+                mapEditorModeStore.switchMode(false);
+            },
+            false,
+            300,
+            this.CurrentPlayer
+        );
     }
 
     private disableCameraResistance(): void {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -181,6 +181,7 @@ import DOMElement = Phaser.GameObjects.DOMElement;
 import Tileset = Phaser.Tilemaps.Tileset;
 import SpriteSheetFile = Phaser.Loader.FileTypes.SpriteSheetFile;
 import FILE_LOAD_ERROR = Phaser.Loader.Events.FILE_LOAD_ERROR;
+import Clamp = Phaser.Math.Clamp;
 
 export interface GameSceneInitInterface {
     reconnecting: boolean;
@@ -776,7 +777,7 @@ export class GameScene extends DirtyScene {
 
         this.cameraManager = new CameraManager(
             this,
-            { x: this.Map.widthInPixels, y: this.Map.heightInPixels },
+            { width: this.Map.widthInPixels, height: this.Map.heightInPixels },
             waScaleManager
         );
         this.configureResistanceToZoomOut();
@@ -3437,7 +3438,11 @@ ${escapedMessage}
         //const zoomFactor = 1 - velocity * 0.1;
 
         // Explanation of the formula: to Zoom x 2, we need a delta of 300
-        const zoomFactor = Math.exp((-deltaY * Math.log(2)) / 200);
+        let zoomFactor = Math.exp((-deltaY * Math.log(2)) / 200);
+
+        // Sometimes, deltaY can be really high (this happens when the browser is lagging for 1 second or so)
+        // Let's clamp the value to avoid zooming too much
+        zoomFactor = Clamp(zoomFactor, 0.5, 2);
 
         debugZoom("DeltaY: ", deltaY, "Zoom factor", zoomFactor);
 

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3437,7 +3437,7 @@ ${escapedMessage}
         // Calculate the zoom factor
         //const zoomFactor = 1 - velocity * 0.1;
 
-        // Explanation of the formula: to Zoom x 2, we need a delta of 300
+        // Explanation of the formula: to Zoom x 2, we need a delta of 200
         let zoomFactor = Math.exp((-deltaY * Math.log(2)) / 200);
 
         // Sometimes, deltaY can be really high (this happens when the browser is lagging for 1 second or so)

--- a/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
@@ -73,11 +73,7 @@ export class ExplorerTool implements MapEditorTool {
         deltaY: number,
         deltaZ: number
     ) => {
-        // Calculate the velocity of the scroll
-        const velocity = deltaY / 53;
-        const zoomFactor = 1 - velocity * 0.1;
-        // Restore camera mode
-        this.scene.zoomByFactor(zoomFactor, true);
+        this.scene.handleMouseWheel(deltaY);
     };
     private pointerDownHandler = (pointer: Phaser.Input.Pointer) => {
         // The motion factor is used to smooth out the velocity of the camera.

--- a/play/src/front/Phaser/Services/HdpiManager.ts
+++ b/play/src/front/Phaser/Services/HdpiManager.ts
@@ -7,6 +7,7 @@ export class HdpiManager {
     private _zoomModifier = 1;
     private _maxZoomOut = 1;
     private _optimalZoomLevel = 1;
+    private _maxZoomInReached = false;
 
     /**
      *
@@ -25,6 +26,7 @@ export class HdpiManager {
      * @param realPixelScreenSize
      */
     public getOptimalGameSize(realPixelScreenSize: Size): { game: Size; real: Size } {
+        this._maxZoomInReached = false;
         const realPixelNumber = realPixelScreenSize.width * realPixelScreenSize.height;
         // If the screen has not a definition small enough to match the minimum number of pixels we want to display,
         // let's make the canvas the size of the screen (in real pixels)
@@ -58,6 +60,7 @@ export class HdpiManager {
 
         // Let's ensure we display a minimum of pixels, even if crazily zoomed in.
         if (gameWidth * gameHeight < this.absoluteMinPixelNumber) {
+            this._maxZoomInReached = true;
             const minGameHeight = Math.sqrt(
                 (this.absoluteMinPixelNumber * realPixelScreenSize.height) / realPixelScreenSize.width
             );
@@ -119,5 +122,9 @@ export class HdpiManager {
 
     public get isMaximumZoomReached(): boolean {
         return this._optimalZoomLevel * this._zoomModifier <= this._maxZoomOut;
+    }
+
+    public get isMaximumZoomInReached(): boolean {
+        return this._maxZoomInReached;
     }
 }

--- a/play/src/front/Phaser/Services/WaScaleManager.ts
+++ b/play/src/front/Phaser/Services/WaScaleManager.ts
@@ -191,6 +191,10 @@ export class WaScaleManager {
     public get isMaximumZoomReached(): boolean {
         return this.hdpiManager.isMaximumZoomReached;
     }
+
+    public get isMaximumZoomInReached(): boolean {
+        return this.hdpiManager.isMaximumZoomInReached;
+    }
 }
 
 export const waScaleManager = new WaScaleManager(640 * 480, 196 * 196);

--- a/play/src/front/Phaser/Services/WaScaleManager.ts
+++ b/play/src/front/Phaser/Services/WaScaleManager.ts
@@ -52,6 +52,10 @@ export class WaScaleManager {
             this.scaleManager.setZoom(this.actualZoom);
             camera?.setZoom(1);
         } else {
+            if (this.scaleManager.width !== realSize.width || this.scaleManager.height !== realSize.height) {
+                this.scaleManager.resize(realSize.width, realSize.height);
+            }
+
             const zoom =
                 this.hdpiManager.zoomModifier * this.hdpiManager.getOptimalZoomLevel(realSize.width * realSize.height);
             this.scaleManager.setZoom(this.actualZoom);

--- a/play/src/front/Phaser/Services/WaScaleManager.ts
+++ b/play/src/front/Phaser/Services/WaScaleManager.ts
@@ -143,7 +143,6 @@ export class WaScaleManager {
             x: camera.worldView.x + camera.worldView.width / 2,
             y: camera.worldView.y + camera.worldView.height / 2,
         };
-
         /*if (zoomFactor > 1 && this.zoomModifier * zoomFactor - this.zoomModifier > 0.1)
             this.setZoomModifier(this.zoomModifier * 1.1, camera);
         else if (zoomFactor < 1 && this.zoomModifier - this.zoomModifier * zoomFactor > 0.1)
@@ -152,10 +151,6 @@ export class WaScaleManager {
         this.setZoomModifier(zoomLevel, camera);
 
         camera.centerOn(cameraCenter.x, cameraCenter.y);
-
-        if (this.focusTarget) {
-            this.game.events.emit(WaScaleManagerEvent.RefreshFocusOnTarget, this.focusTarget);
-        }
     }
 
     public getFocusTarget(): WaScaleManagerFocusTarget | undefined {

--- a/play/src/front/Phaser/Services/WaScaleManager.ts
+++ b/play/src/front/Phaser/Services/WaScaleManager.ts
@@ -138,21 +138,6 @@ export class WaScaleManager {
         this.applyNewSize(camera);
     }
 
-    public handleZoom(zoomLevel: number, camera: Phaser.Cameras.Scene2D.Camera): void {
-        const cameraCenter = {
-            x: camera.worldView.x + camera.worldView.width / 2,
-            y: camera.worldView.y + camera.worldView.height / 2,
-        };
-        /*if (zoomFactor > 1 && this.zoomModifier * zoomFactor - this.zoomModifier > 0.1)
-            this.setZoomModifier(this.zoomModifier * 1.1, camera);
-        else if (zoomFactor < 1 && this.zoomModifier - this.zoomModifier * zoomFactor > 0.1)
-            this.setZoomModifier(this.zoomModifier / 1.1, camera);
-        else //this.setZoomModifier(this.zoomModifier * zoomFactor, camera);*/
-        this.setZoomModifier(zoomLevel, camera);
-
-        camera.centerOn(cameraCenter.x, cameraCenter.y);
-    }
-
     public getFocusTarget(): WaScaleManagerFocusTarget | undefined {
         return this.focusTarget;
     }
@@ -188,7 +173,7 @@ export class WaScaleManager {
         return this.hdpiManager.maxZoomOut;
     }
 
-    public get isMaximumZoomReached(): boolean {
+    public get isMaximumZoomOutReached(): boolean {
         return this.hdpiManager.isMaximumZoomReached;
     }
 

--- a/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
+++ b/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
@@ -21,18 +21,7 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
         deltaY: number,
         deltaZ: number
     ): void {
-        // Calculate the velocity of the zoom
-        //const velocity = Math.sign(deltaY) * Math.sqrt(Math.abs(deltaY)) / 5;
-        let velocity = deltaY / 53;
-        // Fine tuning: if the platform is a Mac, the trackpad is a bit slow so we need to increase the velocity
-        if (navigator.platform.toUpperCase().indexOf("MAC") >= 0) {
-            velocity = deltaY / 15;
-        }
-
-        // Calculate the zoom factor
-        const zoomFactor = 1 - velocity * 0.1;
-        // Apply the zoom
-        this.gameScene.zoomByFactor(zoomFactor, true);
+        this.gameScene.handleMouseWheel(deltaY);
     }
 
     public handlePointerUpEvent(pointer: Phaser.Input.Pointer, gameObjects: Phaser.GameObjects.GameObject[]): void {

--- a/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
+++ b/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
@@ -22,7 +22,13 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
         deltaZ: number
     ): void {
         // Calculate the velocity of the zoom
-        const velocity = deltaY / 53;
+        //const velocity = Math.sign(deltaY) * Math.sqrt(Math.abs(deltaY)) / 5;
+        let velocity = deltaY / 53;
+        // Fine tuning: if the platform is a Mac, the trackpad is a bit slow so we need to increase the velocity
+        if (navigator.platform.toUpperCase().indexOf("MAC") >= 0) {
+            velocity = deltaY / 15;
+        }
+
         // Calculate the zoom factor
         const zoomFactor = 1 - velocity * 0.1;
         // Apply the zoom

--- a/play/src/front/Utils/Debuggers.ts
+++ b/play/src/front/Utils/Debuggers.ts
@@ -5,3 +5,5 @@ export const debugRepo = debug("Players");
 export const debugAddPlayer = debugRepo.extend("AddPlayer");
 export const debugUpdatePlayer = debugRepo.extend("UpdatePlayer");
 export const debugRemovePlayer = debugRepo.extend("RemovePlayer");
+
+export const debugZoom = debug("Zoom");


### PR DESCRIPTION
The wall can be "in-place" or "broken". When the wall is in place, it is NOT possible to pass the resistance zone. We do this by altering the zoom factor to make it slower as we are getting closer to the resistance zone end.

When we get out of the resistance zone OR if we are in the resistance zone but zoom towards the start of the zone, we break the wall for 10 seconds.

Also, improves a number of glitches when doing the automatic zoom-out or zoom-in => the camera is now directed by following a position instead of via scrollX/scrollY which solves a number of rounding issues.

Closes #3871