### PR TITLE
[Matrix] Fixing the blinking notification in proximity chat and refactor room list size

### DIFF
--- a/play/src/front/Chat/Components/RoomFolder.svelte
+++ b/play/src/front/Chat/Components/RoomFolder.svelte
@@ -6,6 +6,7 @@
     import { chatSearchBarValue } from "../Stores/ChatStore";
     import Room from "./Room/Room.svelte";
     import CreateRoomOrFolderOption from "./Room/CreateRoomOrFolderOption.svelte";
+    import ShowMore from "./ShowMore.svelte";
     import { IconChevronDown, IconChevronRight } from "@wa-icons";
 
     export let folders: Readable<Map<string, RoomFolder>>;
@@ -59,9 +60,9 @@
                 {isGuest}
             />
         {/each}
-        {#each filteredRoom as room (room.id)}
+        <ShowMore items={filteredRoom} maxNumber={8} idKey="id" let:item={room} showNothingToDisplayMessage={false}>
             <Room {room} />
-        {/each}
+        </ShowMore>
         {#if $rooms.size === 0 && $folders.size === 0}
             <p class="tw-p-0 tw-m-0 tw-text-center tw-text-gray-300">{$LL.chat.nothingToDisplay()}</p>
         {/if}

--- a/play/src/front/Chat/Components/RoomList.svelte
+++ b/play/src/front/Chat/Components/RoomList.svelte
@@ -214,7 +214,7 @@
                     <IconChevronRight />
                     {$LL.chat.proximity()}
                     <div>
-                        <div class="tw-absolute tw-top-1 -tw-right-6 ">
+                        <div class="tw-absolute tw-top-1 -tw-right-6 tw-w-8 tw-h-8">
                             <span
                                 class="tw-w-4 tw-h-4 tw-block tw-rounded-full tw-absolute tw-top-0 tw-right-0 tw-animate-ping tw-bg-pop-green"
                             />

--- a/play/src/front/Chat/Components/RoomList.svelte
+++ b/play/src/front/Chat/Components/RoomList.svelte
@@ -15,6 +15,7 @@
     import ChatError from "./ChatError.svelte";
     import RoomFolder from "./RoomFolder.svelte";
     import CreateRoomOrFolderOption from "./Room/CreateRoomOrFolderOption.svelte";
+    import ShowMore from "./ShowMore.svelte";
     import { IconChevronDown, IconChevronRight } from "@wa-icons";
 
     export let sideBarWidth: number = INITIAL_SIDEBAR_WIDTH;
@@ -86,6 +87,7 @@
     $: filteredDirectRoom = $directRooms.filter(({ name }) =>
         get(name).toLocaleLowerCase().includes($chatSearchBarValue.toLocaleLowerCase())
     );
+
     $: filteredRooms = $rooms.filter(({ name }) =>
         get(name).toLocaleLowerCase().includes($chatSearchBarValue.toLocaleLowerCase())
     );
@@ -107,15 +109,13 @@
 </script>
 
 <div
-    class="tw-flex-1 tw-flex tw-flex-row tw-overflow-hidden"
+    class="tw-flex-1 tw-flex tw-flex-row tw-overflow-auto"
     class:!tw-flex-row={sideBarWidth > INITIAL_SIDEBAR_WIDTH * 2 && $navChat === "chat"}
 >
     {#if $selectedRoom === undefined || displayTwoColumnLayout}
         <div
-            class="tw-flex tw-flex-col tw-overflow-auto"
-            style={displayTwoColumnLayout
-                ? `border-right:1px solid #4d4b67;padding-right:12px;width:335px ;flex: 0 0 auto`
-                : `flex: 1 1 0%`}
+            class="tw-w-full"
+            style={displayTwoColumnLayout ? `border-right:1px solid #4d4b67;padding-right:12px;width:335px ;` : ``}
         >
             {#if $chatConnectionStatus === "CONNECTING"}
                 <ChatLoader label={$LL.chat.connecting()} />
@@ -126,7 +126,7 @@
             {#if $chatConnectionStatus === "ONLINE"}
                 {#if $joignableRoom.length > 0 && $chatSearchBarValue.trim() !== ""}
                     <p class="tw-p-0 tw-m-0 tw-text-gray-400">{$LL.chat.availableRooms()}</p>
-                    <div class="tw-flex tw-flex-col tw-overflow-auto">
+                    <div class="tw-flex tw-flex-col">
                         {#each $joignableRoom as room (room.id)}
                             <JoignableRooms {room} />
                         {/each}
@@ -142,12 +142,9 @@
                 </button>
                 {#if displayRoomInvitations}
                     <div class="tw-flex tw-flex-col tw-overflow-auto">
-                        {#each filteredRoomInvitations as room (room.id)}
+                        <ShowMore items={filteredRoomInvitations} maxNumber={8} idKey="id" let:item={room}>
                             <RoomInvitation {room} />
-                        {/each}
-                        {#if filteredRoomInvitations.length === 0}
-                            <p class="tw-p-1 tw-m-1 tw-text-center tw-text-gray-300">{$LL.chat.nothingToDisplay()}</p>
-                        {/if}
+                        </ShowMore>
                     </div>
                 {/if}
                 <div class="tw-flex tw-justify-between">
@@ -163,12 +160,9 @@
 
                 {#if displayDirectRooms}
                     <div class="tw-flex tw-flex-col tw-overflow-auto">
-                        {#each filteredDirectRoom as room (room.id)}
+                        <ShowMore items={filteredDirectRoom} maxNumber={8} idKey="id" let:item={room}>
                             <Room {room} />
-                        {/each}
-                        {#if filteredDirectRoom.length === 0}
-                            <p class="tw-p-0 tw-m-0 tw-text-center tw-text-gray-300">{$LL.chat.nothingToDisplay()}</p>
-                        {/if}
+                        </ShowMore>
                     </div>
                 {/if}
 
@@ -187,14 +181,9 @@
                 </div>
 
                 {#if displayRooms}
-                    <div class="tw-flex tw-flex-col tw-overflow-auto">
-                        {#each filteredRooms as room (room.id)}
-                            <Room {room} />
-                        {/each}
-                        {#if filteredRooms.length === 0}
-                            <p class="tw-p-0 tw-m-0 tw-text-center tw-text-gray-300">{$LL.chat.nothingToDisplay()}</p>
-                        {/if}
-                    </div>
+                    <ShowMore items={filteredRooms} maxNumber={8} idKey="id" let:item={room}>
+                        <Room {room} />
+                    </ShowMore>
                 {/if}
                 <!--roomBySpace-->
                 {#each Array.from($roomFolders.values()) as rootRoomFolder (rootRoomFolder.id)}

--- a/play/src/front/Chat/Components/ShowMore.svelte
+++ b/play/src/front/Chat/Components/ShowMore.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+    import LL from "../../../i18n/i18n-svelte";
+
+    // When generics are available, use them instead of "any"
+    // See https://www.reddit.com/r/sveltejs/comments/t10qgb/help_typing_generics_for_slot_props/
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export let items: any[];
+    export let maxNumber = 8;
+    export let idKey = "id";
+    export let showNothingToDisplayMessage = true;
+
+    let showMore = false;
+    $: filteredItems = showMore ? items : items.slice(0, maxNumber);
+</script>
+
+{#each filteredItems as item (item[idKey])}
+    <slot {item} />
+{/each}
+{#if items.length > 8}
+    <div class="tw-flex tw-justify-center">
+        <button
+            class="tw-flex-col tw-p-0 tw-m-0 tw-text-gray-400 tw-text-center tw-w-full tw-text-sm"
+            on:click={() => (showMore = !showMore)}
+        >
+            {showMore ? $LL.chat.showLess() : $LL.chat.showMore({ number: items.length - 8 })}
+        </button>
+    </div>
+{/if}
+{#if showNothingToDisplayMessage && items.length === 0}
+    <p class="tw-p-0 tw-m-0 tw-text-center tw-text-gray-300">{$LL.chat.nothingToDisplay()}</p>
+{/if}

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -170,6 +170,8 @@ const chat: BaseTranslation = {
     messageEdited: "Modified",
     waiting: "Waiting",
     nothingToDisplay: "Nothing to display",
+    showMore: "Show {number} more",
+    showLess: "Show less",
     addRoomToFolderError: "Impossible to add the room to the folder",
     createRoom: {
         title: "Create new room",

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -171,6 +171,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     messageEdited: "Modifié",
     waiting: "En attente",
     nothingToDisplay: "Rien à afficher",
+    showMore: "En afficher {number} de plus",
+    showLess: "En afficher moins",
     addRoomToFolderError: "Impossible d'ajouter la room au dossier",
     createRoom: {
         title: "Créer un nouveau salon",


### PR DESCRIPTION
By fixing the size of the container of the object that blinks, we avoid unwanted resizes.

Also, the room list has no a single big vertical scroll bar instead of one scrollbar per section.


Closes #4186