### PR TITLE
Fix interact entity

### DIFF
--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -150,9 +150,17 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
 
         this.entities.set(entityId, entity);
 
-        if (entity.isActivatable()) {
-            this.activatableEntities.push(entity);
-        }
+        // We use the promise to be sure that the entity is fully loaded before we check if it is activatable and push it to the activatableEntities array
+        this.scene
+            .getEntityPermissionsPromise()
+            .then(() => {
+                if (entity.isActivatable()) {
+                    this.activatableEntities.push(entity);
+                }
+            })
+            .catch((e) => {
+                console.error(e);
+            });
 
         this.scene.markDirty();
         return entity;

--- a/tests/tests/map_editor_interacting_object.spec.ts
+++ b/tests/tests/map_editor_interacting_object.spec.ts
@@ -94,6 +94,9 @@ test.describe("Map editor interacting with object @oidc", () => {
     await EntityEditor.setOpenLinkProperty(page, "https://workadventu.re");
     await Menu.closeMapEditor(page);
 
+    // Refresh the page to see the entity
+    await page.reload();
+
     // Move to the entity
     await EntityEditor.moveAndRightClick(page, 13 * 32, 13 * 32);
 

--- a/tests/tests/map_editor_interacting_object.spec.ts
+++ b/tests/tests/map_editor_interacting_object.spec.ts
@@ -96,6 +96,8 @@ test.describe("Map editor interacting with object @oidc", () => {
 
     // Refresh the page to see the entity
     await page.goto(Map.url("empty"));
+    // Wait for the map to be loaded
+    await expect(page.locator("button#menuIcon").nth(0)).toBeVisible();
 
     // Move to the entity
     await EntityEditor.moveAndRightClick(page, 13 * 32, 13 * 32);

--- a/tests/tests/map_editor_interacting_object.spec.ts
+++ b/tests/tests/map_editor_interacting_object.spec.ts
@@ -95,7 +95,7 @@ test.describe("Map editor interacting with object @oidc", () => {
     await Menu.closeMapEditor(page);
 
     // Refresh the page to see the entity
-    await page.reload();
+    await page.goto(Map.url("empty"));
 
     // Move to the entity
     await EntityEditor.moveAndRightClick(page, 13 * 32, 13 * 32);


### PR DESCRIPTION
Promise error. When we push the entity loaded in the activatable manager, it does not fully load and the property 'isActivatable' is false or not loaded.