### PR TITLE
Trying to install back docker-compose in CI builds

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -509,6 +509,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.14.2'
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -635,6 +638,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.14.2'
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
docker-compose was suddenly removed from Github action runners.