### PR TITLE
Fixing race condition between bubble and player data

### DIFF
--- a/docs/map-building/tiled-editor/hosting.md
+++ b/docs/map-building/tiled-editor/hosting.md
@@ -19,7 +19,7 @@ CORS headers ([Cross Origin Resource Sharing](https://developer.mozilla.org/en-U
 :::caution
 If you are using the "scripting API", only allowing the `play.workadventu.re` will not be enough. You will need to allow `*`
 as a domain in order to be able to load scripts. If for some reason, you cannot or do not want to allow `*` as a domain, please
-read the [scripting internals](../developer/map-scripting/scripting-internals) guide for alternatives.
+read the [scripting internals](../../../developer/map-scripting/scripting-internals) guide for alternatives.
 :::
 
 ### Enabling CORS for Apache

--- a/play/src/front/Components/Video/ScreenSharingMediaBox.svelte
+++ b/play/src/front/Components/Video/ScreenSharingMediaBox.svelte
@@ -14,8 +14,8 @@
 
     export let peer: ScreenSharingPeer;
     let streamStore = peer.streamStore;
-    let name = peer.userName;
-    let backGroundColor = Color.getColorByString(peer.userName);
+    let name = peer.player.name;
+    let backGroundColor = Color.getColorByString(peer.player.name);
     let textColor = Color.getTextColorByBackgroundColor(backGroundColor);
     let statusStore = peer.statusStore;
 

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -36,8 +36,8 @@
 
     let streamStore = peer.streamStore;
     let volumeStore = peer.volumeStore;
-    let name = peer.userName;
-    let backGroundColor = Color.getColorByString(peer.userName);
+    let name = peer.player.name;
+    let backGroundColor = Color.getColorByString(peer.player.name);
     let textColor = Color.getTextColorByBackgroundColor(backGroundColor);
     let statusStore = peer.statusStore;
     let constraintStore = peer.constraintsStore;

--- a/play/src/front/Phaser/Companion/CompanionTexturesLoadingManager.ts
+++ b/play/src/front/Phaser/Companion/CompanionTexturesLoadingManager.ts
@@ -56,6 +56,10 @@ export class CompanionTexturesLoadingManager {
     loadModels(load: LoaderPlugin, companionTextures: CompanionTextures): CompanionTexture[] {
         const returnArray = Object.values(companionTextures.getCompanionResources());
         returnArray.forEach((companionResource) => {
+            if (!companionResource.url) {
+                console.warn("Companion resource has no URL", companionResource);
+                return;
+            }
             load.spritesheet(companionResource.id, companionResource.url, { frameWidth: 32, frameHeight: 32 });
         });
         return returnArray;

--- a/play/src/front/Phaser/Entity/PlayerTexturesLoadingManager.ts
+++ b/play/src/front/Phaser/Entity/PlayerTexturesLoadingManager.ts
@@ -19,6 +19,10 @@ export const loadAllLayers = (
         const layerArray: WokaTextureDescriptionInterface[] = [];
         Object.values(layer).forEach((textureDescriptor) => {
             layerArray.push(textureDescriptor);
+            if (!textureDescriptor.url) {
+                console.warn("Player resource has no URL", textureDescriptor);
+                return;
+            }
             load.spritesheet(textureDescriptor.id, textureDescriptor.url, { frameWidth: 32, frameHeight: 32 });
         });
         returnArray.push(layerArray);
@@ -31,6 +35,10 @@ export const loadAllDefaultModels = (
 ): WokaTextureDescriptionInterface[] => {
     const returnArray = Object.values(playerTextures.getTexturesResources(PlayerTexturesKey.Woka));
     returnArray.forEach((playerResource: WokaTextureDescriptionInterface) => {
+        if (!playerResource.url) {
+            console.warn("Player resource has no URL", playerResource);
+            return;
+        }
         load.spritesheet(playerResource.id, playerResource.url, { frameWidth: 32, frameHeight: 32 });
     });
     return returnArray;

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1652,7 +1652,7 @@ export class GameScene extends DirtyScene {
                 /*const me = this;
                 this.events.once("render", () => {
                     if (me.connection) {*/
-                this.simplePeer = new SimplePeer(this.connection);
+                this.simplePeer = new SimplePeer(this.connection, this.remotePlayersRepository);
                 /*} else {
                         console.warn("Connection to peers not started!");
                     }
@@ -2073,7 +2073,7 @@ export class GameScene extends DirtyScene {
                 // So we know for sure that there is only one new user.
                 const peer = Array.from(peers.values())[0];
                 //askIfUserWantToJoinBubbleOf(peer.userName);
-                statusChanger.setUserNameInteraction(peer.userName);
+                statusChanger.setUserNameInteraction(peer.player.name);
                 statusChanger.applyInteractionRules();
 
                 pendingConnects.add(peer.userId);

--- a/play/src/front/Phaser/Game/PlayerInterface.ts
+++ b/play/src/front/Phaser/Game/PlayerInterface.ts
@@ -13,5 +13,4 @@ export interface PlayerInterface {
     availabilityStatus: AvailabilityStatus;
     color?: string | null;
     outlineColor?: number;
-    isLogged?: boolean;
 }

--- a/play/src/front/Stores/PlayersStore.ts
+++ b/play/src/front/Stores/PlayersStore.ts
@@ -3,7 +3,6 @@ import { AvailabilityStatus } from "@workadventure/messages";
 import { Color } from "@workadventure/shared-utils";
 import type { PlayerInterface } from "../Phaser/Game/PlayerInterface";
 import type { RoomConnection } from "../Connection/RoomConnection";
-import { localUserStore } from "../Connection/LocalUserStore";
 
 let idCount = 0;
 
@@ -34,7 +33,6 @@ function createPlayersStore() {
                         userUuid: message.userUuid,
                         availabilityStatus: message.availabilityStatus,
                         color: Color.getColorByString(message.name),
-                        isLogged: localUserStore.isLogged(),
                     });
                     return users;
                 });
@@ -76,7 +74,6 @@ function createPlayersStore() {
                     availabilityStatus: AvailabilityStatus.ONLINE,
                     userUuid: "dummy",
                     color: Color.getColorByString(name),
-                    isLogged: localUserStore.isLogged(),
                 });
                 return users;
             });

--- a/play/src/front/WebRtc/ScreenSharingPeer.ts
+++ b/play/src/front/WebRtc/ScreenSharingPeer.ts
@@ -5,6 +5,7 @@ import type { RoomConnection } from "../Connection/RoomConnection";
 import { getIceServersConfig, getSdpTransform } from "../Components/Video/utils";
 import { highlightedEmbedScreen } from "../Stores/HighlightedEmbedScreenStore";
 import { screenShareBandwidthStore } from "../Stores/ScreenSharingStore";
+import { RemotePlayerData } from "../Phaser/Game/RemotePlayersRepository";
 import type { PeerStatus } from "./VideoPeer";
 import type { UserSimplePeerInterface } from "./SimplePeer";
 import {
@@ -33,7 +34,7 @@ export class ScreenSharingPeer extends Peer {
     constructor(
         user: UserSimplePeerInterface,
         initiator: boolean,
-        public readonly userName: string,
+        public readonly player: RemotePlayerData,
         private connection: RoomConnection,
         stream: MediaStream | null
     ) {

--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -1,5 +1,6 @@
 import { get } from "svelte/store";
 import type { Subscription } from "rxjs";
+import * as Sentry from "@sentry/svelte";
 import type {
     WebRtcDisconnectMessageInterface,
     WebRtcSignalReceivedMessageInterface,
@@ -12,6 +13,7 @@ import { batchGetUserMediaStore } from "../Stores/MediaStore";
 import { analyticsClient } from "../Administration/AnalyticsClient";
 import { nbSoundPlayedInBubbleStore } from "../Stores/ApparentMediaContraintStore";
 import { askDialogStore } from "../Stores/MeetingStore";
+import { RemotePlayersRepository } from "../Phaser/Game/RemotePlayersRepository";
 import { mediaManager, NotificationType } from "./MediaManager";
 import { ScreenSharingPeer } from "./ScreenSharingPeer";
 import { VideoPeer } from "./VideoPeer";
@@ -35,7 +37,7 @@ export class SimplePeer {
     private lastWebrtcUserName: string | undefined;
     private lastWebrtcPassword: string | undefined;
 
-    constructor(private Connection: RoomConnection) {
+    constructor(private Connection: RoomConnection, private remotePlayersRepository: RemotePlayersRepository) {
         //we make sure we don't get any old peer.
         peerStore.cleanupStore();
         screenSharingPeerStore.cleanupStore();
@@ -51,7 +53,10 @@ export class SimplePeer {
 
                 if (streamResult.stream !== null) {
                     localScreenCapture = streamResult.stream;
-                    this.sendLocalScreenSharingStream(localScreenCapture);
+                    this.sendLocalScreenSharingStream(localScreenCapture).catch((e) => {
+                        console.error("Error while sending local screen sharing stream to user", e);
+                        Sentry.captureException(e);
+                    });
                 } else {
                     if (localScreenCapture) {
                         this.stopLocalScreenSharingStream(localScreenCapture);
@@ -83,7 +88,10 @@ export class SimplePeer {
         this.rxJsUnsubscribers.push(
             this.Connection.webRtcSignalToClientMessageStream.subscribe(
                 (message: WebRtcSignalReceivedMessageInterface) => {
-                    this.receiveWebrtcSignal(message);
+                    this.receiveWebrtcSignal(message).catch((e) => {
+                        console.error("Error while receiving WebRTC signal", e);
+                        Sentry.captureException(e);
+                    });
                 }
             )
         );
@@ -92,7 +100,10 @@ export class SimplePeer {
         this.rxJsUnsubscribers.push(
             this.Connection.webRtcScreenSharingSignalToClientMessageStream.subscribe(
                 (message: WebRtcSignalReceivedMessageInterface) => {
-                    this.receiveWebrtcScreenSharingSignal(message);
+                    this.receiveWebrtcScreenSharingSignal(message).catch((e) => {
+                        console.error("Error while receiving WebRTC signal", e);
+                        Sentry.captureException(e);
+                    });
                 }
             )
         );
@@ -105,7 +116,10 @@ export class SimplePeer {
         //receive message start
         this.rxJsUnsubscribers.push(
             this.Connection.webRtcStartMessageStream.subscribe((message: UserSimplePeerInterface) => {
-                this.receiveWebrtcStart(message);
+                this.receiveWebrtcStart(message).catch((e) => {
+                    console.error("Error while receiving WebRTC signal", e);
+                    Sentry.captureException(e);
+                });
             })
         );
 
@@ -116,7 +130,7 @@ export class SimplePeer {
         );
     }
 
-    private receiveWebrtcStart(user: UserSimplePeerInterface): void {
+    private async receiveWebrtcStart(user: UserSimplePeerInterface): Promise<void> {
         // Note: the clients array contain the list of all clients (even the ones we are already connected to in case a user joins a group)
         // So we can receive a request we already had before. (which will abort at the first line of createPeerConnection)
         // This would be symmetrical to the way we handle disconnection.
@@ -126,14 +140,15 @@ export class SimplePeer {
             return;
         }
 
-        this.createPeerConnection(user);
+        await this.createPeerConnection(user);
     }
 
     /**
      * create peer connection to bind users
      */
-    private createPeerConnection(user: UserSimplePeerInterface): VideoPeer | null {
-        const uuid = playersStore.getPlayerById(user.userId)?.userUuid || "";
+    private async createPeerConnection(user: UserSimplePeerInterface): Promise<VideoPeer | null> {
+        const player = await this.remotePlayersRepository.getPlayer(user.userId);
+        const uuid = player.userUuid;
         if (blackListManager.isBlackListed(uuid)) return null;
 
         const peerConnection = peerStore.getPeer(user.userId);
@@ -144,16 +159,16 @@ export class SimplePeer {
                 peerStore.removePeer(user.userId);
             } else {
                 peerConnection.toClose = false;
-                return null;
+                return Promise.resolve(null);
             }
         }
 
-        const name = this.getName(user.userId);
+        const name = player.name;
 
         this.lastWebrtcUserName = user.webRtcUser;
         this.lastWebrtcPassword = user.webRtcPassword;
 
-        const peer = new VideoPeer(user, user.initiator ? user.initiator : false, name, this.Connection);
+        const peer = new VideoPeer(user, user.initiator ? user.initiator : false, player, this.Connection);
 
         peer.toClose = false;
         // When a connection is established to a video stream, and if a screen sharing is taking place,
@@ -161,7 +176,10 @@ export class SimplePeer {
         peer.on("connect", () => {
             const streamResult = get(screenSharingLocalStreamStore);
             if (streamResult.type === "success" && streamResult.stream !== null) {
-                this.sendLocalScreenSharingStreamToUser(user.userId, streamResult.stream);
+                this.sendLocalScreenSharingStreamToUser(user.userId, streamResult.stream).catch((e) => {
+                    console.error("Error while sending local screen sharing stream to user", e);
+                    Sentry.captureException(e);
+                });
             }
         });
 
@@ -175,17 +193,13 @@ export class SimplePeer {
         return peer;
     }
 
-    private getName(userId: number): string {
-        return playersStore.getPlayerById(userId)?.name || "";
-    }
-
     /**
      * create peer connection to bind users
      */
-    private createPeerScreenSharingConnection(
+    private async createPeerScreenSharingConnection(
         user: UserSimplePeerInterface,
         stream: MediaStream | null
-    ): ScreenSharingPeer | null {
+    ): Promise<ScreenSharingPeer | null> {
         const peerScreenSharingConnection = screenSharingPeerStore.getPeer(user.userId);
         if (peerScreenSharingConnection) {
             if (peerScreenSharingConnection.destroyed) {
@@ -204,12 +218,12 @@ export class SimplePeer {
             user.webRtcPassword = this.lastWebrtcPassword;
         }
 
-        const name = this.getName(user.userId);
+        const player = await this.remotePlayersRepository.getPlayer(user.userId);
 
         const peer = new ScreenSharingPeer(
             user,
             user.initiator ? user.initiator : false,
-            name,
+            player,
             this.Connection,
             stream
         );
@@ -318,12 +332,11 @@ export class SimplePeer {
         screenSharingPeerStore.cleanupStore();
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private receiveWebrtcSignal(data: WebRtcSignalReceivedMessageInterface) {
+    private async receiveWebrtcSignal(data: WebRtcSignalReceivedMessageInterface): Promise<void> {
         try {
             //if offer type, create peer connection
             if (data.signal.type === "offer") {
-                this.createPeerConnection(data);
+                await this.createPeerConnection(data);
             }
             const peer = peerStore.getPeer(data.userId);
             if (peer !== undefined) {
@@ -336,8 +349,8 @@ export class SimplePeer {
         }
     }
 
-    private receiveWebrtcScreenSharingSignal(data: WebRtcSignalReceivedMessageInterface) {
-        const uuid = playersStore.getPlayerById(data.userId)?.userUuid || "";
+    private async receiveWebrtcScreenSharingSignal(data: WebRtcSignalReceivedMessageInterface): Promise<void> {
+        const uuid = (await this.remotePlayersRepository.getPlayer(data.userId)).userUuid;
         if (blackListManager.isBlackListed(uuid)) return;
         const streamResult = get(screenSharingLocalStreamStore);
         let stream: MediaStream | null = null;
@@ -348,7 +361,7 @@ export class SimplePeer {
         try {
             //if offer type, create peer connection
             if (data.signal.type === "offer") {
-                this.createPeerScreenSharingConnection(data, stream);
+                await this.createPeerScreenSharingConnection(data, stream);
             }
             const peer = screenSharingPeerStore.getPeer(data.userId);
             if (peer !== undefined) {
@@ -359,13 +372,13 @@ export class SimplePeer {
                 );
                 console.info("Attempt to create new peer connection");
                 if (stream) {
-                    this.sendLocalScreenSharingStreamToUser(data.userId, stream);
+                    await this.sendLocalScreenSharingStreamToUser(data.userId, stream);
                 }
             }
         } catch (e) {
             console.error(`receiveWebrtcSignal => ${data.userId}`, e);
-            //Comment this peer connection because if we delete and try to reshare screen, the RTCPeerConnection send renegotiate event. This array will be remove when user left circle discussion
-            this.receiveWebrtcScreenSharingSignal(data);
+            //Comment this peer connection because if we delete and try to reshare screen, the RTCPeerConnection send renegotiate event. This array will be removed when user left circle discussion
+            await this.receiveWebrtcScreenSharingSignal(data);
         }
     }
 
@@ -385,9 +398,11 @@ export class SimplePeer {
      * Triggered locally when clicking on the screen sharing button
      */
     public sendLocalScreenSharingStream(localScreenCapture: MediaStream) {
+        const promises: Promise<void>[] = [];
         for (const userId of get(peerStore).keys()) {
-            this.sendLocalScreenSharingStreamToUser(userId, localScreenCapture);
+            promises.push(this.sendLocalScreenSharingStreamToUser(userId, localScreenCapture));
         }
+        return Promise.all(promises);
     }
 
     /**
@@ -399,8 +414,8 @@ export class SimplePeer {
         }
     }
 
-    private sendLocalScreenSharingStreamToUser(userId: number, localScreenCapture: MediaStream): void {
-        const uuid = playersStore.getPlayerById(userId)?.userUuid || "";
+    private async sendLocalScreenSharingStreamToUser(userId: number, localScreenCapture: MediaStream): Promise<void> {
+        const uuid = (await this.remotePlayersRepository.getPlayer(userId)).userUuid;
         if (blackListManager.isBlackListed(uuid)) return;
         // If a connection already exists with user (because it is already sharing a screen with us... let's use this connection)
         if (get(screenSharingPeerStore).has(userId)) {
@@ -412,7 +427,7 @@ export class SimplePeer {
             userId,
             initiator: true,
         };
-        const PeerConnectionScreenSharing = this.createPeerScreenSharingConnection(
+        const PeerConnectionScreenSharing = await this.createPeerScreenSharingConnection(
             screenSharingUser,
             localScreenCapture
         );

--- a/play/src/front/WebRtc/VideoPeer.ts
+++ b/play/src/front/WebRtc/VideoPeer.ts
@@ -18,6 +18,7 @@ import { apparentMediaContraintStore } from "../Stores/ApparentMediaContraintSto
 import { TrackStreamWrapperInterface } from "../Streaming/Contract/TrackStreamWrapperInterface";
 import { TrackInterface } from "../Streaming/Contract/TrackInterface";
 import { showReportScreenStore } from "../Stores/ShowReportScreenStore";
+import { RemotePlayerData } from "../Phaser/Game/RemotePlayersRepository";
 import type { ConstraintMessage, ObtainedMediaStreamConstraints } from "./P2PMessages/ConstraintMessage";
 import type { UserSimplePeerInterface } from "./SimplePeer";
 import { blackListManager } from "./BlackListManager";
@@ -56,7 +57,7 @@ export class VideoPeer extends Peer implements TrackStreamWrapperInterface {
     constructor(
         public user: UserSimplePeerInterface,
         initiator: boolean,
-        public readonly userName: string,
+        public readonly player: RemotePlayerData,
         private connection: RoomConnection
     ) {
         const bandwidth = get(videoBandwidthStore);
@@ -146,6 +147,7 @@ export class VideoPeer extends Peer implements TrackStreamWrapperInterface {
             this._statusStore.set("connected");
 
             this._connected = true;
+
             chatMessagesService.addIncomingUser(this.userId);
 
             this.newMessageSubscription = newChatMessageSubject.subscribe((newMessage) => {
@@ -393,6 +395,6 @@ export class VideoPeer extends Peer implements TrackStreamWrapperInterface {
         this.connection.emitKickOffUserMessage(this.userUuid, "peer");
     }
     blockOrReportUser(): void {
-        showReportScreenStore.set({ userId: this.userId, userName: this.userName });
+        showReportScreenStore.set({ userId: this.userId, userName: this.player.name });
     }
 }


### PR DESCRIPTION
When a player enters a room at the place of another player, the bubble connection could be initiated before all user data is received. This can also happen in special cases where the pusher would be a bit slow or when the browser is slow too (it happens in bots in particular).

Now, when a WebRTC connection is established, if we don't have the data associated with the player ID (yet), we wait 5 seconds for the data to arrive.

As a result, when someone enters a room and directly starts a conversation in a bubble, everything happens correctly (there is no "Unknown" user)