### PR TITLE
Adding a ADMIN_BO_URL env var

### DIFF
--- a/play/src/common/FrontConfigurationInterface.ts
+++ b/play/src/common/FrontConfigurationInterface.ts
@@ -5,6 +5,7 @@ export interface FrontConfigurationInterface {
     PUSHER_URL: string;
     FRONT_URL: string;
     ADMIN_URL: string | undefined;
+    ADMIN_BO_URL: string | undefined;
     UPLOADER_URL: string;
     ICON_URL: string;
     STUN_SERVER: string | undefined;

--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -99,7 +99,7 @@
     } from "../../Stores/MegaphoneStore";
     import { layoutManagerActionStore } from "../../Stores/LayoutManagerStore";
     import { localUserStore } from "../../Connection/LocalUserStore";
-    import { ADMIN_URL } from "../../Enum/EnvironmentVariable";
+    import { ADMIN_BO_URL } from "../../Enum/EnvironmentVariable";
     import AvailabilityStatusComponent from "./AvailabilityStatus/AvailabilityStatus.svelte";
     import { IconCheck, IconChevronDown, IconChevronUp } from "@wa-icons";
 
@@ -317,7 +317,7 @@
     }
 
     function openBo() {
-        window.open(ADMIN_URL, "_blank");
+        window.open(ADMIN_BO_URL, "_blank");
     }
 
     /*function register() {

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -316,7 +316,7 @@ class ConnectionManager {
                         }*/
 
                         if (response.type === "redirect") {
-                            return new URL(response.urlToRedirect);
+                            return new URL(response.urlToRedirect, window.location.href);
                         }
 
                         return {

--- a/play/src/front/Enum/EnvironmentVariable.ts
+++ b/play/src/front/Enum/EnvironmentVariable.ts
@@ -11,6 +11,7 @@ const env = window.env;
 export const DEBUG_MODE = env.DEBUG_MODE;
 export const PUSHER_URL = env.PUSHER_URL;
 export const ADMIN_URL = env.ADMIN_URL;
+export const ADMIN_BO_URL = env.ADMIN_BO_URL;
 export const UPLOADER_URL = env.UPLOADER_URL;
 export const ICON_URL = env.ICON_URL;
 export const STUN_SERVER = env.STUN_SERVER;

--- a/play/src/pusher/enums/EnvironmentVariable.ts
+++ b/play/src/pusher/enums/EnvironmentVariable.ts
@@ -33,6 +33,7 @@ export const API_URL = env.API_URL;
 export const ADMIN_API_URL = env.ADMIN_API_URL;
 export const ADMIN_API_RETRY_DELAY = parseInt(process.env.ADMIN_API_RETRY_DELAY || "500");
 export const ADMIN_URL = env.ADMIN_URL;
+export const ADMIN_BO_URL = env.ADMIN_BO_URL || env.ADMIN_URL;
 export const AUTOLOGIN_URL = env.AUTOLOGIN_URL ?? env.ADMIN_URL + "/workadventure/login";
 export const ADMIN_API_TOKEN = env.ADMIN_API_TOKEN;
 export const ADMIN_SOCKETS_TOKEN = env.ADMIN_SOCKETS_TOKEN;
@@ -121,6 +122,7 @@ export const FRONT_ENVIRONMENT_VARIABLES: FrontConfigurationInterface = {
     PUSHER_URL,
     FRONT_URL,
     ADMIN_URL,
+    ADMIN_BO_URL,
     UPLOADER_URL: env.UPLOADER_URL,
     ICON_URL: env.ICON_URL,
     STUN_SERVER: env.STUN_SERVER,

--- a/play/src/pusher/enums/EnvironmentVariableValidator.ts
+++ b/play/src/pusher/enums/EnvironmentVariableValidator.ts
@@ -20,6 +20,9 @@ export const EnvironmentVariables = z.object({
     ADMIN_URL: AbsoluteOrRelativeUrl.optional().describe(
         "The URL to the admin. This should be a publicly accessible URL."
     ),
+    ADMIN_BO_URL: AbsoluteOrRelativeUrl.optional().describe(
+        "The URL to the admin dashboard. Will be used to redirect the user to the admin dashboard. You can put it a URL that will automatically connect the user."
+    ),
     ADMIN_API_TOKEN: z.string().optional(),
     AUTOLOGIN_URL: AbsoluteOrRelativeUrl.optional().describe(
         "The URL to be used to automatically log someone given a token."


### PR DESCRIPTION
This environment variable is used by the front for only one purpose: the link to the admin BO. It is overriding the current ADMIN_URL that was the previous variable used for the link, but that can be used in a number of other places in the code.