### PR TITLE
Improve UX map explorer

### DIFF
--- a/play/src/front/Components/Exploration/Explorer.svelte
+++ b/play/src/front/Components/Exploration/Explorer.svelte
@@ -16,6 +16,7 @@
     import { ExplorerTool } from "../../Phaser/Game/MapEditor/Tools/ExplorerTool";
     import AddPropertyButtonWrapper from "../MapEditor/PropertyEditor/AddPropertyButtonWrapper.svelte";
     import { connectionManager } from "../../Connection/ConnectionManager";
+    import { mapExplorerSearchinputFocusStore } from "../../Stores/UserInputStore";
     import { IconChevronDown, IconChevronUp } from "@wa-icons";
 
     let filter = "";
@@ -130,6 +131,20 @@
         area.setStrokeStyle(2, 0x000000);
         gameManager.getCurrentGameScene().markDirty();
     }
+
+    // Prevent the input form to be focused when clicking on the filter input
+    // The UserInputManager service automatically focus the input form when a click event is detected
+    // When user looking for entities or areas, we don't move the player
+    function focusin(event: FocusEvent) {
+        event.stopImmediatePropagation();
+        event.preventDefault();
+        mapExplorerSearchinputFocusStore.set(true);
+    }
+    function focusout(event: FocusEvent) {
+        event.stopImmediatePropagation();
+        event.preventDefault();
+        mapExplorerSearchinputFocusStore.set(false);
+    }
 </script>
 
 <div class="mapexplorer tw-flex tw-flex-col tw-overflow-auto">
@@ -143,6 +158,8 @@
                 type="search"
                 bind:value={filter}
                 on:input={onChangeFilterHandle}
+                on:focusin={focusin}
+                on:focusout={focusout}
                 placeholder={$LL.mapEditor.entityEditor.itemPicker.searchPlaceholder()}
             />
         </div>

--- a/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
@@ -18,6 +18,7 @@ import { MapEditorModeManager } from "../MapEditorModeManager";
 import { EntitiesManager } from "../../GameMap/EntitiesManager";
 import { AreaPreview } from "../../../Components/MapEditor/AreaPreview";
 import { waScaleManager } from "../../../Services/WaScaleManager";
+import { mapExplorerSearchinputFocusStore } from "../../../../Stores/UserInputStore";
 import { MapEditorTool } from "./MapEditorTool";
 
 const logger = debug("explorer-tool");
@@ -35,6 +36,7 @@ export class ExplorerTool implements MapEditorTool {
     private zoomLevelBeforeExplorerMode: number | undefined;
 
     private keyDownHandler = (event: KeyboardEvent) => {
+        if (get(mapExplorerSearchinputFocusStore)) return;
         if (event.key === "ArrowDown" || event.key === "s") {
             this.downIsPressed = true;
         }
@@ -49,6 +51,7 @@ export class ExplorerTool implements MapEditorTool {
         }
     };
     private keyUpHandler = (event: KeyboardEvent) => {
+        if (get(mapExplorerSearchinputFocusStore)) return;
         // Define new zone to zoom
         if (event.key === "ArrowDown" || event.key === "s") {
             this.downIsPressed = false;

--- a/play/src/front/Phaser/UserInput/UserInputManager.ts
+++ b/play/src/front/Phaser/UserInput/UserInputManager.ts
@@ -273,20 +273,6 @@ export class UserInputManager {
         this.joystick = undefined;
     }
 
-    private isMoveKey(keyCode: number): boolean {
-        return [
-            Phaser.Input.Keyboard.KeyCodes.Z,
-            Phaser.Input.Keyboard.KeyCodes.W,
-            Phaser.Input.Keyboard.KeyCodes.Q,
-            Phaser.Input.Keyboard.KeyCodes.A,
-            Phaser.Input.Keyboard.KeyCodes.S,
-            Phaser.Input.Keyboard.KeyCodes.D,
-            Phaser.Input.Keyboard.KeyCodes.UP,
-            Phaser.Input.Keyboard.KeyCodes.LEFT,
-            Phaser.Input.Keyboard.KeyCodes.DOWN,
-            Phaser.Input.Keyboard.KeyCodes.RIGHT,
-        ].includes(keyCode);
-    }
     private bindInputEventHandlers() {
         this.scene.input.on(
             Phaser.Input.Events.POINTER_WHEEL,

--- a/play/src/front/Stores/UserInputStore.ts
+++ b/play/src/front/Stores/UserInputStore.ts
@@ -37,3 +37,5 @@ export const enableUserInputsStore = derived(
         );
     }
 );
+
+export const mapExplorerSearchinputFocusStore = writable(false);


### PR DESCRIPTION
When searching for an area or entity, do not move the map explorer camera.