### PR TITLE
Switching the build of the desktop app to Node 16

### DIFF
--- a/.github/workflows/build-and-release-desktop.yml
+++ b/.github/workflows/build-and-release-desktop.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         runtime: [ linux-x64, win-x64, osx-x64 ]
         include:
         - runtime: linux-x64


### PR DESCRIPTION
Node 14 is no longer available.