### PR TITLE
Fixing multiple click on copy in cowebsites

### DIFF
--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -482,7 +482,7 @@
     const onClickOutside = () => {
         //if ($emoteMenuSubStore) emoteMenuSubStore.closeEmoteMenu();
         //if (appMenuOpened) appMenuOpened = false;
-        console.log("Trouble on click outside : it cause open and directly close emote / Appmenu");
+        //console.log("Trouble on click outside : it cause open and directly close emote / Appmenu");
     };
 
     function openAppMenu() {

--- a/play/src/front/Stores/PopupStore.ts
+++ b/play/src/front/Stores/PopupStore.ts
@@ -26,12 +26,21 @@ function createPopupStore() {
                 if (uuid === undefined) {
                     uuid = v4();
                 }
-
-                list.push({
-                    uuid,
-                    component: popup,
-                    props,
-                });
+                // Look for an existing popup with the same uuid, and if existing, replace it
+                const index = list.findIndex((item) => item.uuid === uuid);
+                if (index !== -1) {
+                    list[index] = {
+                        uuid,
+                        component: popup,
+                        props,
+                    };
+                } else {
+                    list.push({
+                        uuid,
+                        component: popup,
+                        props,
+                    });
+                }
                 return list;
             });
         },


### PR DESCRIPTION
The bug was due to a crash of Svelte when several Popups have the same UUID. Now, when adding a popup that has the same UUID as another popup, the previous popup is replaced.

Closes #4421