### PR TITLE
Passing manuallyTrigerred parameter to the OIDC provider

### DIFF
--- a/play/src/front/Phaser/Login/LoginScene.ts
+++ b/play/src/front/Phaser/Login/LoginScene.ts
@@ -30,7 +30,7 @@ export class LoginScene extends ResizableScene {
             gameManager.currentStartedRoom &&
             gameManager.currentStartedRoom.authenticationMandatory
         ) {
-            const redirect = connectionManager.loadOpenIDScreen();
+            const redirect = connectionManager.loadOpenIDScreen(false);
             if (redirect !== null) {
                 window.location.assign(redirect.toString());
             }

--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -100,6 +100,7 @@ export class AuthenticateController extends BaseHttpController {
                 res,
                 z.object({
                     playUri: z.string(),
+                    manuallyTriggered: z.literal("true").optional(),
                 })
             );
             if (query === undefined) {
@@ -117,7 +118,7 @@ export class AuthenticateController extends BaseHttpController {
                 return;
             }
 
-            const loginUri = await openIDClient.authorizationUrl(res, query.playUri, req);
+            const loginUri = await openIDClient.authorizationUrl(res, query.playUri, req, query.manuallyTriggered);
             res.atomic(() => {
                 res.cookie("playUri", query.playUri, undefined, {
                     httpOnly: true, // dont let browser javascript access cookie ever

--- a/play/src/pusher/services/OpenIDClient.ts
+++ b/play/src/pusher/services/OpenIDClient.ts
@@ -59,7 +59,12 @@ class OpenIDClient {
         return this.issuerPromise;
     }
 
-    public authorizationUrl(res: Response, playUri: string, req: Request): Promise<string> {
+    public authorizationUrl(
+        res: Response,
+        playUri: string,
+        req: Request,
+        manuallyTriggered: "true" | undefined
+    ): Promise<string> {
         return this.initClient().then((client) => {
             if (!OPID_SCOPE.includes("email") || !OPID_SCOPE.includes("openid")) {
                 throw new Error("Invalid scope, 'email' and 'openid' are required in OPID_SCOPE.");
@@ -89,6 +94,10 @@ class OpenIDClient {
                 state: state,
                 //nonce: nonce,
                 playUri,
+                // Whether the login was triggered by clicking on the "sign in" button (in which case the user was
+                // anonymous) or whether the login was triggered because user was not authenticated and authentication
+                // is mandatory.
+                manuallyTriggered,
 
                 code_challenge,
                 code_challenge_method: "S256",


### PR DESCRIPTION
Passing a custom manuallyTrigerred parameter to the OIDC authentication page. This parameter will be "true" only when the user clicks the "Sign in" button. It is empty if WorkAdventure triggered a redirect because of mandatory authentication.

In the future, some OIDC providers might use that to allow displaying the login screen on arrival, but with a "stay anonymous" button allowing to skip authentication.