### PR TITLE
Fixing missing HTML Mime type during authentication

### DIFF
--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -338,7 +338,7 @@ export class AuthenticateController extends BaseHttpController {
                     matrixRedirectUrl: matrixRedirectUrl.toString(),
                 });
 
-                res.send(html);
+                res.type("html").send(html);
 
                 return;
             }


### PR DESCRIPTION
During the authentication process, when redirecting to the admin page, an HTML mime type was missing on one page, leading to HTML being output as pure text on some browsers.

Fixes #4327 