### PR TITLE
Removing lazy instanciation of ProximityMeeting (master merge)

### DIFF
--- a/play/src/front/Api/Iframe/player.ts
+++ b/play/src/front/Api/Iframe/player.ts
@@ -51,7 +51,7 @@ export const setIsLogged = (_isLogged: boolean | undefined) => {
 
 export class WorkadventurePlayerCommands extends IframeApiContribution<WorkadventurePlayerCommands> {
     readonly state = playerState;
-    private _proximityMeeting: WorkadventureProximityMeetingCommands | undefined;
+    private _proximityMeeting: WorkadventureProximityMeetingCommands = new WorkadventureProximityMeetingCommands();
 
     callbacks = [
         apiCallback({
@@ -265,9 +265,6 @@ export class WorkadventurePlayerCommands extends IframeApiContribution<Workadven
     }
 
     get proximityMeeting(): WorkadventureProximityMeetingCommands {
-        if (this._proximityMeeting === undefined) {
-            this._proximityMeeting = new WorkadventureProximityMeetingCommands();
-        }
         return this._proximityMeeting;
     }
 


### PR DESCRIPTION
We need to instanciate it when the iframe API starts to instanciate the callbacks as soon as possible. Otherwise, callbacks won't be found if we make a priority meeting before using the "WA.player.proximityMeeting" API.