### PR TITLE
Easy image pull secrets configuration

### DIFF
--- a/contrib/helm/templates/_helpers.tpl
+++ b/contrib/helm/templates/_helpers.tpl
@@ -172,3 +172,9 @@ https://{{ .Values.domainName }}/maps
 {{- define "workadventure.isBooleanText" -}}
 {{- if or (or (or (eq . "false") (eq . "0")) (not .)) (eq . "FALSE") -}}{{- else -}}1{{- end -}}
 {{- end }}
+
+{{- define "imagePullSecret" }}
+{{- with .Values.imageCredentials }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" (required "imageCredentials.registry is required when imageCredentials.enabled = true" .registry) (required "imageCredentials.username is required when imageCredentials.enabled = true" .username) (required "imageCredentials.password is required when imageCredentials.enabled = true" .password) (required "imageCredentials.email is required when imageCredentials.enabled = true" .email) (printf "%s:%s" .username  (required "imageCredentials.password is required when imageCredentials.enabled = true" .password) | b64enc) | b64enc }}
+{{- end }}
+{{- end }}

--- a/contrib/helm/templates/back-statefulset.yaml
+++ b/contrib/helm/templates/back-statefulset.yaml
@@ -34,9 +34,14 @@ spec:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: back
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- if or .Values.imageCredentials.enabled .Values.imagePullSecrets }}
       imagePullSecrets:
+        {{- if .Values.imageCredentials.enabled }}
+        - name: {{ include "workadventure.fullname" . }}-pull-secret
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
       securityContext:

--- a/contrib/helm/templates/icon-deployment.yaml
+++ b/contrib/helm/templates/icon-deployment.yaml
@@ -21,9 +21,14 @@ spec:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: icon
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- if or .Values.imageCredentials.enabled .Values.imagePullSecrets }}
       imagePullSecrets:
+        {{- if .Values.imageCredentials.enabled }}
+        - name: {{ include "workadventure.fullname" . }}-pull-secret
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
       securityContext:

--- a/contrib/helm/templates/maps-deployment.yaml
+++ b/contrib/helm/templates/maps-deployment.yaml
@@ -29,9 +29,14 @@ spec:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: maps
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- if or .Values.imageCredentials.enabled .Values.imagePullSecrets }}
       imagePullSecrets:
+        {{- if .Values.imageCredentials.enabled }}
+        - name: {{ include "workadventure.fullname" . }}-pull-secret
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
       securityContext:

--- a/contrib/helm/templates/mapstorage-deployment.yaml
+++ b/contrib/helm/templates/mapstorage-deployment.yaml
@@ -28,9 +28,14 @@ spec:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: mapstorage
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- if or .Values.imageCredentials.enabled .Values.imagePullSecrets }}
       imagePullSecrets:
+        {{- if .Values.imageCredentials.enabled }}
+        - name: {{ include "workadventure.fullname" . }}-pull-secret
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
       securityContext:

--- a/contrib/helm/templates/play-deployment.yaml
+++ b/contrib/helm/templates/play-deployment.yaml
@@ -29,9 +29,14 @@ spec:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: play
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- if or .Values.imageCredentials.enabled .Values.imagePullSecrets }}
       imagePullSecrets:
+        {{- if .Values.imageCredentials.enabled }}
+        - name: {{ include "workadventure.fullname" . }}-pull-secret
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
       securityContext:

--- a/contrib/helm/templates/pull-secret.yaml
+++ b/contrib/helm/templates/pull-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.imageCredentials.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "workadventure.fullname" . }}-pull-secret
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}

--- a/contrib/helm/templates/uploader-deployment.yaml
+++ b/contrib/helm/templates/uploader-deployment.yaml
@@ -28,9 +28,14 @@ spec:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: uploader
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- if or .Values.imageCredentials.enabled .Values.imagePullSecrets }}
       imagePullSecrets:
+        {{- if .Values.imageCredentials.enabled }}
+        - name: {{ include "workadventure.fullname" . }}-pull-secret
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ include "workadventure.serviceAccountName" . }}
       securityContext:

--- a/contrib/helm/values.yaml
+++ b/contrib/helm/values.yaml
@@ -23,7 +23,18 @@ domainNamePrefix: "-"
 # If empty, a secret key will be generated and stored in the "shared-env-secret" secret.
 secretKey: ""
 
+# This sections will be used "as is" in the deployments (in the spec.template.spec.containers[0].imagePullSecrets section).
+# If you want to use a private registry and have basic needs, we recommend using the "imageCredentials" section instead.
 imagePullSecrets: []
+
+# If you want to use a private registry, you can use this section. All deployments will use the same credentials.
+imageCredentials:
+  enabled: false
+  registry: ""
+  username: ""
+  password: ""
+  email: ""
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
Adding in the Helm chart a way to configure easily image pull secrets in case someone wants to use a custom image protected by a secret.