### PR TITLE
Tracking audio output in scripting API playStream

### DIFF
--- a/docs/developer/map-scripting/references/api-player.md
+++ b/docs/developer/map-scripting/references/api-player.md
@@ -561,7 +561,7 @@ voice chat in WorkAdventure. The sound can be generated on a server and streamed
 WA.player.proximityMeeting.startAudioStream(sampleRate: number): Promise<AudioStream>;
 
 interface AudioStream {
-  appendAudioData(data: Float32Array): void;
+  appendAudioData(data: Float32Array): Promise<void>;
   resetAudioBuffer(): Promise<void>;
   close(): Promise<void>;
 }
@@ -578,12 +578,21 @@ float32 values representing the raw uncompressed audio data.
 You can send multiple chunks of audio data in a row. If you are sending chunks of audio data faster than the sound
 is played, the audio stream will buffer the data and play it at the correct speed.
 
+`appendAudioData` returns a promise. The promise resolves only when the sound was actually dispatched/played in the bubble.
+
 :::warning
+You don't want to put an `await` in front of your call to `appendAudioData`. Indeed, you should put as much as possible
+in the audio buffer. If you wait for the sound to be played before emitting the next bit of sound, the sound will stutter.  
+:::
+
+
+:::note
 Please note the sound is played to all the players in the bubble except the player who called the function.
 :::
 
 If you sent too much data and want to stop the audio stream, you can call the `resetAudioBuffer` function. This will
-empty the audio buffer and stop the audio stream.
+empty the audio buffer and stop the audio stream. When you do so, any promise returned by `appendAudioData` that
+match a chunk of audio data that was not played yet will be rejected.
 
 Finally, when you are done with the audio stream, you can call the `close` function. This will stop the audio stream
 and free the resources.

--- a/play/src/front/Api/Events/IframeEvent.ts
+++ b/play/src/front/Api/Events/IframeEvent.ts
@@ -359,10 +359,6 @@ export const isIframeEventWrapper = z.union([
         data: z.undefined(),
     }),
     z.object({
-        type: z.literal("appendPCMData"),
-        data: isAppendPCMDataEvent,
-    }),
-    z.object({
         type: z.literal("startListeningToStreamInBubble"),
         data: isStartStreamInBubbleEvent,
     }),
@@ -701,6 +697,10 @@ export const iframeQueryMapTypeGuards = {
     },
     stopStreamInBubble: {
         query: z.undefined(),
+        answer: z.undefined(),
+    },
+    appendPCMData: {
+        query: isAppendPCMDataEvent,
         answer: z.undefined(),
     },
     resetAudioBuffer: {

--- a/play/src/front/Api/Iframe/IframeApiContribution.ts
+++ b/play/src/front/Api/Iframe/IframeApiContribution.ts
@@ -20,7 +20,8 @@ export const answerPromises = new Map<
 >();
 
 export function queryWorkadventure<T extends keyof IframeQueryMap>(
-    content: IframeQuery<T>
+    content: IframeQuery<T>,
+    transfer?: Transferable[]
 ): Promise<IframeQueryMap[T]["answer"]> {
     return new Promise<IframeQueryMap[T]["answer"]>((resolve, reject) => {
         window.parent.postMessage(
@@ -28,7 +29,8 @@ export function queryWorkadventure<T extends keyof IframeQueryMap>(
                 id: queryNumber,
                 query: content,
             } as IframeQueryWrapper<T>,
-            "*"
+            "*",
+            transfer
         );
 
         answerPromises.set(queryNumber, {

--- a/play/src/front/Api/Iframe/Player/AudioStream.ts
+++ b/play/src/front/Api/Iframe/Player/AudioStream.ts
@@ -1,8 +1,8 @@
-import { queryWorkadventure, sendToWorkadventure } from "../IframeApiContribution";
+import { queryWorkadventure } from "../IframeApiContribution";
 
 export class AudioStream {
-    public appendAudioData(float32Array: Float32Array): void {
-        sendToWorkadventure(
+    public appendAudioData(float32Array: Float32Array): Promise<void> {
+        return queryWorkadventure(
             {
                 type: "appendPCMData",
                 data: {

--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -54,7 +54,6 @@ import type { AddPlayerEvent } from "./Events/AddPlayerEvent";
 import { ModalEvent } from "./Events/ModalEvent";
 import { AddButtonActionBarEvent } from "./Events/Ui/ButtonActionBarEvent";
 import { ReceiveEventEvent } from "./Events/ReceiveEventEvent";
-import { AppendPCMDataEvent } from "./Events/ProximityMeeting/AppendPCMDataEvent";
 import { StartStreamInBubbleEvent } from "./Events/ProximityMeeting/StartStreamInBubbleEvent";
 
 type AnswererCallback<T extends keyof IframeQueryMap> = (
@@ -217,9 +216,6 @@ class IframeListener {
     private readonly _stopTypingProximityMessageStream: Subject<StopWritingEvent> = new Subject();
     public readonly stopTypingProximityMessageStream = this._stopTypingProximityMessageStream.asObservable();
 
-    private readonly _appendPCMDataStream: Subject<AppendPCMDataEvent> = new Subject();
-    public readonly appendPCMDataStream = this._appendPCMDataStream.asObservable();
-
     private readonly _startListeningToStreamInBubbleStream: Subject<StartStreamInBubbleEvent> = new Subject();
     public readonly startListeningToStreamInBubbleStream = this._startListeningToStreamInBubbleStream.asObservable();
 
@@ -375,8 +371,6 @@ class IframeListener {
                         this._startTypingProximityMessageStream.next(iframeEvent.data);
                     } else if (iframeEvent.type === "stopWriting") {
                         this._stopTypingProximityMessageStream.next(iframeEvent.data);
-                    } else if (iframeEvent.type === "appendPCMData") {
-                        this._appendPCMDataStream.next(iframeEvent.data);
                     } else if (iframeEvent.type === "startListeningToStreamInBubble") {
                         this._startListeningToStreamInBubbleStream.next(iframeEvent.data);
                     } else if (iframeEvent.type === "stopListeningToStreamInBubble") {
@@ -597,7 +591,7 @@ class IframeListener {
                 iframe.sandbox.add("allow-scripts");
                 iframe.sandbox.add("allow-top-navigation-by-user-activation");
 
-                const scriptUrlObj = new URL(scriptUrl);
+                const scriptUrlObj = new URL(scriptUrl, window.location.href);
                 // Note: we define the base URL to be the same as the script URL to fix some issues with some scripts using Vite.
                 const scriptUrlBase = scriptUrlObj.protocol + "//" + scriptUrlObj.host;
 

--- a/play/src/front/Components/Menu/ProfileSubMenu.svelte
+++ b/play/src/front/Components/Menu/ProfileSubMenu.svelte
@@ -64,7 +64,7 @@
     }
 
     function logOut() {
-        disableMenuStores();
+        //disableMenuStores();
         return connectionManager.logout();
     }
 

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -134,8 +134,10 @@ class ConnectionManager {
         const tokenTmp = localUserStore.getAuthToken();
         //remove token in localstorage
         localUserStore.setAuthToken(null);
-        //user logout, set connected store for menu at false
-        userIsConnected.set(false);
+        //user logout, set connected store for menu at false (actually don't do it because we are going to redirect and
+        // it shortly displays the "sign in" button before redirect happens)
+        //userIsConnected.set(false);
+
         // check if we are in a room
         if (!ENABLE_OPENID || !this._currentRoom) {
             window.location.assign("/login");

--- a/play/src/front/WebRtc/AudioStream/OutputAudioWorkletProcessor.ts
+++ b/play/src/front/WebRtc/AudioStream/OutputAudioWorkletProcessor.ts
@@ -1,18 +1,25 @@
+interface PCMData {
+    pcmData: Float32Array;
+    id: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isPcmData(data: any): data is PCMData {
+    return typeof data === "object" && data.pcmData instanceof Float32Array && typeof data.id === "number";
+}
+
 class OutputAudioWorkletProcessor extends AudioWorkletProcessor {
-    private audioQueue: Float32Array[] = [];
+    private audioQueue: PCMData[] = [];
 
     constructor() {
         super();
         this.port.onmessage = (event: MessageEvent) => {
             if (event.data.emptyBuffer === true) {
                 this.audioQueue = [];
+            } else if (isPcmData(event.data)) {
+                this.audioQueue.push(event.data);
             } else {
-                const data = event.data.pcmData;
-                if (data instanceof Float32Array) {
-                    this.audioQueue.push(data);
-                } else {
-                    console.error("Invalid data type received in worklet", event.data);
-                }
+                console.error("Invalid data type received in worklet", event.data);
             }
         };
     }
@@ -21,17 +28,20 @@ class OutputAudioWorkletProcessor extends AudioWorkletProcessor {
         const output = outputs[0];
         const outputData = output[0];
 
-        let nextChunk: Float32Array | undefined;
+        let nextChunk: PCMData | undefined;
         let currentOffset = 0;
         // eslint-disable-next-line no-cond-assign
         while ((nextChunk = this.audioQueue[0])) {
-            if (currentOffset + nextChunk.length <= outputData.length) {
-                outputData.set(nextChunk, currentOffset);
-                currentOffset += nextChunk.length;
+            if (currentOffset + nextChunk.pcmData.length <= outputData.length) {
+                outputData.set(nextChunk.pcmData, currentOffset);
+                currentOffset += nextChunk.pcmData.length;
+                const id = nextChunk.id;
+                // Send the acknoledgement back to the main thread
+                this.port.postMessage({ playedId: id });
                 this.audioQueue.shift();
             } else {
-                outputData.set(nextChunk.subarray(0, outputData.length - currentOffset), currentOffset);
-                this.audioQueue[0] = nextChunk.subarray(outputData.length - currentOffset);
+                outputData.set(nextChunk.pcmData.subarray(0, outputData.length - currentOffset), currentOffset);
+                this.audioQueue[0].pcmData = nextChunk.pcmData.subarray(outputData.length - currentOffset);
                 break;
             }
         }

--- a/play/src/front/WebRtc/AudioStream/ScriptingOutputAudioStreamManager.ts
+++ b/play/src/front/WebRtc/AudioStream/ScriptingOutputAudioStreamManager.ts
@@ -1,4 +1,3 @@
-import { Subscription } from "rxjs";
 import { Deferred } from "ts-deferred";
 import { iframeListener } from "../../Api/IframeListener";
 import { SimplePeer } from "../SimplePeer";
@@ -8,11 +7,9 @@ import { OutputPCMStreamer } from "./OutputPCMStreamer";
  * Class in charge of receiving audio streams from the scripting API and playing them.
  */
 export class ScriptingOutputAudioStreamManager {
-    private appendPCMDataStreamUnsubscriber: Subscription;
     private pcmStreamerDeferred: Deferred<OutputPCMStreamer> = new Deferred<OutputPCMStreamer>();
     private pcmStreamerResolved = false;
     private pcmStreamerResolving = false;
-    private isListening = false;
 
     constructor(simplePeer: SimplePeer) {
         iframeListener.registerAnswerer("startStreamInBubble", async (message) => {
@@ -28,14 +25,9 @@ export class ScriptingOutputAudioStreamManager {
             simplePeer.dispatchStream(pcmStreamer.getMediaStream());
         });
 
-        this.appendPCMDataStreamUnsubscriber = iframeListener.appendPCMDataStream.subscribe((message) => {
-            this.pcmStreamerDeferred.promise
-                .then((pcmStreamer) => {
-                    pcmStreamer.appendPCMData(message.data);
-                })
-                .catch((e) => {
-                    console.error("Error while appending PCM data", e);
-                });
+        iframeListener.registerAnswerer("appendPCMData", async (message) => {
+            const pcmStreamer = await this.pcmStreamerDeferred.promise;
+            await pcmStreamer.appendPCMData(message.data);
         });
 
         iframeListener.registerAnswerer("stopStreamInBubble", () => {
@@ -63,10 +55,10 @@ export class ScriptingOutputAudioStreamManager {
     }
 
     public close(): void {
-        this.appendPCMDataStreamUnsubscriber.unsubscribe();
         iframeListener.unregisterAnswerer("startStreamInBubble");
         iframeListener.unregisterAnswerer("stopStreamInBubble");
         iframeListener.unregisterAnswerer("resetAudioBuffer");
+        iframeListener.unregisterAnswerer("appendPCMData");
 
         if (this.pcmStreamerResolved || this.pcmStreamerResolving) {
             this.pcmStreamerDeferred.promise

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -30,6 +30,7 @@ import { adminService } from "../services/AdminService";
 import { validateWebsocketQuery } from "../services/QueryValidator";
 import { SocketData } from "../models/Websocket/SocketData";
 import { emitInBatch } from "../services/IoSocketHelpers";
+import { Space } from "../models/Space";
 
 type UpgradeFailedInvalidData = {
     rejected: true;
@@ -505,6 +506,14 @@ export class IoSocketController {
                             chatID,
                             world: userData.world,
                             currentChatRoomArea: [],
+                            customJsonReplacer(key: unknown, value: unknown): string | undefined {
+                                if (key === "listenedZones") {
+                                    return `listenedZones : ${(value as Set<Zone>).size}`;
+                                } else if (key === "spaces") {
+                                    return `spaces : ${(value as Space[]).length}`;
+                                }
+                                return undefined;
+                            },
                         };
 
                         /* This immediately calls open handler, you must not use res after this call */

--- a/play/src/pusher/models/Space.ts
+++ b/play/src/pusher/models/Space.ts
@@ -452,7 +452,9 @@ export class Space implements CustomJsonReplacerInterface {
         if (key === "name") {
             return this.name;
         } else if (key === "users") {
-            return `Users : ${this.users.size}`;
+            return `Users : ${(value as Map<number, SpaceUserExtended>).size}`;
+        } else if (key === "spaceStreamToPusher") {
+            return "spaceStreamToPusher";
         }
         return undefined;
     }

--- a/play/src/pusher/models/Websocket/SocketData.ts
+++ b/play/src/pusher/models/Websocket/SocketData.ts
@@ -61,4 +61,5 @@ export type SocketData = {
     chatID?: string;
     world: string;
     currentChatRoomArea: string[];
+    customJsonReplacer?: (key: unknown, value: unknown) => string | undefined;
 };

--- a/tests/tests/utils/oidc.ts
+++ b/tests/tests/utils/oidc.ts
@@ -51,6 +51,7 @@ export async function oidcLogout(page: Page, isMobile = false) {
   }
   await page.click("#menuIcon img:first-child");
   await page.click('button:has-text("Log out")');
+  await expect(page.getByRole('heading', { name: 'Profile' })).toBeHidden();
 }
 
 export async function oidcAdminTagLogin(page, isMobile = false) {


### PR DESCRIPTION
Adding the ability to track the played audio output from the scripting API when playing an audio stream.

The `appendAudioData` method from the scripting API now returns a promise that will resolve only when the sound was actually played.

This is useful to cancel part of the response when using OpenAI's realtime API.