### PR TITLE
Improve external module UX

### DIFF
--- a/play/src/front/Components/MapEditor/PropertyEditor/AddPropertyButtonWrapper.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/AddPropertyButtonWrapper.svelte
@@ -18,6 +18,7 @@
     import { connectionManager } from "../../../Connection/ConnectionManager";
     import { extensionModuleStore } from "../../../Stores/GameSceneStore";
     import { ExtensionModule, ExtensionModuleAreaProperty } from "../../../ExternalModule/ExtensionModule";
+    import { mapEditorRestrictedPropertiesStore } from "../../../Stores/MapEditorStore";
     import AddPropertyButton from "./AddPropertyButton.svelte";
 
     export let property: AreaDataPropertiesKeys | EntityDataPropertiesKeys;
@@ -85,15 +86,28 @@
     />
 {/if}
 {#if property === "jitsiRoomProperty"}
-    <AddPropertyButton
-        headerText={$LL.mapEditor.properties.jitsiProperties.label()}
-        descriptionText={$LL.mapEditor.properties.jitsiProperties.description()}
-        img={"resources/icons/icon_meeting.png"}
-        style={`z-index: 260;${isActive ? "background-color: #4156f6;" : ""}`}
-        on:click={(event) => {
-            dispatch("click", event);
-        }}
-    />
+    {#if $mapEditorRestrictedPropertiesStore.includes("jitsiRoomProperty")}
+        <AddPropertyButton
+            headerText={$LL.mapEditor.properties.jitsiProperties.label()}
+            descriptionText={$LL.mapEditor.properties.jitsiProperties.disabled()}
+            img={"resources/icons/icon_meeting.png"}
+            style={`z-index: 260;${isActive ? "background-color: #4156f6;cursor:not-allowed;" : ""}`}
+            on:click={(event) => {
+                dispatch("click", event);
+            }}
+            disabled={true}
+        />
+    {:else}
+        <AddPropertyButton
+            headerText={$LL.mapEditor.properties.jitsiProperties.label()}
+            descriptionText={$LL.mapEditor.properties.jitsiProperties.description()}
+            img={"resources/icons/icon_meeting.png"}
+            style={`z-index: 260;${isActive ? "background-color: #4156f6;" : ""}`}
+            on:click={(event) => {
+                dispatch("click", event);
+            }}
+        />
+    {/if}
 {/if}
 {#if property === "speakerMegaphone"}
     <AddPropertyButton

--- a/play/src/front/ExternalModule/ExtensionModule.ts
+++ b/play/src/front/ExternalModule/ExtensionModule.ts
@@ -26,6 +26,7 @@ export interface ExtensionModuleOptions {
     roomId: string;
     externalModuleMessage: Observable<ExternalModuleMessage>;
     externalSvelteComponent: Readable<ExternalSvelteComponentStore>;
+    externalRestrictedMapEditorProperties?: Readable<string[]>;
     onExtensionModuleStatusChange: (workAdventureNewStatus: AvailabilityStatus) => void;
     openCoWebSite: (
         openCoWebsiteObject: OpenCoWebsiteObject,

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -132,6 +132,7 @@ import { currentPlayerWokaStore } from "../../Stores/CurrentPlayerWokaStore";
 import {
     cameraResistanceModeStore,
     mapEditorModeStore,
+    mapEditorRestrictedPropertiesStore,
     mapEditorSelectedToolStore,
     mapEditorWamSettingsEditorToolCurrentMenuItemStore,
     mapExplorationModeStore,
@@ -1993,6 +1994,7 @@ export class GameScene extends DirtyScene {
                         logoutCallback: () => {
                             connectionManager.logout();
                         },
+                        externalRestrictedMapEditorProperties: mapEditorRestrictedPropertiesStore,
                     });
 
                     if (defaultExtensionModule.calendarSynchronised) isCalendarActiveStore.set(true);

--- a/play/src/front/Stores/MapEditorStore.ts
+++ b/play/src/front/Stores/MapEditorStore.ts
@@ -111,3 +111,5 @@ export const cameraResistanceModeStore = derived(
 export type CustomTag = "Custom";
 export type SelectableTag = string | CustomTag | undefined;
 export const selectCategoryStore = writable<SelectableTag>(undefined);
+
+export const mapEditorRestrictedPropertiesStore = writable<string[]>([]);

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -61,6 +61,7 @@ const mapEditor: BaseTranslation = {
                 cancel: "Cancel",
                 validate: "Validate",
             },
+            disabled: "Jitsi integration is disabled for this room ❌",
         },
         audioProperties: {
             label: "Play Audio File",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -62,6 +62,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "Annuler",
                 validate: "Valider",
             },
+            disabled: "L'intégration Jitsi est désactivée pour cette carte ❌",
         },
         audioProperties: {
             label: "Jouer un fichier audio",


### PR DESCRIPTION
Create store to disable or enable properties in the map editor. One module is able to update properties of the map editor for the current room.