### PR TITLE
Removing the black outline around entities in explorer mode

### DIFF
--- a/play/src/front/Components/Exploration/Explorer.svelte
+++ b/play/src/front/Components/Exploration/Explorer.svelte
@@ -100,7 +100,7 @@
         // Don't unhighlight if the entity is selected
         if ($mapExplorationObjectSelectedStore == entity) return;
 
-        entity.setPointedToEditColor(0x000000);
+        entity.removePointedToEditColor();
         gameManager.getCurrentGameScene().markDirty();
     }
     function highlightArea(area: AreaPreview) {

--- a/play/src/front/Components/Modal/ObjectDetails.svelte
+++ b/play/src/front/Components/Modal/ObjectDetails.svelte
@@ -23,7 +23,7 @@
     };
 
     let iconProperties = writable<Map<string, AddPropertyButtonType>>(new Map());
-    let holdEntity: Entity | AreaPreview | undefined;
+    let oldEntity: Entity | AreaPreview | undefined;
     let mapExplorationObjectSelectedStoreSubscription: Unsubscriber;
     let description: string | undefined;
 
@@ -40,11 +40,11 @@
         initPropertyComponents();
 
         // Make sure that if the user click on another object, the previous one is not selected anymore
-        holdEntity = $mapExplorationObjectSelectedStore;
+        oldEntity = $mapExplorationObjectSelectedStore;
         mapExplorationObjectSelectedStoreSubscription = mapExplorationObjectSelectedStore.subscribe((value) => {
-            if (holdEntity instanceof Entity) holdEntity.setPointedToEditColor(0x000000);
-            if (holdEntity instanceof AreaPreview) holdEntity.setStrokeStyle(2, 0x000000);
-            holdEntity = value;
+            if (oldEntity instanceof Entity) oldEntity.removePointedToEditColor();
+            if (oldEntity instanceof AreaPreview) oldEntity.setStrokeStyle(2, 0x000000);
+            oldEntity = value;
             if (value instanceof Entity) value.setPointedToEditColor(0xf9e82d);
             if (value instanceof AreaPreview) value.setStrokeStyle(2, 0xf9e82d);
 
@@ -54,11 +54,11 @@
     onDestroy(() => {
         if (mapExplorationObjectSelectedStoreSubscription) mapExplorationObjectSelectedStoreSubscription();
         if ($mapExplorationObjectSelectedStore instanceof Entity)
-            $mapExplorationObjectSelectedStore.setPointedToEditColor(0x000000);
+            $mapExplorationObjectSelectedStore.removePointedToEditColor();
         if ($mapExplorationObjectSelectedStore instanceof AreaPreview)
             $mapExplorationObjectSelectedStore.setStrokeStyle(2, 0x000000);
-        if (holdEntity instanceof Entity) holdEntity.setPointedToEditColor(0x000000);
-        if (holdEntity instanceof AreaPreview) holdEntity.setStrokeStyle(2, 0x000000);
+        if (oldEntity instanceof Entity) oldEntity.removePointedToEditColor();
+        if (oldEntity instanceof AreaPreview) oldEntity.setStrokeStyle(2, 0x000000);
 
         cleanPropertyComponents();
     });
@@ -87,11 +87,11 @@
 
     function close() {
         if ($mapExplorationObjectSelectedStore instanceof Entity)
-            $mapExplorationObjectSelectedStore.setPointedToEditColor(0x000000);
+            $mapExplorationObjectSelectedStore.removePointedToEditColor();
         if ($mapExplorationObjectSelectedStore instanceof AreaPreview)
             $mapExplorationObjectSelectedStore.setStrokeStyle(2, 0x000000);
-        if (holdEntity instanceof Entity) holdEntity.setPointedToEditColor(0x000000);
-        if (holdEntity instanceof AreaPreview) holdEntity.setStrokeStyle(2, 0x000000);
+        if (oldEntity instanceof Entity) oldEntity.removePointedToEditColor();
+        if (oldEntity instanceof AreaPreview) oldEntity.setStrokeStyle(2, 0x000000);
         mapExplorationObjectSelectedStore.set(undefined);
     }
     function goTo() {

--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -341,12 +341,8 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
         entity.on(Phaser.Input.Events.POINTER_OUT, () => {
             this.pointerOutEntitySubject.next(entity);
             if (get(mapEditorModeStore)) {
-                if (this.isEntityEditorToolActive()) {
+                if (this.isEntityEditorToolActive() || this.isExplorerToolActive()) {
                     entity.removePointedToEditColor();
-                    this.scene.markDirty();
-                }
-                if (this.isExplorerToolActive()) {
-                    entity.setPointedToEditColor(0x000000);
                     this.scene.markDirty();
                 }
             }
@@ -431,16 +427,5 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
 
     public close() {
         this.actionsMenuStoreUnsubscriber();
-    }
-
-    public setAllEntitiesPointedToEditColor(color: number) {
-        for (const entity of this.entities.values()) {
-            entity.setPointedToEditColor(color);
-        }
-    }
-    public removeAllEntitiesPointedToEditColor() {
-        for (const entity of this.entities.values()) {
-            entity.removePointedToEditColor();
-        }
     }
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
@@ -181,7 +181,6 @@ export class ExplorerTool implements MapEditorTool {
         cameraManager.startFollowPlayer(this.scene.CurrentPlayer, 1000, targetZoom);
 
         // Restore entities
-        this.entitiesManager.removeAllEntitiesPointedToEditColor();
         this.removeAllAreasPreviewPointedToEditColor();
 
         // Restore cursor
@@ -257,7 +256,6 @@ export class ExplorerTool implements MapEditorTool {
 
         // Make all entities interactive
         this.entitiesManager.makeAllEntitiesInteractive();
-        this.entitiesManager.setAllEntitiesPointedToEditColor(0x000000);
         this.setAllAreasPreviewPointedToEditColor();
 
         this.scene.playSound("audio-cloud");
@@ -273,12 +271,6 @@ export class ExplorerTool implements MapEditorTool {
         /*setTimeout(() => {
             this.scene.zoomByFactor(1, 1);
         }, 200);*/
-
-        // Create subscribe to entities store
-        this.mapExplorationEntitiesSubscribe = mapExplorationEntitiesStore.subscribe((entities) => {
-            this.entitiesManager.setAllEntitiesPointedToEditColor(0x000000);
-            this.scene.markDirty();
-        });
     }
     public destroy(): void {
         this.clear();


### PR DESCRIPTION
The black outline around entities as a dreadful effect on performances when zooming out.