### PR TITLE
Removing the iframeAuthentication field in /map

### DIFF
--- a/libs/messages/src/JsonMessages/MapDetailsData.ts
+++ b/libs/messages/src/JsonMessages/MapDetailsData.ts
@@ -140,10 +140,6 @@ export const isMapDetailsData = z.object({
         description: "The URL to the contact page",
         example: "https://mycompany.com/contact-us",
     }),
-    iframeAuthentication: extendApi(z.string().nullable().optional(), {
-        description: "The URL of the authentication Iframe",
-        example: "https://mycompany.com/authc",
-    }),
     opidLogoutRedirectUrl: extendApi(z.string().nullable().optional(), {
         description: "The URL of the logout redirect",
         example: "https://mycompany.com/logout",

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -34,6 +34,7 @@ import { gameManager } from "../Phaser/Game/GameManager";
 import { locales } from "../../i18n/i18n-util";
 import type { Locales } from "../../i18n/i18n-types";
 import { setCurrentLocale } from "../../i18n/locales";
+import { ABSOLUTE_PUSHER_URL } from "../Enum/ComputedConst";
 import { axiosToPusher, axiosWithRetry } from "./AxiosUtils";
 import { Room } from "./Room";
 import { LocalUser } from "./LocalUser";
@@ -114,17 +115,13 @@ class ConnectionManager {
      */
     public loadOpenIDScreen(): URL | null {
         localUserStore.setAuthToken(null);
-        // FIXME: remove this._currentRoom.iframeAuthentication
-        // FIXME: remove this._currentRoom.iframeAuthentication
-        // FIXME: remove this._currentRoom.iframeAuthentication
-        // FIXME: remove this._currentRoom.iframeAuthentication
-        if (!ENABLE_OPENID || !this._currentRoom || !this._currentRoom.iframeAuthentication) {
+        if (!ENABLE_OPENID || !this._currentRoom) {
             analyticsClient.loggedWithToken();
             loginSceneVisibleIframeStore.set(false);
             return null;
         }
         analyticsClient.loggedWithSso();
-        const redirectUrl = new URL(`${this._currentRoom.iframeAuthentication}`, window.location.href);
+        const redirectUrl = new URL("login-screen", ABSOLUTE_PUSHER_URL);
         redirectUrl.searchParams.append("playUri", this._currentRoom.key);
         return redirectUrl;
     }

--- a/play/src/front/Connection/Room.ts
+++ b/play/src/front/Connection/Room.ts
@@ -17,7 +17,6 @@ export interface RoomRedirect {
 export class Room {
     public readonly id: string;
     private _authenticationMandatory: boolean = DISABLE_ANONYMOUS;
-    private _iframeAuthentication?: string = new URL("login-screen", ABSOLUTE_PUSHER_URL).toString();
     private _opidLogoutRedirectUrl: string = new URL("logout", ABSOLUTE_PUSHER_URL).toString();
     private _opidWokaNamePolicy: OpidWokaNamePolicy | undefined;
     private _mapUrl: string | undefined;
@@ -144,8 +143,6 @@ export class Room {
                 this._group = data.group;
                 this._authenticationMandatory =
                     data.authenticationMandatory != null ? data.authenticationMandatory : DISABLE_ANONYMOUS;
-                this._iframeAuthentication =
-                    data.iframeAuthentication || new URL("login-screen", ABSOLUTE_PUSHER_URL).toString();
                 this._opidLogoutRedirectUrl =
                     data.opidLogoutRedirectUrl || new URL("logout", ABSOLUTE_PUSHER_URL).toString();
                 this._contactPage = data.contactPage || CONTACT_URL;
@@ -253,10 +250,6 @@ export class Room {
 
     get authenticationMandatory(): boolean {
         return this._authenticationMandatory;
-    }
-
-    get iframeAuthentication(): string | undefined {
-        return this._iframeAuthentication;
     }
 
     get opidLogoutRedirectUrl(): string {

--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -47,11 +47,6 @@ export class AuthenticateController extends BaseHttpController {
          *        description: "todo"
          *        required: false
          *        type: "string"
-         *      - name: "redirect"
-         *        in: "query"
-         *        description: "todo"
-         *        required: false
-         *        type: "string"
          *     responses:
          *       302:
          *         description: Redirects the user to the OpenID login screen
@@ -64,7 +59,6 @@ export class AuthenticateController extends BaseHttpController {
                 res,
                 z.object({
                     playUri: z.string(),
-                    redirect: z.string().optional(),
                 })
             );
             if (query === undefined) {
@@ -82,7 +76,7 @@ export class AuthenticateController extends BaseHttpController {
                 return;
             }
 
-            const loginUri = await openIDClient.authorizationUrl(res, query.redirect, query.playUri, req);
+            const loginUri = await openIDClient.authorizationUrl(res, query.playUri, req);
             res.atomic(() => {
                 res.cookie("playUri", query.playUri, undefined, {
                     httpOnly: true, // dont let browser javascript access cookie ever

--- a/play/src/pusher/services/LocalAdmin.ts
+++ b/play/src/pusher/services/LocalAdmin.ts
@@ -260,7 +260,6 @@ class LocalAdmin implements AdminInterface {
             authenticationMandatory: DISABLE_ANONYMOUS,
             contactPage: null,
             group: wamUrl ? "default" : null,
-            iframeAuthentication: null,
             opidLogoutRedirectUrl: null,
             opidUsernamePolicy: opidWokaNamePolicyCheck.success ? opidWokaNamePolicyCheck.data : null,
             miniLogo: null,

--- a/play/src/pusher/services/OpenIDClient.ts
+++ b/play/src/pusher/services/OpenIDClient.ts
@@ -59,12 +59,7 @@ class OpenIDClient {
         return this.issuerPromise;
     }
 
-    public authorizationUrl(
-        res: Response,
-        redirect: string | undefined,
-        playUri: string,
-        req: Request
-    ): Promise<string> {
+    public authorizationUrl(res: Response, playUri: string, req: Request): Promise<string> {
         return this.initClient().then((client) => {
             if (!OPID_SCOPE.includes("email") || !OPID_SCOPE.includes("openid")) {
                 throw new Error("Invalid scope, 'email' and 'openid' are required in OPID_SCOPE.");
@@ -94,7 +89,6 @@ class OpenIDClient {
                 state: state,
                 //nonce: nonce,
                 playUri,
-                redirect: redirect,
 
                 code_challenge,
                 code_challenge_method: "S256",


### PR DESCRIPTION
This field was a hack to make the AdminAPI redirect to some different pages. It is in fact not needed as when authenticating, we can redirect to the OAuth page configured that can itself redirect us where we want.