### PR TITLE
Removing admin to external admin API doc

### DIFF
--- a/play/src/pusher/controllers/SwaggerController.ts
+++ b/play/src/pusher/controllers/SwaggerController.ts
@@ -64,161 +64,6 @@ export class SwaggerController extends BaseHttpController {
             });
         });
 
-        this.app.get("/openapi/external-admin", (req, res) => {
-            // Let's load the module dynamically (it may not exist in prod because part of the -dev packages)
-            const options = {
-                swagger: "2.0",
-                //openapi: "3.0.0",
-                info: {
-                    title: "WorkAdventure External Admin",
-                    version: "1.0.0",
-                    description:
-                        "This is a documentation about the external endpoints called by the pusher (aka the Admin API). \n Those endpoints should be implemented by the Admin API. The pusher will access those endpoints (just like webhooks). You can find out more about WorkAdventure and the Admin API on [GitHub](https://github.com/thecodingmachine/workadventure/blob/develop/docs/dev/adminAPI.md).",
-                    contact: {
-                        email: "hello@workadventu.re",
-                    },
-                },
-                tags: [
-                    {
-                        name: "ExternalAdminAPI",
-                        description: "Access to end points of the external admin from the pusher",
-                    },
-                ],
-                securityDefinitions: {
-                    Header: {
-                        type: "apiKey",
-                        name: "Authorization",
-                        in: "header",
-                    },
-                },
-                ...SwaggerGenerator.definitions("external"),
-                paths: {
-                    "/api/mapinformation": {
-                        get: {
-                            security: [
-                                {
-                                    Header: [],
-                                },
-                            ],
-                            tags: ["ExternalAdminAPI"],
-                            parameters: [
-                                {
-                                    name: "playUri",
-                                    in: "query",
-                                    description: "The full URL of WorkAdventure",
-                                    required: true,
-                                    type: "string",
-                                    example: "http://example.com/@/teamSlug/worldSLug/roomSlug",
-                                },
-                            ],
-                            responses: {
-                                200: {
-                                    description: "The details of the map",
-                                    schema: {
-                                        $ref: "#/definitions/MapDetailsData",
-                                    },
-                                },
-                                401: {
-                                    description: "Error while retrieving the data because you are not authorized",
-                                    schema: {
-                                        $ref: "#/definitions/ErrorApiUnauthorizedData",
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    "/api/roomaccess": {
-                        get: {
-                            security: [
-                                {
-                                    Header: [],
-                                },
-                            ],
-                            tags: ["ExternalAdminAPI"],
-                            parameters: [
-                                {
-                                    name: "playUri",
-                                    in: "query",
-                                    description: "The full URL of WorkAdventure",
-                                    required: true,
-                                    type: "string",
-                                    example: "http://example.com/@/teamSlug/worldSLug/roomSlug",
-                                },
-                                {
-                                    name: "ipAddress",
-                                    in: "query",
-                                    description:
-                                        "IP Address of the user logged in, allows you to check whether a user has been banned or not",
-                                    required: true,
-                                    type: "string",
-                                    example: "127.0.0.1",
-                                },
-                                {
-                                    name: "userIdentifier",
-                                    in: "query",
-                                    description:
-                                        "The identifier of the current user \n It can be null or an uuid or an email",
-                                    type: "string",
-                                    example: "998ce839-3dea-4698-8b41-ebbdf7688ad9",
-                                },
-                            ],
-                            responses: {
-                                200: {
-                                    description: "The details of the member if he can access this room",
-                                    schema: {
-                                        $ref: "#/definitions/FetchMemberDataByUuidResponse",
-                                    },
-                                },
-                                401: {
-                                    description: "Error while retrieving the data because you are not authorized",
-                                    schema: {
-                                        $ref: "#/definitions/ErrorApiUnauthorizedData",
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    "/api/loginurl/{organizationMemberToken}": {
-                        get: {
-                            security: [
-                                {
-                                    Header: [],
-                                },
-                            ],
-                            description: "Returns a member from the token",
-                            tags: ["ExternalAdminAPI"],
-                            parameters: [
-                                {
-                                    name: "organizationMemberToken",
-                                    in: "path",
-                                    description: "The token of member in the organization",
-                                    required: true,
-                                    type: "string",
-                                },
-                            ],
-                            responses: {
-                                200: {
-                                    description: "The details of the member",
-                                    schema: {
-                                        $ref: "#/definitions/AdminApiData",
-                                    },
-                                },
-                                401: {
-                                    description: "Error while retrieving the data because you are not authorized",
-                                    schema: {
-                                        $ref: "#/definitions/ErrorApiUnauthorizedData",
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            };
-            res.atomic(() => {
-                res.json(options);
-            });
-        });
-
         // Create static serve route to serve index.html
         this.app.get("/swagger-ui/", (request, response) => {
             fs.readFile(process.cwd() + "/../node_modules/swagger-ui-dist/index.html", "utf8", function (err, data) {
@@ -233,11 +78,10 @@ export class SwaggerController extends BaseHttpController {
                 const urls = [
                     { url: "/openapi/pusher", name: "Front -> Pusher <- Admin" },
                     { url: "/openapi/admin", name: "Pusher -> Admin" },
-                    { url: "/openapi/external-admin", name: "Admin -> External Admin" },
                 ];
                 const swaggerScript = `<script charset="UTF-8">window.onload = function() {
                     window.ui = SwaggerUIBundle({
-                        urls: ${JSON.stringify(urls)}, "urls.primaryName": "Admin -> External Admin",
+                        urls: ${JSON.stringify(urls)}, "urls.primaryName": "Pusher -> Admin",
                         dom_id: '#swagger-ui',
                         deepLinking: true,
                         presets: [

--- a/tests/tests/swagger_doc.spec.ts
+++ b/tests/tests/swagger_doc.spec.ts
@@ -1,46 +1,6 @@
 import {expect, test} from '@playwright/test';
 
 test.describe('Swagger documentation', () => {
-    test('Admin -> External Admin', async ({page}, { project }) => {
-        // Skip test for mobile device
-        if(project.name === "mobilechromium") {
-            //eslint-disable-next-line playwright/no-skipped-test
-            test.skip();
-            return;
-        }
-
-        await page.goto(
-            `/swagger-ui/?urls.primaryName=Admin%20->%20External%20Admin`
-        );
-
-        // Test if the component "operations-ExternalAdminAPI-get_api_mapinformation" is visible
-        await expect(page.locator('#operations-ExternalAdminAPI-get_api_mapinformation')).toBeVisible();
-
-        // Test if the component "operations-ExternalAdminAPI-get_api_roomaccess" is visible
-        await expect(page.locator('#operations-ExternalAdminAPI-get_api_roomaccess')).toBeVisible();
-
-        // Test if the component "operations-ExternalAdminAPI-get_api_loginurl__organizationMemberToken_" is visible
-        await expect(page.locator('#operations-ExternalAdminAPI-get_api_loginurl__organizationMemberToken_')).toBeVisible();
-
-        // Test if the component "model-AdminApiData" is visible
-        await expect(page.locator('#model-AdminApiData')).toBeVisible();
-
-        // Test if the component "model-ErrorApiUnauthorizedData" is visible
-        await expect(page.locator('#model-ErrorApiUnauthorizedData')).toBeVisible();
-
-        // Test if the component "model-FetchMemberDataByUuidResponse" is visible
-        await expect(page.locator('#model-FetchMemberDataByUuidResponse')).toBeVisible();
-
-        // Test if the component "model-MapDetailsData" is visible
-        await expect(page.locator('#model-MapDetailsData')).toBeVisible();
-
-        // Test if the component "model-RoomRedirect" is visible
-        await expect(page.locator('#model-RoomRedirect')).toBeVisible();
-
-        // Test if the component "model-WokaDetail" is visible
-        await expect(page.locator('#model-WokaDetail')).toBeVisible();
-    });
-
     test('Pusher -> Admin', async ({page}, { project }) => {
         // Skip test for mobile device
         if(project.name === "mobilechromium") {


### PR DESCRIPTION
The "outbound" API from the admin has been removed from the SAAS version 1 month ago. This piece of doc should therefore be removed too.