### PR TITLE
Fixing hard-coded "Fermer" text in map editor

### DIFF
--- a/play/src/front/Components/Modal/ObjectDetails.svelte
+++ b/play/src/front/Components/Modal/ObjectDetails.svelte
@@ -164,7 +164,7 @@
         <div
             class="tw-flex tw-flex-row tw-justify-evenly tw-items-center tw-bg-dark-purple tw-w-full tw-p-2 tw-rounded-b-3xl"
         >
-            <button class="tw-bg-dark-purple tw-p-4" on:click={close}>Fermer</button>
+            <button class="tw-bg-dark-purple tw-p-4" on:click={close}>{$LL.mapEditor.explorer.details.close()}</button>
             <button class="light tw-p-4" on:click={goTo}>
                 {$LL.mapEditor.explorer.details.moveToEntity({
                     name: $mapExplorationObjectSelectedStore?.getPrefab().name.toUpperCase(),


### PR DESCRIPTION
Replaced by the correct translated word.

Closes #4340