### PR TITLE
Fixing missing content-type for the matrix-callback route

### DIFF
--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -389,7 +389,7 @@ export class AuthenticateController extends BaseHttpController {
                 const html = Mustache.render(this.redirectToPlayFile, {
                     playUri: playUri.toString(),
                 });
-                res.send(html);
+                res.type("html").send(html);
             });
             return;
         });


### PR DESCRIPTION
This would cause HTML to be displayed as is with some reverse proxys (like Traefik 3)