### PR TITLE
Adding the playUri parameter to the userinfo endpoint

### DIFF
--- a/.github/workflows/room-api-push-to-npm.yml
+++ b/.github/workflows/room-api-push-to-npm.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -257,7 +257,7 @@ export class AuthenticateController extends BaseHttpController {
 
             let userInfo = null;
             try {
-                userInfo = await openIDClient.getUserInfo(req, res);
+                userInfo = await openIDClient.getUserInfo(req, res, playUri);
             } catch (err) {
                 //if no access on openid provider, return error
                 Sentry.captureException("An error occurred while connecting to OpenID Provider => " + err);

--- a/play/src/pusher/services/OpenIDClient.ts
+++ b/play/src/pusher/services/OpenIDClient.ts
@@ -104,7 +104,8 @@ class OpenIDClient {
 
     public getUserInfo(
         req: Request,
-        res: Response
+        res: Response,
+        playUri: string
     ): Promise<{
         tags: string[] | undefined;
         email: string;
@@ -140,19 +141,25 @@ class OpenIDClient {
                 res.clearCookie("code_verifier");
                 res.clearCookie("oidc_state");
 
-                return client.userinfo(tokenSet).then((res) => {
-                    return {
-                        ...res,
-                        email: res.email ?? "",
-                        sub: res.sub,
-                        access_token: tokenSet.access_token ?? "",
-                        username: res[OPID_USERNAME_CLAIM] as string,
-                        locale: res[OPID_LOCALE_CLAIM] as string,
-                        tags: res[OPID_TAGS_CLAIM] as string[],
-                        matrix_url: res.matrix_url as string | undefined,
-                        matrix_identity_provider: res.matrix_identity_provider as string | undefined,
-                    };
-                });
+                return client
+                    .userinfo(tokenSet, {
+                        params: {
+                            playUri,
+                        },
+                    })
+                    .then((res) => {
+                        return {
+                            ...res,
+                            email: res.email ?? "",
+                            sub: res.sub,
+                            access_token: tokenSet.access_token ?? "",
+                            username: res[OPID_USERNAME_CLAIM] as string,
+                            locale: res[OPID_LOCALE_CLAIM] as string,
+                            tags: res[OPID_TAGS_CLAIM] as string[],
+                            matrix_url: res.matrix_url as string | undefined,
+                            matrix_identity_provider: res.matrix_identity_provider as string | undefined,
+                        };
+                    });
             });
         });
     }


### PR DESCRIPTION
When WorkAdventure calls the userinfo endpoint of a SSO token, it will pass in addition the playUrl GET parameter. This can be used by admins to return specific data based on the room the login is attempted from.