### PR TITLE
Configuring "lang" attribute to unknown

### DIFF
--- a/play/index.html
+++ b/play/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="">
     <head>
         <title>{{ title }}</title>
         <meta charset="UTF-8" />

--- a/play/src/front/Api/ScriptUtils.ts
+++ b/play/src/front/Api/ScriptUtils.ts
@@ -41,6 +41,10 @@ class ScriptUtils {
     }
 
     public getWebsiteUrl(url: string) {
+        if (!url.startsWith("http://") && !url.startsWith("https://")) {
+            // Relative URL, let's return right away.
+            return url;
+        }
         const urlApi = new URL(url);
         // Check if the url is a klaxoon link
         if (KlaxoonService.isKlaxoonLink(urlApi)) {

--- a/play/src/front/Chat/Components/Room/Message/MessageText.svelte
+++ b/play/src/front/Chat/Components/Room/Message/MessageText.svelte
@@ -74,6 +74,6 @@
     });
 </script>
 
-<p class="tw-p-0 tw-m-0 tw-text-xs">
+<p class="tw-p-0 tw-m-0 tw-text-xs" lang="">
     {@html sanitizeHTML(html)}
 </p>

--- a/play/src/front/Chat/Components/Room/MessageInput.svelte
+++ b/play/src/front/Chat/Components/Room/MessageInput.svelte
@@ -72,6 +72,7 @@
     role="textbox"
     tabindex="0"
     dir="auto"
+    lang=""
 />
 
 <style lang="scss">

--- a/play/src/i18n/locales.ts
+++ b/play/src/i18n/locales.ts
@@ -45,6 +45,8 @@ export const setCurrentLocale = async (locale: Locales) => {
     localStorage.setItem(localStorageProperty, locale);
     await loadLocaleAsync(locale);
     setLocale(locale);
+    // Let's update the locale in the HTML lang tag
+    document.documentElement.lang = locale;
 };
 
 export const displayableLocales: { id: Locales; language: string | undefined; region: string | undefined }[] =


### PR DESCRIPTION
The "lang" attribute of the HTML doc is set to "en" but this is a lie because the website might be translated. We set it to "" (unknown).
Dynamically, the page will set it to the correct value based on i18n settings. Also, chat messages always have the lang="" set as you don't know who you are going to talk to.