### PR TITLE
Reading custom Matrix server from the OpenID provider

### DIFF
--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -281,12 +281,18 @@ export class AuthenticateController extends BaseHttpController {
                 email ? matrixProvider.getBareMatrixIdFromEmail(email) : undefined
             );
 
+            const matrixPublicUri = userInfo.matrix_url ?? MATRIX_PUBLIC_URI;
+
             // If Matrix is configured, we need to get an access token for the Synapse server
-            if (MATRIX_PUBLIC_URI) {
+            if (matrixPublicUri) {
                 // TODO: check Matrix server login parameters to be sure we can connect
 
                 const matrixCallbackUrl = new URL("/matrix-callback", PUSHER_URL).toString();
-                const matrixRedirectUrl = new URL("/_matrix/client/r0/login/sso/redirect", MATRIX_PUBLIC_URI);
+                let redirectPath = "/_matrix/client/v3/login/sso/redirect";
+                if (userInfo.matrix_identity_provider) {
+                    redirectPath += "/" + userInfo.matrix_identity_provider;
+                }
+                const matrixRedirectUrl = new URL(redirectPath, matrixPublicUri);
                 matrixRedirectUrl.searchParams.append("redirectUrl", matrixCallbackUrl);
 
                 res.atomic(() => {

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -872,18 +872,18 @@ export class IoSocketController {
                                 };
                                 switch (message.message.queryMessage.query?.$case) {
                                     case "roomTagsQuery": {
-                                        void socketManager.handleRoomTagsQuery(socket, message.message.queryMessage);
+                                        await socketManager.handleRoomTagsQuery(socket, message.message.queryMessage);
                                         break;
                                     }
                                     case "embeddableWebsiteQuery": {
-                                        void socketManager.handleEmbeddableWebsiteQuery(
+                                        await socketManager.handleEmbeddableWebsiteQuery(
                                             socket,
                                             message.message.queryMessage
                                         );
                                         break;
                                     }
                                     case "roomsFromSameWorldQuery": {
-                                        void socketManager.handleRoomsFromSameWorldQuery(
+                                        await socketManager.handleRoomsFromSameWorldQuery(
                                             socket,
                                             message.message.queryMessage
                                         );

--- a/play/src/pusher/services/AdminApi.ts
+++ b/play/src/pusher/services/AdminApi.ts
@@ -1,7 +1,8 @@
 import type { AxiosResponse } from "axios";
 import axios, { isAxiosError } from "axios";
-import type { AdminApiData, ChatMemberData, MapDetailsData, MemberData, RoomRedirect } from "@workadventure/messages";
+import type { AdminApiData, ChatMemberData, MapDetailsData, RoomRedirect } from "@workadventure/messages";
 import {
+    MemberData,
     Capabilities,
     CompanionDetail,
     ErrorApiData,
@@ -1050,11 +1051,11 @@ class AdminApi implements AdminInterface {
      *            $ref: '#/definitions/MemberData'
      */
     async searchMembers(playUri: string | null, searchText: string): Promise<MemberData[]> {
-        const response = await axios.get<MemberData[]>(ADMIN_API_URL + "/api/members", {
+        const response = await axios.get<unknown>(ADMIN_API_URL + "/api/members", {
             params: { playUri, searchText },
             headers: { Authorization: `${ADMIN_API_TOKEN}` },
         });
-        return response.data ? response.data : [];
+        return MemberData.array().parse(response.data);
     }
 
     /**

--- a/play/src/pusher/services/OpenIDClient.ts
+++ b/play/src/pusher/services/OpenIDClient.ts
@@ -112,6 +112,8 @@ class OpenIDClient {
         access_token: string;
         username: string;
         locale: string;
+        matrix_url: string | undefined;
+        matrix_identity_provider: string | undefined;
     }> {
         const fullUrl = req.url;
         const cookies = req.cookies;
@@ -147,6 +149,8 @@ class OpenIDClient {
                         username: res[OPID_USERNAME_CLAIM] as string,
                         locale: res[OPID_LOCALE_CLAIM] as string,
                         tags: res[OPID_TAGS_CLAIM] as string[],
+                        matrix_url: res.matrix_url as string | undefined,
+                        matrix_identity_provider: res.matrix_identity_provider as string | undefined,
                     };
                 });
             });


### PR DESCRIPTION
The OpenID provider can now return a custom Matrix server. The /userinfo endpoint can return a "matrix_url" and "matrix_identity_provider" fields. Those fields will be used to redirect the user to a custom Matrix server after login.