### PR TITLE
Fixing collision grid when an area has restricted access rights

### DIFF
--- a/libs/map-editor/src/GameMap/GameMapAreas.ts
+++ b/libs/map-editor/src/GameMap/GameMapAreas.ts
@@ -139,6 +139,16 @@ export class GameMapAreas {
         return areaRightTags.some((tag) => userConnectedTags.includes(tag));
     }
 
+    public hasAreaAccess(area: AreaData, userConnectedTags: string[]) {
+        const areaRights = this.getAreaRightPropertyData(area);
+        if (areaRights === undefined) {
+            return true;
+        }
+
+        const areaRightTags = [...areaRights.writeTags, ...areaRights.readTags];
+        return areaRightTags.some((tag) => userConnectedTags.includes(tag));
+    }
+
     public isOverlappingArea(areaId: string): boolean {
         const area = this.getArea(areaId);
         if (area === undefined) {
@@ -431,5 +441,12 @@ export class GameMapAreas {
             }
         }
         return flattenedProperties;
+    }
+
+    /**
+     * Returns the list of all areas that the user has no access to.
+     */
+    public getCollidingAreas(userConnectedTags: string[]): AreaData[] {
+        return Array.from(this.areas.values()).filter((area) => !this.hasAreaAccess(area, userConnectedTags));
     }
 }

--- a/play/src/front/Phaser/Game/GameMap/AreasManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/AreasManager.ts
@@ -14,8 +14,8 @@ export class AreasManager {
     constructor(
         private scene: GameScene,
         private gameMapAreas: GameMapAreas,
-        userConnectedTags: string[],
-        userCanEdit: boolean
+        private userConnectedTags: string[],
+        private userCanEdit: boolean
     ) {
         this.areaPermissions = new AreaPermissions(gameMapAreas, userConnectedTags, userCanEdit);
         this.initializeAreas();
@@ -77,5 +77,15 @@ export class AreasManager {
 
     public getAreaByUd(areaId: string): Area | undefined {
         return this.areas.find((area) => area.areaData.id === areaId);
+    }
+
+    /**
+     * Returns the list of all areas that the user has no access to.
+     */
+    public getCollidingAreas(): AreaData[] {
+        if (this.userCanEdit) {
+            return [];
+        }
+        return this.gameMapAreas.getCollidingAreas(this.userConnectedTags);
     }
 }

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/CreateAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/CreateAreaFrontCommand.ts
@@ -21,7 +21,7 @@ export class CreateAreaFrontCommand extends CreateAreaCommand implements FrontCo
     public async execute(): Promise<void> {
         await super.execute();
         this.areaEditorTool.handleAreaCreation(this.areaConfig, this.localCommand);
-        this.gameMapFrontWrapper.recomputeEntitiesAndAreasCollisionGrid();
+        this.gameMapFrontWrapper.recomputeAreasCollisionGrid();
     }
 
     public getUndoCommand(): DeleteAreaFrontCommand {

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/CreateAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/CreateAreaFrontCommand.ts
@@ -3,6 +3,7 @@ import { AreaEditorTool } from "../../Tools/AreaEditorTool";
 import { FrontCommandInterface } from "../FrontCommandInterface";
 import { TrashEditorTool } from "../../Tools/TrashEditorTool";
 import { RoomConnection } from "../../../../../Connection/RoomConnection";
+import { GameMapFrontWrapper } from "../../../GameMap/GameMapFrontWrapper";
 import { DeleteAreaFrontCommand } from "./DeleteAreaFrontCommand";
 
 export class CreateAreaFrontCommand extends CreateAreaCommand implements FrontCommandInterface {
@@ -11,7 +12,8 @@ export class CreateAreaFrontCommand extends CreateAreaCommand implements FrontCo
         areaObjectConfig: AreaData,
         commandId: string | undefined,
         private areaEditorTool: AreaEditorTool | TrashEditorTool,
-        private localCommand: boolean
+        private localCommand: boolean,
+        private gameMapFrontWrapper: GameMapFrontWrapper
     ) {
         super(gameMap, areaObjectConfig, commandId);
     }
@@ -19,10 +21,17 @@ export class CreateAreaFrontCommand extends CreateAreaCommand implements FrontCo
     public async execute(): Promise<void> {
         await super.execute();
         this.areaEditorTool.handleAreaCreation(this.areaConfig, this.localCommand);
+        this.gameMapFrontWrapper.recomputeEntitiesAndAreasCollisionGrid();
     }
 
     public getUndoCommand(): DeleteAreaFrontCommand {
-        return new DeleteAreaFrontCommand(this.gameMap, this.areaConfig.id, undefined, this.areaEditorTool);
+        return new DeleteAreaFrontCommand(
+            this.gameMap,
+            this.areaConfig.id,
+            undefined,
+            this.areaEditorTool,
+            this.gameMapFrontWrapper
+        );
     }
 
     public emitEvent(roomConnection: RoomConnection): void {

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/DeleteAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/DeleteAreaFrontCommand.ts
@@ -23,6 +23,9 @@ export class DeleteAreaFrontCommand extends DeleteAreaCommand implements FrontCo
         const returnVal = super.execute();
 
         this.editorTool.handleAreaDeletion(this.areaId, area);
+
+        this.gameMapFrontWrapper.recomputeAreasCollisionGrid();
+
         return returnVal;
     }
 

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/DeleteAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/DeleteAreaFrontCommand.ts
@@ -4,6 +4,7 @@ import { FrontCommandInterface } from "../FrontCommandInterface";
 import { RoomConnection } from "../../../../../Connection/RoomConnection";
 import { TrashEditorTool } from "../../Tools/TrashEditorTool";
 import { VoidFrontCommand } from "../VoidFrontCommand";
+import { GameMapFrontWrapper } from "../../../GameMap/GameMapFrontWrapper";
 import { CreateAreaFrontCommand } from "./CreateAreaFrontCommand";
 
 export class DeleteAreaFrontCommand extends DeleteAreaCommand implements FrontCommandInterface {
@@ -11,7 +12,8 @@ export class DeleteAreaFrontCommand extends DeleteAreaCommand implements FrontCo
         gameMap: GameMap,
         areaId: string,
         commandId: string | undefined,
-        private editorTool: AreaEditorTool | TrashEditorTool
+        private editorTool: AreaEditorTool | TrashEditorTool,
+        private gameMapFrontWrapper: GameMapFrontWrapper
     ) {
         super(gameMap, areaId, commandId);
     }
@@ -28,7 +30,14 @@ export class DeleteAreaFrontCommand extends DeleteAreaCommand implements FrontCo
         if (!this.areaConfig) {
             return new VoidFrontCommand();
         }
-        return new CreateAreaFrontCommand(this.gameMap, this.areaConfig, undefined, this.editorTool, false);
+        return new CreateAreaFrontCommand(
+            this.gameMap,
+            this.areaConfig,
+            undefined,
+            this.editorTool,
+            false,
+            this.gameMapFrontWrapper
+        );
     }
 
     public emitEvent(roomConnection: RoomConnection): void {

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/UpdateAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/UpdateAreaFrontCommand.ts
@@ -2,6 +2,7 @@ import { AreaData, AtLeast, GameMap, UpdateAreaCommand } from "@workadventure/ma
 import { AreaEditorTool } from "../../Tools/AreaEditorTool";
 import { FrontCommandInterface } from "../FrontCommandInterface";
 import { RoomConnection } from "../../../../../Connection/RoomConnection";
+import { GameMapFrontWrapper } from "../../../GameMap/GameMapFrontWrapper";
 
 export class UpdateAreaFrontCommand extends UpdateAreaCommand implements FrontCommandInterface {
     constructor(
@@ -9,7 +10,8 @@ export class UpdateAreaFrontCommand extends UpdateAreaCommand implements FrontCo
         dataToModify: AtLeast<AreaData, "id">,
         commandId: string | undefined,
         oldConfig: AtLeast<AreaData, "id"> | undefined,
-        private areaEditorTool: AreaEditorTool
+        private areaEditorTool: AreaEditorTool,
+        private gameMapFrontWrapper: GameMapFrontWrapper
     ) {
         super(gameMap, dataToModify, commandId, oldConfig);
     }
@@ -18,11 +20,20 @@ export class UpdateAreaFrontCommand extends UpdateAreaCommand implements FrontCo
         const returnVal = await super.execute();
         this.areaEditorTool.handleAreaUpdate(this.oldConfig, this.newConfig);
 
+        this.gameMapFrontWrapper.recomputeEntitiesAndAreasCollisionGrid();
+
         return returnVal;
     }
 
     public getUndoCommand(): UpdateAreaFrontCommand {
-        return new UpdateAreaFrontCommand(this.gameMap, this.oldConfig, undefined, this.newConfig, this.areaEditorTool);
+        return new UpdateAreaFrontCommand(
+            this.gameMap,
+            this.oldConfig,
+            undefined,
+            this.newConfig,
+            this.areaEditorTool,
+            this.gameMapFrontWrapper
+        );
     }
 
     public emitEvent(roomConnection: RoomConnection): void {

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/UpdateAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/UpdateAreaFrontCommand.ts
@@ -20,7 +20,7 @@ export class UpdateAreaFrontCommand extends UpdateAreaCommand implements FrontCo
         const returnVal = await super.execute();
         this.areaEditorTool.handleAreaUpdate(this.oldConfig, this.newConfig);
 
-        this.gameMapFrontWrapper.recomputeEntitiesAndAreasCollisionGrid();
+        this.gameMapFrontWrapper.recomputeAreasCollisionGrid();
 
         return returnVal;
     }

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Entity/ModifyCustomEntityFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Entity/ModifyCustomEntityFrontCommand.ts
@@ -26,7 +26,7 @@ export class ModifyCustomEntityFrontCommand extends ModifyCustomEntityCommand im
         if (depthOffset !== undefined) {
             this.entitiesManager.updateEntitiesDepth(id, depthOffset);
         }
-        this.gameFrontWrapper.recomputeEntitiesCollisionGrid();
+        this.gameFrontWrapper.recomputeEntitiesAndAreasCollisionGrid();
         return super.execute();
     }
 

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Entity/ModifyCustomEntityFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Entity/ModifyCustomEntityFrontCommand.ts
@@ -26,7 +26,7 @@ export class ModifyCustomEntityFrontCommand extends ModifyCustomEntityCommand im
         if (depthOffset !== undefined) {
             this.entitiesManager.updateEntitiesDepth(id, depthOffset);
         }
-        this.gameFrontWrapper.recomputeEntitiesAndAreasCollisionGrid();
+        this.gameFrontWrapper.recomputeEntitiesCollisionGrid();
         return super.execute();
     }
 

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -490,7 +490,8 @@ export class MapEditorModeManager {
                 areaDataToClaim,
                 undefined,
                 oldAreaData,
-                this.editorTools.AreaEditor as AreaEditorTool
+                this.editorTools.AreaEditor as AreaEditorTool,
+                this.scene.getGameMapFrontWrapper()
             )
         ).catch((error) => console.error(error));
     }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -133,7 +133,8 @@ export class AreaEditorTool extends MapEditorTool {
                         },
                         commandId,
                         undefined,
-                        this
+                        this,
+                        this.scene.getGameMapFrontWrapper()
                     )
                 );
                 break;
@@ -146,7 +147,14 @@ export class AreaEditorTool extends MapEditorTool {
                 };
                 // execute command locally
                 await this.mapEditorModeManager.executeLocalCommand(
-                    new CreateAreaFrontCommand(this.scene.getGameMap(), config, commandId, this, false)
+                    new CreateAreaFrontCommand(
+                        this.scene.getGameMap(),
+                        config,
+                        commandId,
+                        this,
+                        false,
+                        this.scene.getGameMapFrontWrapper()
+                    )
                 );
                 break;
             }
@@ -154,7 +162,13 @@ export class AreaEditorTool extends MapEditorTool {
                 const data = editMapCommandMessage.editMapMessage?.message.deleteAreaMessage;
                 // execute command locally
                 await this.mapEditorModeManager.executeLocalCommand(
-                    new DeleteAreaFrontCommand(this.scene.getGameMap(), data.id, commandId, this)
+                    new DeleteAreaFrontCommand(
+                        this.scene.getGameMap(),
+                        data.id,
+                        commandId,
+                        this,
+                        this.scene.getGameMapFrontWrapper()
+                    )
                 );
                 break;
             }
@@ -167,7 +181,8 @@ export class AreaEditorTool extends MapEditorTool {
             this.scene.getGameMap(),
             areaId,
             undefined,
-            editorTool ?? this
+            editorTool ?? this,
+            this.scene.getGameMapFrontWrapper()
         );
         if (isPersonalArea) {
             const entitiesInsideArea = this.getEntitiesInsideArea(areaId);
@@ -547,7 +562,8 @@ export class AreaEditorTool extends MapEditorTool {
                     },
                     undefined,
                     this,
-                    true
+                    true,
+                    this.scene.getGameMapFrontWrapper()
                 )
             )
             .catch((e) => console.error(e));
@@ -571,7 +587,8 @@ export class AreaEditorTool extends MapEditorTool {
                     },
                     undefined,
                     this,
-                    true
+                    true,
+                    this.scene.getGameMapFrontWrapper()
                 )
             )
             .catch((e) => console.error(e));
@@ -620,7 +637,16 @@ export class AreaEditorTool extends MapEditorTool {
             this.removeAreaEntities(newData.id);
         }
         this.mapEditorModeManager
-            .executeCommand(new UpdateAreaFrontCommand(gameMap, newData, undefined, oldData, this))
+            .executeCommand(
+                new UpdateAreaFrontCommand(
+                    gameMap,
+                    newData,
+                    undefined,
+                    oldData,
+                    this,
+                    this.scene.getGameMapFrontWrapper()
+                )
+            )
             .catch((error) => console.error(error));
     }
 


### PR DESCRIPTION
The collision grid used by the Easystar library was not updated to reflect collision zones created by restricted access rights zones. As a result, it was possible to enter a restricted zone with a right click.

This commit fixes the collision grid.