### PR TITLE
Fix CEA Chat issues: auto-open for non-connected users and store mismatch error

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -233,7 +233,14 @@ export class MatrixChatConnection implements ChatConnectionInterface {
         this.client.on(UserEvent.Presence, this.handleUserPresence);
 
         await this.client.store.startup();
-        await this.client.initRustCrypto();
+
+        try {
+            await this.client.initRustCrypto();
+        } catch {
+            await this.client.clearStores();
+            await this.client.initRustCrypto();
+        }
+
         await this.client.startClient({
             threadSupport: false,
             //Detached to prevent using listener on localIdReplaced for each event

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -569,7 +569,8 @@ export class AreasPropertiesListener {
     }
 
     private handleMatrixRoomAreaOnEnter(property: MatrixRoomPropertyData) {
-        if (this.scene.connection && property.serverData?.matrixRoomId && get(userIsConnected)) {
+        const isConnected = get(userIsConnected);
+        if (this.scene.connection && property.serverData?.matrixRoomId && isConnected) {
             this.scene.connection
                 .queryEnterChatRoomArea(property.serverData.matrixRoomId)
                 .then(() => {
@@ -589,8 +590,11 @@ export class AreasPropertiesListener {
                     Sentry.captureMessage(`Failed to join room area : ${error}`);
                     console.error(error);
                 });
-
             return;
+        }
+
+        if (!isConnected && property.shouldOpenAutomatically) {
+            chatVisibilityStore.set(true);
         }
     }
 
@@ -777,6 +781,7 @@ export class AreasPropertiesListener {
 
     private handleMatrixRoomAreaOnLeave(property: MatrixRoomPropertyData) {
         if (!get(userIsConnected)) {
+            chatVisibilityStore.set(false);
             return;
         }
 


### PR DESCRIPTION
1.	Open chat when the user enters a chat room area, even if they are not connected.
2.	Fix the “store doesn’t match the account” error by clearing the store and retrying initialization.​⬤