### PR TITLE
Fixing Helm release chart deployment

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -26,15 +26,15 @@ jobs:
 
       - name: Configure proper version number. Use "0.0.9-dev1" for master and "tag" for releases
         run: |
-            if [ -z "$GITHUB_REF" ]; then
-                echo "GITHUB_REF is not set. Exiting."
+            if [ -z "$GITHUB_REF_NAME" ]; then
+                echo "GITHUB_REF_NAME is not set. Exiting."
                 exit 1
             fi
-            if [ "$GITHUB_REF" != "refs/heads/master" ]; then
-                echo "Setting version to $GITHUB_REF"
-                sed -i "s/version: 0.0.9-dev1/version: $GITHUB_REF/g" Chart.yaml
-                sed -i "s/appVersion: \"0.0.9-dev1\"/appVersion: \"$GITHUB_REF\"/g" Chart.yaml
-                sed -i "s/^appVersion: \"master\"/appVersion: \"$GITHUB_REF\"/g" values.yaml
+            if [ "$GITHUB_REF_NAME" != "master" ]; then
+                echo "Setting version to $GITHUB_REF_NAME"
+                sed -i "s/version: 0.0.9-dev1/version: $GITHUB_REF_NAME/g" Chart.yaml
+                sed -i "s/appVersion: \"0.0.9-dev1\"/appVersion: \"$GITHUB_REF_NAME\"/g" Chart.yaml
+                sed -i "s/^appVersion: \"master\"/appVersion: \"$GITHUB_REF_NAME\"/g" values.yaml
             fi
         working-directory: contrib/helm
 


### PR DESCRIPTION
An error in the way we replace the version number in the Chart file prevents the chart file from being properly generated in the CI.