### PR TITLE
Fixing variable optimization

### DIFF
--- a/play/src/front/Api/Iframe/players.ts
+++ b/play/src/front/Api/Iframe/players.ts
@@ -30,7 +30,7 @@ export class WorkadventurePlayersCommands extends IframeApiContribution<Workadve
                 const remotePlayer = remotePlayers.get(payloadData.playerId);
                 if (remotePlayer === undefined) {
                     console.warn(
-                        "Received a variable message for a player that isn't connected. Ignoring.",
+                        'Received a variable message for a player that isn\'t connected. Did you forget to call "WA.players.configureTracking()"?. Ignoring.',
                         payloadData
                     );
                     return;

--- a/play/src/front/Api/Iframe/state.ts
+++ b/play/src/front/Api/Iframe/state.ts
@@ -17,7 +17,8 @@ export class WorkadventureStateCommands extends AbstractWorkadventureStateComman
     ];
 
     saveVariable(key: string, value: unknown): Promise<void> {
-        if (this.variables.get(key) === value) {
+        // Let's not save anything if the value has not changed (and if it is a primitive type)
+        if (this.variables.get(key) === value && typeof value !== "object") {
             return Promise.resolve();
         }
 


### PR DESCRIPTION
Previously, if a variable was not changed, on calling `saveVariable`, we would not do anything. This issue is that if the variable was an object or an array, pushing a new value to the array or modifying a key of the object would not change the reference of the object. As a result, saving a modified object would not work.

We fix this by disabling the check if we are only modifying an object or array.