### PR TITLE
Fix the keyboard issue when the Woka moves during map editing.

### DIFF
--- a/play/src/front/Phaser/UserInput/UserInputManager.ts
+++ b/play/src/front/Phaser/UserInput/UserInputManager.ts
@@ -241,6 +241,15 @@ export class UserInputManager {
         eventsMap.set(UserInputEvent.JoystickMove, this.joystickEvents.any());
         this.keysCode.forEach((d) => {
             if (d.keyInstance?.isDown) {
+                // Fix mac keyboard issue
+                // Prevents the input from being triggered when the focus is on an input field
+                if (
+                    d.keyInstance.originalEvent.target instanceof HTMLInputElement ||
+                    d.keyInstance.originalEvent.target instanceof HTMLTextAreaElement
+                ) {
+                    d.keyInstance.reset();
+                    return;
+                }
                 eventsMap.set(d.event, true);
             }
         });


### PR DESCRIPTION
When we try to edit the properties of objects in the map editor, sometimes the Woka moves in one direction. This is currently happening on the Mac computer. I resolved this problem by examining if the keyboard down has an input or area HTML element target when the user moves. If the answer is positive, it can be inferred that the user is typing into the input or text element and unable to move Woka.