### PR TITLE
Fixing click target misplaced when zooming out

### DIFF
--- a/play/src/front/Phaser/Services/WaScaleManager.ts
+++ b/play/src/front/Phaser/Services/WaScaleManager.ts
@@ -1,7 +1,6 @@
 import { coWebsiteManager } from "../../WebRtc/CoWebsiteManager";
 import type { Game } from "../Game/Game";
 import { ResizableScene } from "../Login/ResizableScene";
-import { HtmlUtils } from "../../WebRtc/HtmlUtils";
 import { HdpiManager } from "./HdpiManager";
 import ScaleManager = Phaser.Scale.ScaleManager;
 
@@ -68,9 +67,16 @@ export class WaScaleManager {
         style.height = Math.ceil(realSize.height !== 0 ? realSize.height / devicePixelRatio : 0) + "px";
 
         // Resize the game element at the same size at the canvas
-        const gameStyle = HtmlUtils.getElementByIdOrFail<HTMLDivElement>("game").style;
+        /*const gameStyle = HtmlUtils.getElementByIdOrFail<HTMLDivElement>("game").style;
         gameStyle.width = style.width;
-        gameStyle.height = style.height;
+        gameStyle.height = style.height;*/
+
+        // Resize the game element at the same size at the canvas
+        // By default, the scaleManager.resize() method will change the take the zoom into account in the displaySize.
+        // This is not what we want, we want the displaySize to be the real size of the game.
+        this.scaleManager.displaySize.width = realSize.width;
+        this.scaleManager.displaySize.height = realSize.height;
+        this.scaleManager.refresh(realSize.width, realSize.height);
 
         // Note: onResize will be called twice (once here and once in Game.ts), but we have no better way.
         for (const scene of this.game.scene.getScenes(true)) {


### PR DESCRIPTION
The bug was due to the overlay div not being aligned with the canvas when zooming out (we were manually resizing the canvas, but not the overlay div). We fix this by also manually resizing the "scaleManager.displaySize".

Closes #3936