### PR TITLE
Replacing docker-compose with docker compose in CI

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Load image (for sentry)
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
-        run: docker load --input /tmp/play.tar
+        run: docker image load --input /tmp/play.tar
 
       - name: Sentry push source maps
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
@@ -181,7 +181,7 @@ jobs:
 
       - name: Load image (for sentry)
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
-        run: docker load --input /tmp/back.tar
+        run: docker image load --input /tmp/back.tar
 
       - name: Sentry push source maps
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
@@ -400,7 +400,7 @@ jobs:
 
       - name: Load image (for sentry)
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
-        run: docker load --input /tmp/map-storage.tar
+        run: docker image load --input /tmp/map-storage.tar
 
       - name: Sentry push source maps
         if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build')) }}
@@ -571,11 +571,11 @@ jobs:
           path: /tmp
       - name: Load image
         run: |
-          docker load --input /tmp/play.tar.gz
-          docker load --input /tmp/back.tar.gz
-          docker load --input /tmp/maps.tar.gz
-          docker load --input /tmp/map-storage.tar.gz
-          docker load --input /tmp/uploader.tar.gz
+          docker image load --input /tmp/play.tar.gz
+          docker image load --input /tmp/back.tar.gz
+          docker image load --input /tmp/maps.tar.gz
+          docker image load --input /tmp/map-storage.tar.gz
+          docker image load --input /tmp/uploader.tar.gz
           docker image ls -a
       - name: Start WorkAdventure
         run: |

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -579,8 +579,8 @@ jobs:
           docker image ls -a
       - name: Start WorkAdventure
         run: |
-          docker-compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml pull
-          docker-compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml up -d
+          docker compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml pull
+          docker compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml up -d
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
       - name: Upload test-map
@@ -592,18 +592,18 @@ jobs:
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
           RENDERER_MODE: ${{ matrix.renderer }}
-      - name: Display docker-compose logs on failure
-        run: docker-compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml logs
+      - name: Display docker compose logs on failure
+        run: docker compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml logs
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
       - name: Display containers state
-        run: docker-compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml ps
+        run: docker compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml ps
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
-      - name: Side-load docker-compose logs in the playwright report
-        run: docker-compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml logs > tests/playwright-report/docker-compose.log
+      - name: Side-load docker compose logs in the playwright report
+        run: docker compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml logs > tests/playwright-report/docker-compose.log
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
@@ -615,7 +615,7 @@ jobs:
           retention-days: 30
 
   prod-single-domain-deploy-tests:
-    name: "Test production docker-compose (${{ matrix.shard }}/${{ matrix.nbShards }})"
+    name: "Test production docker compose (${{ matrix.shard }}/${{ matrix.nbShards }})"
     strategy:
       fail-fast: false
       matrix:
@@ -678,7 +678,7 @@ jobs:
           KLAXOON_CLIENT_ID: ${{ secrets.KLAXOON_CLIENT_ID }}
         working-directory: contrib/docker
       - name: Start WorkAdventure
-        run: docker-compose -f docker-compose.prod.yaml -f tests/docker-compose.test-maps.yaml up -d
+        run: docker compose -f docker-compose.prod.yaml -f tests/docker-compose.test-maps.yaml up -d
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
@@ -694,20 +694,20 @@ jobs:
         working-directory: tests
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
-      - name: Display docker-compose logs on failure
-        run: docker-compose  -f docker-compose.prod.yaml -f tests/docker-compose.test-maps.yaml logs
+      - name: Display docker compose logs on failure
+        run: docker compose  -f docker-compose.prod.yaml -f tests/docker-compose.test-maps.yaml logs
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Display containers state
-        run: docker-compose  -f docker-compose.prod.yaml -f tests/docker-compose.test-maps.yaml ps
+        run: docker compose  -f docker-compose.prod.yaml -f tests/docker-compose.test-maps.yaml ps
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
-      - name: Side-load docker-compose logs in the playwright report
-        run: docker-compose  -f docker-compose.prod.yaml -f tests/docker-compose.test-maps.yaml logs > ../../tests/playwright-report/docker-compose.log
+      - name: Side-load docker compose logs in the playwright report
+        run: docker compose  -f docker-compose.prod.yaml -f tests/docker-compose.test-maps.yaml logs > ../../tests/playwright-report/docker-compose.log
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -578,9 +578,7 @@ jobs:
           docker image load --input /tmp/uploader.tar.gz
           docker image ls -a
       - name: Start WorkAdventure
-        run: |
-          docker compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml pull
-          docker compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml up -d
+        run: docker compose -f docker-compose.yaml -f docker-compose-oidc.yaml -f docker-compose.e2e.yml up -d
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
       - name: Upload test-map


### PR DESCRIPTION
It seems newer Github action runners don't have "docker-compose" any more.