### PR TITLE
During redirection to the Matrix login, we now temporarily store the authToken in localStorage, instead of cookies.

### DIFF
--- a/play/redirectToMatrix.html
+++ b/play/redirectToMatrix.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        // The authToken can be bigger than the cookie limit max size so we need to use localStorage to store it.
+        window.localStorage.setItem("authToken", "{{authToken}}");
+
+        window.location.href = "{{{matrixRedirectUrl}}}";
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/play/redirectToPlay.html
+++ b/play/redirectToPlay.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        // The authToken can be bigger than the cookie limit max size so we need to use localStorage to store it.
+        const token = window.localStorage.getItem("authToken");
+
+        const playUrl = new URL("{{{playUri}}}");
+        playUrl.searchParams.append("token", token);
+
+
+        window.location.href = playUrl.toString();
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -1,8 +1,11 @@
+import fs from "fs";
 import { v4 } from "uuid";
 import { MeRequest, MeResponse, RegisterData } from "@workadventure/messages";
 import { z } from "zod";
 import * as Sentry from "@sentry/node";
 import { JsonWebTokenError } from "jsonwebtoken";
+import Mustache from "mustache";
+import type { Server } from "hyper-express";
 import { AuthTokenData, jwtTokenManager } from "../services/JWTTokenManager";
 import { openIDClient } from "../services/OpenIDClient";
 import { DISABLE_ANONYMOUS, FRONT_URL, MATRIX_PUBLIC_URI, PUSHER_URL } from "../enums/EnvironmentVariable";
@@ -13,6 +16,44 @@ import { matrixProvider } from "../services/MatrixProvider";
 import { BaseHttpController } from "./BaseHttpController";
 
 export class AuthenticateController extends BaseHttpController {
+    private readonly redirectToMatrixFile: string;
+    private readonly redirectToPlayFile: string;
+    constructor(app: Server) {
+        super(app);
+
+        let redirectToMatrixPath: string;
+        if (fs.existsSync("dist/public/redirectToMatrix.html")) {
+            // In prod mode
+            redirectToMatrixPath = "dist/public/redirectToMatrix.html";
+        } else if (fs.existsSync("redirectToMatrix.html")) {
+            // In dev mode
+            redirectToMatrixPath = "redirectToMatrix.html";
+        } else {
+            throw new Error("Could not find redirectToMatrix.html file");
+        }
+
+        this.redirectToMatrixFile = fs.readFileSync(redirectToMatrixPath, "utf8");
+
+        // Pre-parse the file for speed (and validation)
+        Mustache.parse(this.redirectToMatrixFile);
+
+        let redirectToPlayPath: string;
+        if (fs.existsSync("dist/public/redirectToPlay.html")) {
+            // In prod mode
+            redirectToPlayPath = "dist/public/redirectToPlay.html";
+        } else if (fs.existsSync("redirectToPlay.html")) {
+            // In dev mode
+            redirectToPlayPath = "redirectToPlay.html";
+        } else {
+            throw new Error("Could not find redirectToPlay.html file");
+        }
+
+        this.redirectToPlayFile = fs.readFileSync(redirectToPlayPath, "utf8");
+
+        // Pre-parse the file for speed (and validation)
+        Mustache.parse(this.redirectToPlayFile);
+    }
+
     routes(): void {
         this.openIDLogin();
         this.me();
@@ -295,14 +336,16 @@ export class AuthenticateController extends BaseHttpController {
                 const matrixRedirectUrl = new URL(redirectPath, matrixPublicUri);
                 matrixRedirectUrl.searchParams.append("redirectUrl", matrixCallbackUrl);
 
-                res.atomic(() => {
-                    // Let's save temporarily the auth token temporarily in a cookie to get it back when we are redirected by the Matrix server
-                    res.cookie("authToken", authToken, undefined, {
-                        httpOnly: true, // dont let browser javascript access cookie ever
-                        secure: req.secure, // only use cookie over https
-                    });
-                    res.redirect(matrixRedirectUrl.toString());
+                // Note: the authToken cannot be saved in a cookie because sometimes, it can be pretty large (>4kB)
+                // Therefore, we use localStorage to store it. So we need to render an HTML page with a script that will
+                // save the token in localStorage
+                const html = Mustache.render(this.redirectToMatrixFile, {
+                    authToken,
+                    matrixRedirectUrl: matrixRedirectUrl.toString(),
                 });
+
+                res.send(html);
+
                 return;
             }
 
@@ -336,10 +379,6 @@ export class AuthenticateController extends BaseHttpController {
             if (!playUri) {
                 throw new Error("Missing playUri in cookies");
             }
-            const authToken = req.cookies.authToken;
-            if (!authToken) {
-                throw new Error("Missing authToken in cookies");
-            }
 
             const query = validateQuery(req, res, z.object({ loginToken: z.string() }));
             if (query === undefined) {
@@ -351,9 +390,11 @@ export class AuthenticateController extends BaseHttpController {
                 res.clearCookie("authToken");
                 const playUri = new URL(req.cookies.playUri);
                 playUri.searchParams.append("matrixLoginToken", query.loginToken);
-                playUri.searchParams.append("token", authToken);
 
-                res.redirect(playUri.toString());
+                const html = Mustache.render(this.redirectToPlayFile, {
+                    playUri: playUri.toString(),
+                });
+                res.send(html);
             });
             return;
         });

--- a/tests/tests/utils/oidc.ts
+++ b/tests/tests/utils/oidc.ts
@@ -29,9 +29,13 @@ export async function oidcLogin(
   });
 
   if (!isMobile) {
-    await expect(page.locator("button#menuIcon").first()).toBeVisible();
+    await expect(page.locator("button#menuIcon").first()).toBeVisible({
+      timeout: 50_000,
+    });
   } else {
-    await expect(page.locator("button#burgerIcon")).toBeVisible();
+    await expect(page.locator("button#burgerIcon")).toBeVisible({
+      timeout: 50_000,
+    });
   }
 }
 


### PR DESCRIPTION
Indeed, the authToken can be large (>4kB) which is the max supported size of cookies. This was causing "Request Header Too Large" errors in µWebsockets.

Fixes #4294 