### PR TITLE
Initialise area properties

### DIFF
--- a/libs/map-editor/src/GameMap/GameMapAreas.ts
+++ b/libs/map-editor/src/GameMap/GameMapAreas.ts
@@ -5,7 +5,6 @@ import {
     AreaDataProperties,
     AtLeast,
     EntityCoordinates,
-    GameMapProperties,
     PersonalAreaPropertyData,
     RestrictedRightsPropertyData,
     WAMFileFormat,
@@ -265,24 +264,6 @@ export class GameMapAreas {
         }
     }
 
-    public getProperties(position: { x: number; y: number }): Map<string, string | boolean | number> {
-        const properties = new Map<string, string | boolean | number>();
-        for (const area of this.getAreasOnPosition(position, this.areasPositionOffsetY)) {
-            if (area.properties === undefined) {
-                continue;
-            }
-            const flattenedProperties = this.flattenAreaProperties(area.properties);
-            for (const key in flattenedProperties) {
-                const property = flattenedProperties[key];
-                if (property === undefined) {
-                    continue;
-                }
-                properties.set(key, property);
-            }
-        }
-        return properties;
-    }
-
     public getAreasOnPosition(position: { x: number; y: number }, offsetY = 0): AreaData[] {
         const areasOfInterest = [...this.areas.values()];
 
@@ -385,62 +366,6 @@ export class GameMapAreas {
             return true;
         }
         return false;
-    }
-
-    private flattenAreaProperties(areaProperties: AreaDataProperties): Record<string, string | boolean | number> {
-        const flattenedProperties: Record<string, string | boolean | number> = {};
-        for (const property of areaProperties) {
-            switch (property.type) {
-                case "focusable": {
-                    flattenedProperties[GameMapProperties.FOCUSABLE] = true;
-                    if (property.zoom_margin) {
-                        flattenedProperties[GameMapProperties.ZOOM_MARGIN] = property.zoom_margin;
-                    }
-                    break;
-                }
-                case "jitsiRoomProperty": {
-                    flattenedProperties[GameMapProperties.JITSI_ROOM] = property.roomName ?? "";
-                    if (property.jitsiRoomConfig) {
-                        flattenedProperties[GameMapProperties.JITSI_CONFIG] = JSON.stringify(property.jitsiRoomConfig);
-                    }
-                    break;
-                }
-                case "openWebsite": {
-                    if (property.link == undefined) break;
-                    if (property.newTab) {
-                        flattenedProperties[GameMapProperties.OPEN_TAB] = property.link;
-                    } else {
-                        flattenedProperties[GameMapProperties.OPEN_WEBSITE] = property.link;
-                    }
-                    break;
-                }
-                case "playAudio": {
-                    flattenedProperties[GameMapProperties.PLAY_AUDIO] = property.audioLink;
-                    break;
-                }
-                case "start": {
-                    flattenedProperties[GameMapProperties.START] = true;
-                    break;
-                }
-                case "exit": {
-                    flattenedProperties[GameMapProperties.EXIT_URL] = property.url;
-                    break;
-                }
-                case "silent": {
-                    flattenedProperties[GameMapProperties.SILENT] = true;
-                    break;
-                }
-                case "speakerMegaphone": {
-                    flattenedProperties[GameMapProperties.SPEAKER_MEGAPHONE] = property.name;
-                    break;
-                }
-                case "listenerMegaphone": {
-                    flattenedProperties[GameMapProperties.LISTENER_MEGAPHONE] = property.speakerZoneName;
-                    break;
-                }
-            }
-        }
-        return flattenedProperties;
     }
 
     /**

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -271,6 +271,7 @@ export class GameMapFrontWrapper {
         const gameMapAreas = this.getGameMap().getGameMapAreas();
         if (gameMapAreas !== undefined) {
             this.areasManager = new AreasManager(this.scene, gameMapAreas, userConnectedTags, userCanEdit);
+            gameMapAreas.triggerAreasChange(undefined, this.position);
         } else {
             console.error("Unable to load AreasManager because gameMapAreas is undefined");
         }

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -1163,12 +1163,14 @@ export class GameMapFrontWrapper {
         const properties = new Map<string, string | boolean | number>();
         // NOTE: WE DO NOT WANT AREAS TO BE THE PART OF THE OLD PROPERTIES CHANGE SYSTEM
         // CHECK FOR AREAS PROPERTIES
-        // if (this.position) {
-        //     const areasProperties = this.gameMap.getGameMapAreas()?.getProperties(this.position);
-        //     if (areasProperties) {
-        //         properties = areasProperties;
-        //     }
-        // }
+        if (this.position) {
+            const areasProperties = this.gameMap.getGameMapAreas()?.getProperties(this.position);
+            if (areasProperties) {
+                for (const [key, value] of areasProperties) {
+                    properties.set(key, value);
+                }
+            }
+        }
 
         // CHECK FOR DYNAMIC AREAS PROPERTIES
         if (this.position) {

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -1163,14 +1163,14 @@ export class GameMapFrontWrapper {
         const properties = new Map<string, string | boolean | number>();
         // NOTE: WE DO NOT WANT AREAS TO BE THE PART OF THE OLD PROPERTIES CHANGE SYSTEM
         // CHECK FOR AREAS PROPERTIES
-        if (this.position) {
-            const areasProperties = this.gameMap.getGameMapAreas()?.getProperties(this.position);
-            if (areasProperties) {
-                for (const [key, value] of areasProperties) {
-                    properties.set(key, value);
-                }
-            }
-        }
+        //if (this.position) {
+        //    const areasProperties = this.gameMap.getGameMapAreas()?.getProperties(this.position);
+        //    if (areasProperties) {
+        //        for (const [key, value] of areasProperties) {
+        //            properties.set(key, value);
+        //        }
+        //    }
+        //}
 
         // CHECK FOR DYNAMIC AREAS PROPERTIES
         if (this.position) {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1853,7 +1853,7 @@ export class GameScene extends DirtyScene {
                 const error = get(errorScreenStore);
                 if (error && error?.type === "reconnecting") errorScreenStore.delete();
                 //this.scene.stop(ReconnectingSceneName);
-
+                this.gameMapFrontWrapper.setPosition(this.CurrentPlayer.x, this.CurrentPlayer.y);
                 // Init layer change listener
                 this.gameMapFrontWrapper.onEnterLayer((layers) => {
                     layers.forEach((layer) => {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -858,7 +858,6 @@ export class GameScene extends DirtyScene {
                 this.hide(false);
                 this.sceneReadyToStartDeferred.resolve();
                 this.initializeAreaManager();
-                this.gameMapFrontWrapper.setPosition(this.CurrentPlayer.x, this.CurrentPlayer.y);
             })
             .catch((e) =>
                 console.error(

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -858,6 +858,7 @@ export class GameScene extends DirtyScene {
                 this.hide(false);
                 this.sceneReadyToStartDeferred.resolve();
                 this.initializeAreaManager();
+                this.gameMapFrontWrapper.setPosition(this.CurrentPlayer.x, this.CurrentPlayer.y);
             })
             .catch((e) =>
                 console.error(
@@ -1852,9 +1853,6 @@ export class GameScene extends DirtyScene {
                 const error = get(errorScreenStore);
                 if (error && error?.type === "reconnecting") errorScreenStore.delete();
                 //this.scene.stop(ReconnectingSceneName);
-
-                //init user position and play trigger to check layers properties
-                this.gameMapFrontWrapper.setPosition(this.CurrentPlayer.x, this.CurrentPlayer.y);
 
                 // Init layer change listener
                 this.gameMapFrontWrapper.onEnterLayer((layers) => {


### PR DESCRIPTION
When we set position, the area properties need to be defined to apply area properties (silent, jisti...) when the user spawn.

# Issue
The user spawns in a silent area... but it not works: 
https://github.com/user-attachments/assets/dc2e280a-b295-4d06-88e7-02cf8e427ad3



# Fix
The user spawns in the silent area and it working:
https://github.com/user-attachments/assets/94e288d4-b311-417f-8615-8c145b3e45e9


