### PR TITLE
Fixing bug when leaving space

### DIFF
--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -413,7 +413,7 @@ export class ProximityChatRoom implements ChatRoom {
             this.usersUnsubscriber();
         }
         this.users = undefined;
-        this.spaceRegistry.leaveSpace(spaceName);
+        this.spaceRegistry.leaveSpace(this._space);
         this.spaceMessageSubscription?.unsubscribe();
         this.spaceIsTypingSubscription?.unsubscribe();
 

--- a/play/src/front/Phaser/Game/MapEditor/Tools/CloseTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/CloseTool.ts
@@ -7,10 +7,10 @@ import { MapEditorTool } from "./MapEditorTool";
 
 export class CloseTool implements MapEditorTool {
     public update(time: number, dt: number): void {
-        console.warn("Method not implemented.", time, dt);
+        // Nothing to be done
     }
     public clear(): void {
-        console.warn("Method not implemented.");
+        // Nothing to be done
     }
     public activate(): void {
         analyticsClient.toggleMapEditor(false);
@@ -19,16 +19,16 @@ export class CloseTool implements MapEditorTool {
         mapEditorVisibilityStore.set(false);
     }
     public destroy(): void {
-        console.warn("Method not implemented.");
+        // Nothing to be done
     }
     public subscribeToGameMapFrontWrapperEvents(gameMapFrontWrapper: GameMapFrontWrapper): void {
-        console.warn("Method not implemented.", gameMapFrontWrapper);
+        // Nothing to be done
     }
     public handleKeyDownEvent(event: KeyboardEvent): void {
-        console.warn("Method not implemented.", event);
+        // Nothing to be done
     }
     public handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
-        console.warn("Method not implemented.", editMapCommandMessage);
+        // Nothing to be done
         return Promise.resolve();
     }
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/FloorEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/FloorEditorTool.ts
@@ -15,28 +15,28 @@ export class FloorEditorTool extends MapEditorTool {
     }
 
     public update(time: number, dt: number): void {
-        console.info("FloorEditorTool update");
+        // To implement
     }
     public clear(): void {
-        console.info("FloorEditorTool clear");
+        // To implement
     }
     public activate(): void {
-        console.info("FloorEditorTool activate");
+        // To implement
     }
     public destroy(): void {
-        console.info("FloorEditorTool destroy");
+        // To implement
     }
     public subscribeToGameMapFrontWrapperEvents(gameMapFrontWrapper: GameMapFrontWrapper): void {
-        console.info("FloorEditorTool subscribeToGameMapFrontWrapperEvents");
+        // To implement
     }
     public handleKeyDownEvent(event: KeyboardEvent): void {
-        console.info("FloorEditorTool handleKeyDownEvent");
+        // To implement
     }
     /**
      * React on commands coming from the outside
      */
     public handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
-        console.info("FloorEditorTool handleIncomingCommandMessage");
+        // To implement
         return Promise.resolve();
     }
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/WAMSettingsEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/WAMSettingsEditorTool.ts
@@ -17,22 +17,22 @@ export class WAMSettingsEditorTool extends MapEditorTool {
     }
 
     public update(time: number, dt: number): void {
-        console.info("WAMSettingsEditorTool update");
+        // Nothing to be done
     }
     public clear(): void {
-        console.info("WAMSettingsEditorTool clear");
+        // Nothing to be done
     }
     public activate(): void {
         mapEditorVisibilityStore.set(false);
     }
     public destroy(): void {
-        console.info("WAMSettingsEditorTool destroy");
+        // Nothing to be done
     }
     public subscribeToGameMapFrontWrapperEvents(gameMapFrontWrapper: GameMapFrontWrapper): void {
-        console.info("WAMSettingsEditorTool subscribeToGameMapFrontWrapperEvents");
+        // Nothing to be done
     }
     public handleKeyDownEvent(event: KeyboardEvent): void {
-        console.info("WAMSettingsEditorTool handleKeyDownEvent");
+        // Nothing to be done
     }
     /**
      * React on commands coming from the outside

--- a/play/src/front/Space/Space.ts
+++ b/play/src/front/Space/Space.ts
@@ -7,8 +7,6 @@ import { AllUsersSpaceFilter, AllUsersSpaceFilterInterface } from "./SpaceFilter
 import { LiveStreamingUsersSpaceFilter } from "./SpaceFilter/LiveStreamingUsersSpaceFilter";
 import { RoomConnectionForSpacesInterface } from "./SpaceRegistry/SpaceRegistry";
 
-export const WORLD_SPACE_NAME = "allWorldUser";
-
 export class Space implements SpaceInterface {
     private readonly name: string;
     private filters: Map<string, SpaceFilter> = new Map<string, SpaceFilter>();

--- a/play/src/front/Space/SpaceRegistry/SpaceRegistryInterface.ts
+++ b/play/src/front/Space/SpaceRegistry/SpaceRegistryInterface.ts
@@ -4,6 +4,6 @@ export interface SpaceRegistryInterface {
     get(spaceName: string): SpaceInterface;
     joinSpace(spaceName: string): SpaceInterface;
     exist(spaceName: string): boolean;
-    leaveSpace(spaceName: string): void;
+    leaveSpace(space: SpaceInterface): void;
     destroy(): void;
 }

--- a/play/src/front/Space/tests/SpaceRegistry.test.ts
+++ b/play/src/front/Space/tests/SpaceRegistry.test.ts
@@ -87,9 +87,9 @@ describe("SpaceProviderInterface implementation", () => {
 
                 spaceRegistry.joinSpace("space-test1");
                 spaceRegistry.joinSpace("space-test2");
-                spaceRegistry.joinSpace("space-to-delete");
+                const spaceToDelete = spaceRegistry.joinSpace("space-to-delete");
 
-                spaceRegistry.leaveSpace("space-to-delete");
+                spaceRegistry.leaveSpace(spaceToDelete);
                 expect(spaceRegistry.getAll().find((space) => space.getName() === "space-to-delete")).toBeUndefined();
                 expect(roomConnectionMock.emitLeaveSpace).toHaveBeenCalledOnce();
             });
@@ -102,7 +102,7 @@ describe("SpaceProviderInterface implementation", () => {
                 const spaceRegistry: SpaceRegistryInterface = new SpaceRegistry(defaultRoomConnectionMock);
 
                 expect(() => {
-                    spaceRegistry.leaveSpace(newSpace.getName());
+                    spaceRegistry.leaveSpace(newSpace);
                 }).toThrow(SpaceDoesNotExistError);
             });
         });

--- a/play/src/front/Streaming/Jitsi/JitsiBroadcastSpace.ts
+++ b/play/src/front/Streaming/Jitsi/JitsiBroadcastSpace.ts
@@ -239,7 +239,7 @@ export class JitsiBroadcastSpace extends EventTarget implements BroadcastSpace {
             });
         jitsiConferencesStore.delete(this.space.getName());
         this.space.stopWatching(this.spaceFilter);
-        this.spaceRegistry.leaveSpace(this.space.getName());
+        this.spaceRegistry.leaveSpace(this.space);
         this.unsubscribes.forEach((unsubscribe) => unsubscribe());
     }
 }


### PR DESCRIPTION
The SpaceRegistry cleanup was called before each individual space was cleaned, resulting in a crash when we were looking to clean remaining spaces. In addition, the space with all user was not properly destroyed.

Finally, we are refactoring the SpaceRegistry.leaveSpace method to take a space in parameter instead of a name.