### PR TITLE
Fixing random characters

### DIFF
--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -20,7 +20,6 @@ import { ProtobufClientUtils } from "../../Network/ProtobufClientUtils";
 import { SpeakerIcon } from "../Components/SpeakerIcon";
 import { MegaphoneIcon } from "../Components/MegaphoneIcon";
 import { passStatusToOnlineWhenUserIsInSetableStatus } from "../../Rules/StatusRules/statusChangerFunctions";
-import { gameManager } from "../Game/GameManager";
 import { lazyLoadPlayerCharacterTextures } from "./PlayerTexturesLoadingManager";
 import { SpeechBubble } from "./SpeechBubble";
 import { SpeechDomElement } from "./SpeechDomElement";
@@ -93,9 +92,6 @@ export abstract class Character extends Container implements OutlineableInterfac
         //textures are inside a Promise in case they need to be lazyloaded before use.
         this.texturePromise = texturesPromise
             .then((textures) => {
-                // Save the textures in the gameManager to be able to get them into SelectCharacterScene and CustomizationScene
-                gameManager.setCharacterTextureIds(textures);
-
                 this.addTextures(textures, frame);
                 this.invisible = false;
                 this.playAnimation(direction, moving);


### PR DESCRIPTION
For some reason, a bug was introduced where the last loaded character would become the active character of the Woka in local storage. Why? No idea.
Let's fix this.