### PR TITLE
Fixing proximityChat scripting getting stuck

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2077,6 +2077,14 @@ export class GameScene extends DirtyScene {
                 statusChanger.applyInteractionRules();
 
                 pendingConnects.add(peer.userId);
+                setTimeout(() => {
+                    // In case the peer never connects, we should remove it from the pendingConnects after a timeout
+                    pendingConnects.delete(peer.userId);
+                    /*if (pendingConnects.size === 0 && !alreadyInBubble && !this.cleanupDone) {
+                        iframeListener.sendJoinProximityMeetingEvent(Array.from(newUsers.values()));
+                        alreadyInBubble = true;
+                    }*/
+                }, 5000);
                 peer.once("connect", () => {
                     pendingConnects.delete(peer.userId);
                     if (pendingConnects.size === 0) {
@@ -2114,6 +2122,14 @@ export class GameScene extends DirtyScene {
                         const peer = peers.get(newUser.userId);
                         if (peer) {
                             pendingConnects.add(newUser.userId);
+                            setTimeout(() => {
+                                // In case the peer never connects, we should remove it from the pendingConnects after a timeout
+                                pendingConnects.delete(newUser.userId);
+                                /*if (pendingConnects.size === 0 && !alreadyInBubble && !this.cleanupDone) {
+                                    iframeListener.sendJoinProximityMeetingEvent(Array.from(newUsers.values()));
+                                    alreadyInBubble = true;
+                                }*/
+                            }, 5000);
                             peer.once("connect", () => {
                                 pendingConnects.delete(newUser.userId);
                                 if (pendingConnects.size === 0) {


### PR DESCRIPTION
In the event a user fails to connect within the proximity chat, this user  would stay in "pendingConnect" mode and would prevent the "joinProximityMeetingEvent" to be sent correctly. We now add a timeout to clean "pendingConnects" after 5 seconds.