### PR TITLE
[Scripting API]: Adding a function to get areas from the map-editor

### DIFF
--- a/docs/developer/map-scripting/references/api-mapeditor.md
+++ b/docs/developer/map-scripting/references/api-mapeditor.md
@@ -2,7 +2,10 @@
 sidebar_position: 1
 ---
 
-# Mapeditor
+# Map Editor API
+
+Currently, the map editor API provides a way to read the areas defined in the map editor and to detect when the user enters or leaves an area.
+It is "read-only". You cannot modify the map using this API.
 
 We opted for a different approach to the event's detection of 'enter' and 'leave' zones when dealing with an area edited by the map editor.
 
@@ -15,17 +18,50 @@ WA.mapEditor.onLeave(name: string): Subscription
 
 Listens to the position of the current user. The event is triggered when the user enters or leaves a given area.
 
-- **name**: the name of the layer who as defined in Tiled.
+- **name**: the name of the area defined in the map editor.
 
 Example:
 
 ```ts
-const myAreaSubscriber = WA.mapEditor.onEnter("myAreaName").subscribe(() => {
+const myAreaEnterSubscriber = WA.mapEditor.area.onEnter("myAreaName").subscribe(() => {
   WA.chat.sendChatMessage("Hello!", "Mr Robot");
 });
 
-WA.mapEditor.onLeave("myAreaName").subscribe(() => {
+const myAreaLeaveSubscriber = WA.mapEditor.area.onLeave("myAreaName").subscribe(() => {
   WA.chat.sendChatMessage("Goodbye!", "Mr Robot");
   myAreaSubscriber.unsubscribe();
 });
+
+// If you want to stop listening to the events at some point:
+myAreaEnterSubscriber.unsubscribe();
+myAreaLeaveSubscriber.unsubscribe();
+```
+
+## Getting the list of all areas created in the map editor
+
+```ts
+WA.mapEditor.area.list(): MapEditorArea[]
+```
+
+Returns the list of all areas created in the map editor.
+
+```ts
+interface MapEditorArea {
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  description: string|undefined;
+  searchable: boolean|undefined;
+}
+```
+
+Example:
+
+```ts
+const areas = await WA.mapEditor.area.list();
+for (const area of areas) {
+  console.log(`Area ${area.name} at (${area.x}, ${area.y}) with width ${area.width} and height ${area.height}`);
+}
 ```

--- a/play/src/front/Api/Events/IframeEvent.ts
+++ b/play/src/front/Api/Events/IframeEvent.ts
@@ -68,6 +68,7 @@ import { isReceiveEventEvent } from "./ReceiveEventEvent";
 import { isPlaySoundInBubbleEvent } from "./ProximityMeeting/PlaySoundInBubbleEvent";
 import { isStartStreamInBubbleEvent } from "./ProximityMeeting/StartStreamInBubbleEvent";
 import { isAppendPCMDataEvent } from "./ProximityMeeting/AppendPCMDataEvent";
+import { isWamMapDataEvent } from "./WamMapDataEvent";
 
 export interface TypedMessageEvent<T> extends MessageEvent {
     data: T;
@@ -714,6 +715,10 @@ export const iframeQueryMapTypeGuards = {
     stopLeading: {
         query: z.undefined(),
         answer: z.undefined(),
+    },
+    getWamMapData: {
+        query: z.undefined(),
+        answer: isWamMapDataEvent,
     },
 };
 

--- a/play/src/front/Api/Events/WamMapDataEvent.ts
+++ b/play/src/front/Api/Events/WamMapDataEvent.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const isWamMapDataEvent = z.object({
+    data: z.unknown(),
+});
+
+/**
+ * A message sent from the game to the iFrame with the content of the WAM file. We don't type the content of the WAM file for performance reasons.
+ */
+export type MapDataEvent = z.infer<typeof isWamMapDataEvent>;

--- a/play/src/front/Api/Iframe/MapEditor/MapEditorArea.ts
+++ b/play/src/front/Api/Iframe/MapEditor/MapEditorArea.ts
@@ -1,0 +1,28 @@
+import { AreaData, AreaDescriptionPropertyData } from "@workadventure/map-editor";
+
+export interface MapEditorArea {
+    id: string;
+    name: string;
+    description: string | undefined;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    searchable: boolean | undefined;
+}
+
+export function toMapEditorArea(area: AreaData): MapEditorArea {
+    const descriptionProperty = area.properties.find((property) => property.type === "areaDescriptionProperties") as
+        | AreaDescriptionPropertyData
+        | undefined;
+    return {
+        id: area.id,
+        name: area.name,
+        description: descriptionProperty?.description,
+        searchable: descriptionProperty?.searchable,
+        x: area.x,
+        y: area.y,
+        width: area.width,
+        height: area.height,
+    };
+}

--- a/play/src/front/Api/Iframe/area.ts
+++ b/play/src/front/Api/Iframe/area.ts
@@ -57,7 +57,7 @@ export class WorkadventureAreaCommands extends IframeApiContribution<Workadventu
     }
 
     /**
-     * Delete Area by it's name.
+     * Delete Area by its name.
      * {@link https://docs.workadventu.re/map-building/api-room.md#delete-area | Website documentation}
      *
      * @param {string} name Area name

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1032,6 +1032,7 @@ export class GameScene extends DirtyScene {
         iframeListener.unregisterAnswerer("getState");
         iframeListener.unregisterAnswerer("loadTileset");
         iframeListener.unregisterAnswerer("getMapData");
+        iframeListener.unregisterAnswerer("getWamMapData");
         iframeListener.unregisterAnswerer("triggerActionMessage");
         iframeListener.unregisterAnswerer("triggerPlayerMessage");
         iframeListener.unregisterAnswerer("removeActionMessage");
@@ -2740,6 +2741,12 @@ ${escapedMessage}
         iframeListener.registerAnswerer("getMapData", () => {
             return {
                 data: this.gameMapFrontWrapper.getMap(),
+            };
+        });
+
+        iframeListener.registerAnswerer("getWamMapData", () => {
+            return {
+                data: this.gameMapFrontWrapper.getGameMap().getWam(),
             };
         });
 


### PR DESCRIPTION
Adding a `WA.mapEditor.area.list()` function to fetch the list of areas defined in the map editor. Currently, only the name, description and position are available.