### PR TITLE
Attempt to use a fieldMask for space user updates

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -59,6 +59,7 @@
     "mkdirp": "^1.0.4",
     "openapi3-ts": "^3.0.2",
     "prom-client": "^12.0.0",
+    "protobuf-fieldmask": "^2.0.0",
     "query-string": "^6.13.3",
     "redis": "^4.3.1",
     "source-map-support": "^0.5.21",

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -1461,10 +1461,21 @@ export class SocketManager {
     }
 
     handleUpdateSpaceUserMessage(pusher: SpacesWatcher, updateSpaceUserMessage: UpdateSpaceUserMessage) {
-        const space = this.spaces.get(updateSpaceUserMessage.spaceName);
-        if (space && updateSpaceUserMessage.user) {
-            space.updateUser(pusher, updateSpaceUserMessage.user);
+        const updateMask = updateSpaceUserMessage.updateMask;
+        if (!updateSpaceUserMessage.user || !updateMask) {
+            console.error("UpdateSpaceUserMessage has no user or updateMask");
+            Sentry.captureException("UpdateSpaceUserMessage has no user or updateMask");
+            return;
         }
+
+        const space = this.spaces.get(updateSpaceUserMessage.spaceName);
+        if (!space) {
+            console.error("Could not find space to update in UpdateSpaceUserMessage");
+            Sentry.captureException("Could not find space to update in UpdateSpaceUserMessage");
+            return;
+        }
+
+        space.updateUser(pusher, updateSpaceUserMessage.user, updateMask);
     }
 
     handleRemoveSpaceUserMessage(pusher: SpacesWatcher, removeSpaceUserMessage: RemoveSpaceUserMessage) {

--- a/back/tests/Space.test.ts
+++ b/back/tests/Space.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BackToPusherSpaceMessage, PartialSpaceUser, SpaceUser } from "@workadventure/messages";
+import { BackToPusherSpaceMessage, SpaceUser } from "@workadventure/messages";
 import { mock } from "vitest-mock-extended";
 import { Space } from "../src/Model/Space";
 import { SpacesWatcher } from "../src/Model/SpacesWatcher";
@@ -82,7 +82,7 @@ describe("Space", () => {
         const watcher3 = new SpacesWatcher("uuid-watcher-3", spaceSocketToPusher3);
         space.addWatcher(watcher3);
 
-        const spaceUser: PartialSpaceUser = PartialSpaceUser.fromPartial({
+        const spaceUser: SpaceUser = SpaceUser.fromPartial({
             id: 1,
             uuid: "uuid-test",
             name: "test2",
@@ -98,7 +98,20 @@ describe("Space", () => {
             visitCardUrl: "test2",
         });
 
-        space.updateUser(watcher1, spaceUser);
+        space.updateUser(watcher1, spaceUser, [
+            "uuid",
+            "name",
+            "playUri",
+            "color",
+            "roomName",
+            "isLogged",
+            "availabilityStatus",
+            "cameraState",
+            "microphoneState",
+            "megaphoneState",
+            "screenSharingState",
+            "visitCardUrl",
+        ]);
 
         // should have received the addUser event
         expect(eventsWatcher3.some((message) => message.message?.$case === "updateSpaceUserMessage")).toBe(true);

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "google/protobuf/wrappers.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/field_mask.proto";
 
 /*********** PARTIAL MESSAGES **************/
 
@@ -1261,7 +1262,7 @@ message SpaceUser{
   google.protobuf.StringValue chatID = 17; // used
 }
 
-message PartialSpaceUser{
+/*message PartialSpaceUser{
   int32 id = 1;
   google.protobuf.StringValue name = 2;
   google.protobuf.StringValue playUri = 3;
@@ -1279,7 +1280,7 @@ message PartialSpaceUser{
   google.protobuf.StringValue jitsiParticipantId = 15;
   string uuid = 16;
   google.protobuf.StringValue chatID = 17;
-}
+}*/
 
 message AddSpaceUserMessage{
   string spaceName = 1;
@@ -1288,8 +1289,10 @@ message AddSpaceUserMessage{
 }
 message UpdateSpaceUserMessage{
   string spaceName = 1;
-  PartialSpaceUser user = 2;
+  SpaceUser user = 2;
+  // FIXME; is the filterName needed?
   google.protobuf.StringValue filterName = 3;
+  google.protobuf.FieldMask updateMask = 4;
 }
 message RemoveSpaceUserMessage{
   string spaceName = 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "mkdirp": "^1.0.4",
         "openapi3-ts": "^3.0.2",
         "prom-client": "^12.0.0",
+        "protobuf-fieldmask": "^2.0.0",
         "query-string": "^6.13.3",
         "redis": "^4.3.1",
         "source-map-support": "^0.5.21",
@@ -19765,6 +19766,17 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
     },
+    "node_modules/protobuf-fieldmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/protobuf-fieldmask/-/protobuf-fieldmask-2.0.0.tgz",
+      "integrity": "sha512-bIDu8u5EnALoATV4cjeuxesL2f/g4Tk2bkCFK0MZ/ZFHECeh+B7Eo+AYlMs/+TyhiHxfFwgBpi0BcYM0UXngGw==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
@@ -24856,6 +24868,7 @@
         "phaser3-rex-plugins": "^1.1.42",
         "posthog-js": "^1.14.1",
         "prom-client": "^14.1.0",
+        "protobuf-fieldmask": "^2.0.0",
         "qs": "^6.11.0",
         "queue-typescript": "^1.0.1",
         "quill": "1.3.7",
@@ -40474,6 +40487,14 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
     },
+    "protobuf-fieldmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/protobuf-fieldmask/-/protobuf-fieldmask-2.0.0.tgz",
+      "integrity": "sha512-bIDu8u5EnALoATV4cjeuxesL2f/g4Tk2bkCFK0MZ/ZFHECeh+B7Eo+AYlMs/+TyhiHxfFwgBpi0BcYM0UXngGw==",
+      "requires": {
+        "lodash": "^4.17.21"
+      }
+    },
     "protobufjs": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
@@ -43988,6 +44009,7 @@
         "prettier": "^2.8.1",
         "prettier-plugin-svelte": "^2.9.0",
         "prom-client": "^14.1.0",
+        "protobuf-fieldmask": "^2.0.0",
         "qs": "^6.11.0",
         "queue-typescript": "^1.0.1",
         "quill": "1.3.7",
@@ -44528,6 +44550,7 @@
         "openapi3-ts": "^3.0.2",
         "prettier": "^2.8.1",
         "prom-client": "^12.0.0",
+        "protobuf-fieldmask": "^2.0.0",
         "query-string": "^6.13.3",
         "redis": "^4.3.1",
         "source-map-support": "^0.5.21",

--- a/play/package.json
+++ b/play/package.json
@@ -151,6 +151,7 @@
     "phaser3-rex-plugins": "^1.1.42",
     "posthog-js": "^1.14.1",
     "prom-client": "^14.1.0",
+    "protobuf-fieldmask": "^2.0.0",
     "qs": "^6.11.0",
     "queue-typescript": "^1.0.1",
     "quill": "1.3.7",

--- a/play/src/front/Space/SpaceFilter/SpaceFilter.ts
+++ b/play/src/front/Space/SpaceFilter/SpaceFilter.ts
@@ -1,6 +1,5 @@
 import merge from "lodash/merge";
 import {
-    PartialSpaceUser,
     SpaceFilterContainName,
     SpaceFilterEverybody,
     SpaceFilterLiveStreaming,
@@ -30,7 +29,8 @@ export interface SpaceUserExtended extends SpaceUser {
     getWokaBase64: string;
     updateSubject: Subject<{
         newUser: SpaceUserExtended;
-        changes: PartialSpaceUser;
+        changes: SpaceUser;
+        updateMask: string[];
     }>;
     emitter: JitsiEventEmitter | undefined;
     spaceName: string;
@@ -158,7 +158,8 @@ export class SpaceFilter implements SpaceFilterInterface {
             getWokaBase64: wokaBase64,
             updateSubject: new Subject<{
                 newUser: SpaceUserExtended;
-                changes: PartialSpaceUser;
+                changes: SpaceUser;
+                updateMask: string[];
             }>(),
             emitter,
             spaceName,

--- a/play/src/front/Space/SpaceWatcher/SocketSpaceWatcher.ts
+++ b/play/src/front/Space/SpaceWatcher/SocketSpaceWatcher.ts
@@ -27,7 +27,7 @@ export class StreamSpaceWatcher {
 
         this.updateSpaceUserMessageStreamSubscription = roomConnection.updateSpaceUserMessageStream.subscribe(
             (message) => {
-                if (!message.user || !message.filterName) return;
+                if (!message.user || !message.filterName || !message.updateMask) return;
 
                 spaceProvider.get(message.spaceName).getSpaceFilter(message.filterName).updateUserData(message.user);
             }

--- a/play/src/pusher/models/Space.ts
+++ b/play/src/pusher/models/Space.ts
@@ -1,6 +1,5 @@
 import {
     AddSpaceFilterMessage,
-    PartialSpaceUser,
     PrivateEvent,
     PublicEvent,
     PusherToBackSpaceMessage,
@@ -10,6 +9,8 @@ import {
     SubMessage,
     UpdateSpaceFilterMessage,
 } from "@workadventure/messages";
+import { applyFieldMask } from "protobuf-fieldmask";
+import merge from "lodash/merge";
 import Debug from "debug";
 import * as Sentry from "@sentry/node";
 import { Socket } from "../services/SocketManager";
@@ -17,6 +18,8 @@ import { CustomJsonReplacerInterface } from "./CustomJsonReplacerInterface";
 import { BackSpaceConnection, SocketData } from "./Websocket/SocketData";
 
 type SpaceUserExtended = { lowercaseName: string } & SpaceUser;
+
+type PartialSpaceUser = Partial<Omit<SpaceUser, "id">> & Pick<SpaceUser, "id">;
 
 const debug = Debug("space");
 
@@ -103,21 +106,22 @@ export class Space implements CustomJsonReplacerInterface {
         this.notifyAll(subMessage, user);
     }
 
-    public updateUser(spaceUser: PartialSpaceUser, world: string) {
+    public updateUser(spaceUser: PartialSpaceUser, updateMask: string[]) {
         const pusherToBackSpaceMessage: PusherToBackSpaceMessage = {
             message: {
                 $case: "updateSpaceUserMessage",
                 updateSpaceUserMessage: {
                     spaceName: this.name,
-                    user: spaceUser,
+                    user: SpaceUser.fromPartial(spaceUser),
                     filterName: undefined,
+                    updateMask,
                 },
             },
         };
         this.spaceStreamToPusher.write(pusherToBackSpaceMessage);
-        this.localUpdateUser(spaceUser, world);
+        this.localUpdateUser(spaceUser, updateMask);
     }
-    public localUpdateUser(spaceUser: PartialSpaceUser, world: string) {
+    public localUpdateUser(spaceUser: PartialSpaceUser, updateMask: string[]) {
         const user = this.users.get(spaceUser.id);
         let oldUser: SpaceUserExtended | undefined;
         if (!user) {
@@ -125,61 +129,9 @@ export class Space implements CustomJsonReplacerInterface {
             return;
         }
 
-        //const updatedUser = merge(user,spaceUser) as SpaceUserExtended;
+        const updateValues = applyFieldMask(spaceUser, updateMask);
 
-        if (user) {
-            oldUser = structuredClone(user);
-            if (spaceUser.tags.length > 0) {
-                user.tags = spaceUser.tags;
-            }
-            if (spaceUser.name) {
-                user.name = spaceUser.name;
-                user.lowercaseName = spaceUser.name.toLowerCase();
-            }
-            if (spaceUser.playUri) {
-                user.playUri = spaceUser.playUri;
-            }
-            if (spaceUser.color) {
-                user.color = spaceUser.color;
-            }
-            if (spaceUser.characterTextures.length > 0) {
-                user.characterTextures = spaceUser.characterTextures;
-            }
-            if (spaceUser.isLogged !== undefined) {
-                user.isLogged = spaceUser.isLogged;
-            }
-            if (spaceUser.availabilityStatus !== undefined) {
-                user.availabilityStatus = spaceUser.availabilityStatus;
-            }
-            if (spaceUser.roomName) {
-                user.roomName = spaceUser.roomName;
-            }
-            if (spaceUser.visitCardUrl) {
-                user.visitCardUrl = spaceUser.visitCardUrl;
-            }
-            if (spaceUser.screenSharingState !== undefined) {
-                user.screenSharingState = spaceUser.screenSharingState;
-            }
-            if (spaceUser.microphoneState !== undefined) {
-                user.microphoneState = spaceUser.microphoneState;
-            }
-            if (spaceUser.cameraState !== undefined) {
-                user.cameraState = spaceUser.cameraState;
-            }
-            if (spaceUser.megaphoneState !== undefined) {
-                user.megaphoneState = spaceUser.megaphoneState;
-            }
-            if (spaceUser.jitsiParticipantId) {
-                user.jitsiParticipantId = spaceUser.jitsiParticipantId;
-            }
-            if (spaceUser.uuid) {
-                user.uuid = spaceUser.uuid;
-            }
-
-            if (spaceUser.chatID) {
-                user.chatID = spaceUser.chatID;
-            }
-        }
+        merge(user, updateValues);
 
         if (spaceUser.name) user.lowercaseName = spaceUser.name.toLowerCase();
 
@@ -189,9 +141,10 @@ export class Space implements CustomJsonReplacerInterface {
             message: {
                 $case: "updateSpaceUserMessage",
                 updateSpaceUserMessage: {
-                    spaceName: `${this.name}`,
-                    user: spaceUser,
+                    spaceName: this.name,
+                    user: SpaceUser.fromPartial(spaceUser),
                     filterName: undefined,
+                    updateMask,
                 },
             },
         };
@@ -469,7 +422,7 @@ export class Space implements CustomJsonReplacerInterface {
         this.notifyMe(watcher, subMessage);
     }
 
-    private notifyMeUpdateUser(watcher: Socket, user: SpaceUserExtended, filterName: string | undefined) {
+    /*private notifyMeUpdateUser(watcher: Socket, user: SpaceUserExtended, filterName: string | undefined) {
         const subMessage: SubMessage = {
             message: {
                 $case: "updateSpaceUserMessage",
@@ -481,7 +434,7 @@ export class Space implements CustomJsonReplacerInterface {
             },
         };
         this.notifyMe(watcher, subMessage);
-    }
+    }*/
     private notifyMeRemoveUser(watcher: Socket, user: SpaceUserExtended, filterName: string | undefined) {
         const subMessage: SubMessage = {
             message: {

--- a/play/tests/pusher/Space.test.ts
+++ b/play/tests/pusher/Space.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 import {
     AvailabilityStatus,
-    PartialSpaceUser,
     PusherToBackSpaceMessage,
     SpaceFilterMessage,
     SpaceUser,
@@ -134,7 +133,7 @@ describe("Space", () => {
     it("should notify client and back that a user is updated", () => {
         eventsClient = [];
         eventsWatcher = [];
-        const spaceUser = PartialSpaceUser.fromPartial({
+        const spaceUser = SpaceUser.fromPartial({
             id: 1,
             uuid: "uuid-test",
             name: "test2",
@@ -151,7 +150,19 @@ describe("Space", () => {
             tags: [],
             visitCardUrl: "test",
         });
-        space.updateUser(spaceUser, "");
+        space.updateUser(spaceUser, [
+            "name",
+            "playUri",
+            "color",
+            "roomName",
+            "isLogged",
+            "availabilityStatus",
+            "cameraState",
+            "microphoneState",
+            "screenSharingState",
+            "megaphoneState",
+            "visitCardUrl",
+        ]);
         expect(eventsClient.some((message) => message.message?.$case === "updateSpaceUserMessage")).toBe(true);
         expect(eventsWatcher.some((message) => message.message?.$case === "updateSpaceUserMessage")).toBe(true);
 


### PR DESCRIPTION
Trying to use a field mask to specify what part of users should be updated in a space. Using a field mask allows us to have a generic user update method on the pusher/bash side.

With this, adding a new field to a space user would simply mean updating the proto file without touching any code on the pusher or back side.