### PR TITLE
Fix Svelet Crash

### DIFF
--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -116,8 +116,8 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
             .getEntityPrefab(data.prefabRef.collectionName, data.prefabRef.id);
         if (prefab === undefined) {
             console.warn(`Could not find entity ${data.prefabRef.id} in collection ${data.prefabRef.collectionName}`);
-            throw new Error(
-                `Could not find entity ${data.prefabRef.id} in collection ${data.prefabRef.collectionName}`
+            return Promise.reject(
+                new Error(`Could not find entity ${data.prefabRef.id} in collection ${data.prefabRef.collectionName}`)
             );
         }
 


### PR DESCRIPTION
When we are trying to add entity and information doesn't existe, the svelte component crash WorkAdventure is useless. Correct that to reject promise.