### PR TITLE
Fixing loading of maps on back with relative TMJ path

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -137,13 +137,7 @@ export class GameRoom implements BrothersFinder {
             mapUrl = mapDetails.mapUrl;
         } else if (wamUrl) {
             wamFile = await mapFetcher.fetchWamFile(wamUrl, INTERNAL_MAP_STORAGE_URL, PUBLIC_MAP_STORAGE_PREFIX);
-            try {
-                new URL(wamFile.mapUrl);
-                mapUrl = wamFile.mapUrl;
-            } catch (e) {
-                console.info("Map URL is not a valid URL, trying to normalize it", e);
-                mapUrl = mapFetcher.normalizeMapUrl(wamUrl, wamFile.mapUrl);
-            }
+            mapUrl = new URL(wamFile.mapUrl, wamUrl).toString();
         } else {
             throw new Error("No mapUrl or wamUrl");
         }

--- a/libs/map-editor/src/MapFetcher.ts
+++ b/libs/map-editor/src/MapFetcher.ts
@@ -21,13 +21,7 @@ class MapFetcher {
             throw new Error("Both mapUrl and wamUrl are undefined. Can't get mapUrl.");
         }
         const mapPath = (await this.fetchWamFile(wamUrl, internalMapStorageUrl, stripPrefix)).mapUrl;
-        try {
-            new URL(mapPath);
-            return mapPath;
-        } catch (e) {
-            console.info("Map URL is not a valid URL, trying to normalize it", e);
-            return this.normalizeMapUrl(mapPath, wamUrl);
-        }
+        return new URL(mapPath, wamUrl).toString();
     }
 
     normalizeMapUrl(mapUrl: string, wamUrl: string): string {

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -264,7 +264,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             floatingObject: "Objet flottant",
             floatingObjectDescription:
                 "Un objet flottant peut être placé librement sur la carte. Autrement, il sera aligné sur la grille de la carte.",
-            depth: "Prodondeur",
+            depth: "Profondeur",
             groundLevel: "Au sol",
             custom: "Personnalisé",
             standing: "Debout",


### PR DESCRIPTION
When a mapUrl is relative, the loading of the TMJ file on the back side was failing.