### PR TITLE
[WIP] Synchronizing only required player details

### DIFF
--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -1185,8 +1185,9 @@ message BackToPusherSpaceMessage{
 /**
  * Message sent by the user to join a space as a participant.
  */
-message JoinSpaceMessage{
+message JoinSpaceMessage {
   string spaceName = 1;
+  repeated string synchronizedPlayerProperties = 2;
 }
 message LeaveSpaceMessage{
   string spaceName = 1;

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -30,6 +30,7 @@ import { adminService } from "../services/AdminService";
 import { validateWebsocketQuery } from "../services/QueryValidator";
 import { SocketData } from "../models/Websocket/SocketData";
 import { emitInBatch } from "../services/IoSocketHelpers";
+import { Space } from "../models/Space";
 
 type UpgradeFailedInvalidData = {
     rejected: true;
@@ -501,7 +502,13 @@ export class IoSocketController {
                             backConnection: undefined,
                             listenedZones: new Set<Zone>(),
                             pusherRoom: undefined,
-                            spaces: [],
+                            spaces: new Map<
+                                string,
+                                {
+                                    space: Space;
+                                    synchronizedPlayerProperties: string[];
+                                }
+                            >(),
                             spacesFilters: new Map<string, SpaceFilterMessage[]>(),
                             chatID,
                             world: userData.world,
@@ -757,7 +764,7 @@ export class IoSocketController {
 
                             await socketManager.handleJoinSpace(
                                 socket,
-                                message.message.joinSpaceMessage.spaceName,
+                                message.message.joinSpaceMessage,
                                 localSpaceName
                             );
                             break;

--- a/play/src/pusher/models/Websocket/SocketData.ts
+++ b/play/src/pusher/models/Websocket/SocketData.ts
@@ -58,7 +58,14 @@ export type SocketData = {
     backConnection?: BackConnection;
     listenedZones: Set<Zone>;
     pusherRoom: PusherRoom | undefined;
-    spaces: Space[];
+    // A map mapping the name of spaces to the space and the list of properties that should be synchronized from the user details.
+    spaces: Map<
+        string,
+        {
+            space: Space;
+            synchronizedPlayerProperties: string[];
+        }
+    >;
     spacesFilters: Map<string, SpaceFilterMessage[]>;
     chatID?: string;
     world: string;


### PR DESCRIPTION
Right now, when a player details is updated, all spaces are notified. Some spaces don't need all player details.

We should whitelist the fields to be sychronized when connecting to a space.