### PR TITLE
Fixing bypassing collidion by moving with mouse close to collision

### DIFF
--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -29,6 +29,11 @@ import DOMElement = Phaser.GameObjects.DOMElement;
 const playerNameY = -25;
 const interactiveRadius = 25;
 
+export const CHARACTER_BODY_WIDTH = 16;
+export const CHARACTER_BODY_HEIGHT = 16;
+export const CHARACTER_BODY_OFFSET_X = 0;
+export const CHARACTER_BODY_OFFSET_Y = 8;
+
 export abstract class Character extends Container implements OutlineableInterface {
     private bubble: SpeechBubble | null = null;
     private playerNameText: Text | undefined;
@@ -201,9 +206,9 @@ export abstract class Character extends Container implements OutlineableInterfac
         this.scene.physics.world.enableBody(this);
         this.getBody().setImmovable(true);
         this.getBody().setCollideWorldBounds(true);
-        this.setSize(16, 16);
-        this.getBody().setSize(16, 16); //edit the hitbox to better match the character model
-        this.getBody().setOffset(0, 8);
+        this.setSize(CHARACTER_BODY_WIDTH, CHARACTER_BODY_HEIGHT);
+        this.getBody().setSize(CHARACTER_BODY_WIDTH, CHARACTER_BODY_HEIGHT); //edit the hitbox to better match the character model
+        this.getBody().setOffset(CHARACTER_BODY_OFFSET_X, CHARACTER_BODY_OFFSET_Y);
         this.setDepth(0);
     }
 


### PR DESCRIPTION
When moving close to a collide tile with the mouse, the Woka would step parially on the collided block. This would further allow to pass through the wall completely. We fix this by making sure a Woka hitbox is 100% within the tile targetted (which is non collidable).

Closes #3894 