### PR TITLE
Cancel animation to position if camera is manually moved

### DIFF
--- a/play/src/front/Phaser/Game/CameraManager.ts
+++ b/play/src/front/Phaser/Game/CameraManager.ts
@@ -865,6 +865,7 @@ export class CameraManager extends Phaser.Events.EventEmitter {
 
     setSpeed(speed: { x: number; y: number }) {
         this.cameraSpeed = speed;
+        this.explorerFocusOnTarget = undefined;
         this.startAnimation();
     }
 
@@ -878,6 +879,8 @@ export class CameraManager extends Phaser.Events.EventEmitter {
 
         this.explorerFocusOn.x = Clamp(this.explorerFocusOn.x, 0, this.mapSize.width);
         this.explorerFocusOn.y = Clamp(this.explorerFocusOn.y, 0, this.mapSize.height);
+
+        this.explorerFocusOnTarget = undefined;
 
         this.emit(CameraManagerEvent.CameraUpdate, this.getCameraUpdateEventData());
         this.scene.markDirty();

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3438,7 +3438,8 @@ ${escapedMessage}
         //const zoomFactor = 1 - velocity * 0.1;
 
         // Explanation of the formula: to Zoom x 2, we need a delta of 200
-        let zoomFactor = Math.exp((-deltaY * Math.log(2)) / 200);
+        // Question: Why 200 ? For mac usage, it's too slow
+        let zoomFactor = Math.exp((-deltaY * Math.log(2)) /* / 200 */ / 100);
 
         // Sometimes, deltaY can be really high (this happens when the browser is lagging for 1 second or so)
         // Let's clamp the value to avoid zooming too much


### PR DESCRIPTION
In exploration mode, when the camera is moving to a given position, the animation is stopped
and position is "forgotten" if the user moves the camera manually.