### PR TITLE
Fix focus on object/area in map explorer

### DIFF
--- a/play/src/front/Components/Exploration/Explorer.svelte
+++ b/play/src/front/Components/Exploration/Explorer.svelte
@@ -90,7 +90,7 @@
 
     function highlightEntity(entity: Entity) {
         entity.setPointedToEditColor(0xf9e82d);
-        gameManager.getCurrentGameScene().getCameraManager().goToEntity(entity);
+        gameManager.getCurrentGameScene().getCameraManager().centerCameraOn(entity);
         // Use explorer tool to define the zoom to center camera position
         (
             gameManager.getCurrentGameScene().getMapEditorModeManager().currentlyActiveTool as ExplorerTool
@@ -105,7 +105,7 @@
     }
     function highlightArea(area: AreaPreview) {
         area.setStrokeStyle(2, 0xf9e82d);
-        gameManager.getCurrentGameScene().getCameraManager().goToAreaPreviex(area);
+        gameManager.getCurrentGameScene().getCameraManager().centerCameraOn(area);
         // Use explorer tool to define the zoom to center camera position
         (
             gameManager.getCurrentGameScene().getMapEditorModeManager().currentlyActiveTool as ExplorerTool

--- a/play/src/front/Phaser/Game/CameraManager.ts
+++ b/play/src/front/Phaser/Game/CameraManager.ts
@@ -2,8 +2,6 @@ import { mapEditorModeStore } from "../../Stores/MapEditorStore";
 import { Easing } from "../../types";
 import { HtmlUtils } from "../../WebRtc/HtmlUtils";
 import type { Box } from "../../WebRtc/LayoutManager";
-import { AreaPreview } from "../Components/MapEditor/AreaPreview";
-import { Entity } from "../ECS/Entity";
 import type { Player } from "../Player/Player";
 import { hasMovedEventName } from "../Player/Player";
 import {
@@ -522,12 +520,14 @@ export class CameraManager extends Phaser.Events.EventEmitter {
         this.camera.panEffect.reset();
     }
 
-    public goToEntity(entity: Entity): void {
-        this.scene.cameras.main.centerOn(entity.x, entity.y);
-        this.scene.markDirty();
-    }
-    public goToAreaPreviex(area: AreaPreview): void {
-        this.scene.cameras.main.centerOn(area.x, area.y);
+    public centerCameraOn(position: { x: number; y: number }): void {
+        this.explorerFocusOn.x = position.x;
+        this.explorerFocusOn.y = position.y;
+
+        if (this.waScaleManager.zoomModifier < this._resistanceEndZoomLevel) {
+            this.waScaleManager.zoomModifier = this._resistanceEndZoomLevel;
+        }
+
         this.scene.markDirty();
     }
 


### PR DESCRIPTION
When hovering on an entity or area, the viewport would no more center on it. This is now fixed.

Bonus: we now center on the entity/area with a smooth animation.