### PR TITLE
Adding "allow" option in WA.ui.registerMenuCommand

### DIFF
--- a/docs/developer/map-scripting/references/api-ui.md
+++ b/docs/developer/map-scripting/references/api-ui.md
@@ -74,6 +74,7 @@ Add a custom menu item containing the text `commandDescriptor` in the navbar of 
 - `iframe: string` : A click on the custom menu will open the `iframe` inside the menu.
 - `key?: string` : A unique identifier for your menu item.
 - `allowApi?: boolean` : Allow the iframe of the custom menu to use the Scripting API.
+- `allow?: string` : The `allow` attribute used by the iframe.
 
 Important : `options` accepts only `callback` or `iframe` not both.
 

--- a/play/src/front/Api/Events/Ui/MenuEvents.ts
+++ b/play/src/front/Api/Events/Ui/MenuEvents.ts
@@ -11,6 +11,7 @@ export type UnregisterMenuEvent = z.infer<typeof isUnregisterMenuEvent>;
 
 export const isMenuRegisterOptions = z.object({
     allowApi: z.boolean(),
+    allow: z.string().optional(),
 });
 
 /**

--- a/play/src/front/Api/Iframe/ui.ts
+++ b/play/src/front/Api/Iframe/ui.ts
@@ -39,6 +39,10 @@ interface MenuDescriptor {
      * A unique technical key identifying this menu
      */
     key?: string;
+    /**
+     * The "allow" attribute of the iframe tag.
+     */
+    allow?: string;
 }
 
 export type MenuOptions = RequireOnlyOne<MenuDescriptor, "callback" | "iframe">;
@@ -202,6 +206,7 @@ export class WorkAdventureUiCommands extends IframeApiContribution<WorkAdventure
         if (typeof options === "function") {
             options = {
                 callback: options,
+                allow: undefined,
             };
         }
 
@@ -209,6 +214,7 @@ export class WorkAdventureUiCommands extends IframeApiContribution<WorkAdventure
             ...options,
             allowApi: options.allowApi === undefined ? options.iframe !== undefined : options.allowApi,
             key: options.key ?? v4(),
+            allow: options.allow,
         };
 
         const menu = new Menu(finalOptions.key);
@@ -222,6 +228,7 @@ export class WorkAdventureUiCommands extends IframeApiContribution<WorkAdventure
                     key: finalOptions.key,
                     options: {
                         allowApi: finalOptions.allowApi,
+                        allow: finalOptions.allow,
                     },
                 },
             });

--- a/play/src/front/Components/Menu/CustomSubMenu.svelte
+++ b/play/src/front/Components/Menu/CustomSubMenu.svelte
@@ -5,6 +5,8 @@
     export let url: string;
     export let allowApi: boolean;
 
+    export let allow: string | undefined;
+
     let HTMLIframe: HTMLIFrameElement;
 
     onMount(() => {
@@ -20,7 +22,7 @@
     });
 </script>
 
-<iframe title="customSubMenu" src={url} bind:this={HTMLIframe} />
+<iframe title="customSubMenu" src={url} bind:this={HTMLIframe} {allow} />
 
 <style lang="scss">
     iframe {

--- a/play/src/front/Components/Menu/Menu.svelte
+++ b/play/src/front/Components/Menu/Menu.svelte
@@ -27,7 +27,7 @@
 
     let activeSubMenu: MenuItem = $subMenusStore[$activeSubMenuStore];
     let activeComponent: typeof ProfileSubMenu | typeof CustomSubMenu = ProfileSubMenu;
-    let props: { url: string; allowApi: boolean };
+    let props: { url: string; allowApi: boolean; allow: string | undefined };
     let unsubscriberSubMenuStore: Unsubscriber;
     let unsubscriberActiveSubMenuStore: Unsubscriber;
 
@@ -100,7 +100,7 @@
             const customMenu = customMenuIframe.get(menu.key);
             if (customMenu !== undefined) {
                 activeSubMenu = menu;
-                props = { url: customMenu.url, allowApi: customMenu.allowApi };
+                props = { url: customMenu.url, allowApi: customMenu.allowApi, allow: customMenu.allow };
                 activeComponent = CustomSubMenu;
             } else {
                 sendMenuClickedEvent(menu.key);

--- a/play/src/front/Stores/MenuStore.ts
+++ b/play/src/front/Stores/MenuStore.ts
@@ -267,14 +267,14 @@ export function checkSubMenuToShow() {
     }
 }
 
-export const customMenuIframe = new Map<string, { url: string; allowApi: boolean }>();
+export const customMenuIframe = new Map<string, { url: string; allowApi: boolean; allow?: string | undefined }>();
 
 export function handleMenuRegistrationEvent(
     menuName: string,
     iframeUrl: string | undefined = undefined,
     key: string,
     source: string | undefined = undefined,
-    options: { allowApi: boolean }
+    options: { allowApi: boolean; allow?: string | undefined }
 ) {
     if (get(subMenusStore).find((item) => item.type === "scripting" && item.label === menuName)) {
         console.warn("The menu " + menuName + " already exist.");
@@ -285,7 +285,7 @@ export function handleMenuRegistrationEvent(
 
     if (iframeUrl !== undefined) {
         const url = new URL(iframeUrl, source);
-        customMenuIframe.set(key, { url: url.toString(), allowApi: options.allowApi });
+        customMenuIframe.set(key, { url: url.toString(), allowApi: options.allowApi, allow: options.allow });
     }
 }
 


### PR DESCRIPTION
The `WA.ui.registerMenuCommand` options now accept an additional `allow` that you can use to pass an optional "allow" attribute to the iframe opened in the submenu.

Useful to allow fullscreen or access to the clipboard from within the custom menu item.

Closes #4344 