### PR TITLE
Fix when the GameScene is reload for external module

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1074,6 +1074,7 @@ export class GameScene extends DirtyScene {
         get(extensionModuleStore).forEach((extensionModule) => {
             extensionModule.destroy();
         });
+        extensionModuleStore.set([]);
 
         //When we leave game, the camera is stop to be reopen after.
         // I think that we could keep camera status and the scene can manage camera setup


### PR DESCRIPTION
We need to call destroy of the external module and clean the store.