### PR TITLE
Migrating to ts-proto version 2.4.2

### DIFF
--- a/libs/messages/package.json
+++ b/libs/messages/package.json
@@ -11,11 +11,11 @@
   "license": "ISC",
   "dependencies": {
     "@anatine/zod-openapi": "^1.3.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@grpc/grpc-js": "^1.7.1",
     "google-protobuf": "^3.21.0",
     "long": "^5.2.1",
     "openapi3-ts": "^3.0.2",
-    "protobufjs": "^7.2.4",
     "rxjs": "6.6.3",
     "zod": "^3.23.8"
   },

--- a/libs/room-api-clients/room-api-client-js/package-lock.json
+++ b/libs/room-api-clients/room-api-client-js/package-lock.json
@@ -23,7 +23,7 @@
         "grpc-tools": "^1.12.4",
         "lint-staged": "^13.2.0",
         "prettier": "^2.8.6",
-        "ts-proto": "^1.164.1",
+        "ts-proto": "^2.4.2",
         "tsx": "^4.7.0",
         "typescript": "^5.0.2"
       }
@@ -355,6 +355,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.2.tgz",
+      "integrity": "sha512-UNtPCbrwrenpmrXuRwn9jYpPoweNXj8X5sMvYgsqYyaH8jQ6LfUJSk3dJLnBK+6sfYPrF4iAIo5sd5HQ+tg75A==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.11",
@@ -1888,6 +1895,7 @@
       "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.8.tgz",
       "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^1.0.3"
       }
@@ -1897,6 +1905,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -3862,37 +3871,39 @@
       "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="
     },
     "node_modules/ts-poet": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.6.0.tgz",
-      "integrity": "sha512-4vEH/wkhcjRPFOdBwIh9ItO6jOoumVLRF4aABDX5JSNEubSqwOulihxQPqai+OkuygJm3WYMInxXQX4QwVNMuw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.9.0.tgz",
+      "integrity": "sha512-roe6W6MeZmCjRmppyfOURklO5tQFQ6Sg7swURKkwYJvV7dbGCrK28um5+51iW3twdPRKtwarqFAVMU6G1mvnuQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "dprint-node": "^1.0.7"
+        "dprint-node": "^1.0.8"
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.164.1",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.164.1.tgz",
-      "integrity": "sha512-zClJYMo5ZrZoMJZyEJHI7eNxAOY4XhJecsyi/D4gyqBTQ6HYjQHzBF/RT7bScfXP/Z5dpS5IaoAxWyR8npEjPA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-2.4.2.tgz",
+      "integrity": "sha512-fwZeyFRLcHSDpKnbSnrAeN67v3ujVt6+DVnu2UHBkJm/grvCI4QLMlO9TkoK3XXRlQqI6i17b0c4v9uDRzsWuQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
         "case-anything": "^2.1.13",
-        "protobufjs": "^7.2.4",
-        "ts-poet": "^6.5.0",
-        "ts-proto-descriptors": "1.15.0"
+        "ts-poet": "^6.7.0",
+        "ts-proto-descriptors": "2.0.0"
       },
       "bin": {
         "protoc-gen-ts_proto": "protoc-gen-ts_proto"
       }
     },
     "node_modules/ts-proto-descriptors": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.15.0.tgz",
-      "integrity": "sha512-TYyJ7+H+7Jsqawdv+mfsEpZPTIj9siDHS6EMCzG/z3b/PZiphsX+mWtqFfFVe5/N0Th6V3elK9lQqjnrgTOfrg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-2.0.0.tgz",
+      "integrity": "sha512-wHcTH3xIv11jxgkX5OyCSFfw27agpInAd6yh89hKG6zqIXnjW9SYqSER2CVQxdPj4czeOhGagNvZBEbJPy7qkw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "long": "^5.2.3",
-        "protobufjs": "^7.2.4"
+        "@bufbuild/protobuf": "^2.0.0"
       }
     },
     "node_modules/tslib": {
@@ -4445,6 +4456,12 @@
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@bufbuild/protobuf": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.2.tgz",
+      "integrity": "sha512-UNtPCbrwrenpmrXuRwn9jYpPoweNXj8X5sMvYgsqYyaH8jQ6LfUJSk3dJLnBK+6sfYPrF4iAIo5sd5HQ+tg75A==",
+      "dev": true
     },
     "@esbuild/aix-ppc64": {
       "version": "0.19.11",
@@ -6870,34 +6887,33 @@
       "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="
     },
     "ts-poet": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.6.0.tgz",
-      "integrity": "sha512-4vEH/wkhcjRPFOdBwIh9ItO6jOoumVLRF4aABDX5JSNEubSqwOulihxQPqai+OkuygJm3WYMInxXQX4QwVNMuw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.9.0.tgz",
+      "integrity": "sha512-roe6W6MeZmCjRmppyfOURklO5tQFQ6Sg7swURKkwYJvV7dbGCrK28um5+51iW3twdPRKtwarqFAVMU6G1mvnuQ==",
       "dev": true,
       "requires": {
-        "dprint-node": "^1.0.7"
+        "dprint-node": "^1.0.8"
       }
     },
     "ts-proto": {
-      "version": "1.164.1",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.164.1.tgz",
-      "integrity": "sha512-zClJYMo5ZrZoMJZyEJHI7eNxAOY4XhJecsyi/D4gyqBTQ6HYjQHzBF/RT7bScfXP/Z5dpS5IaoAxWyR8npEjPA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-2.4.2.tgz",
+      "integrity": "sha512-fwZeyFRLcHSDpKnbSnrAeN67v3ujVt6+DVnu2UHBkJm/grvCI4QLMlO9TkoK3XXRlQqI6i17b0c4v9uDRzsWuQ==",
       "dev": true,
       "requires": {
+        "@bufbuild/protobuf": "^2.0.0",
         "case-anything": "^2.1.13",
-        "protobufjs": "^7.2.4",
-        "ts-poet": "^6.5.0",
-        "ts-proto-descriptors": "1.15.0"
+        "ts-poet": "^6.7.0",
+        "ts-proto-descriptors": "2.0.0"
       }
     },
     "ts-proto-descriptors": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.15.0.tgz",
-      "integrity": "sha512-TYyJ7+H+7Jsqawdv+mfsEpZPTIj9siDHS6EMCzG/z3b/PZiphsX+mWtqFfFVe5/N0Th6V3elK9lQqjnrgTOfrg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-2.0.0.tgz",
+      "integrity": "sha512-wHcTH3xIv11jxgkX5OyCSFfw27agpInAd6yh89hKG6zqIXnjW9SYqSER2CVQxdPj4czeOhGagNvZBEbJPy7qkw==",
       "dev": true,
       "requires": {
-        "long": "^5.2.3",
-        "protobufjs": "^7.2.4"
+        "@bufbuild/protobuf": "^2.0.0"
       }
     },
     "tslib": {

--- a/libs/room-api-clients/room-api-client-js/package.json
+++ b/libs/room-api-clients/room-api-client-js/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/thecodingmachine/workadventure/tree/master/libs/room-api-clients/room-api-client-js#readme",
   "dependencies": {
+    "@bufbuild/protobuf": "^2.2.2",
     "long": "^5.2.1",
-    "nice-grpc": "^2.1.3",
-    "protobufjs": "^7.2.2"
+    "nice-grpc": "^2.1.3"
   },
   "devDependencies": {
     "@types/node": "^18.15.5",
@@ -49,7 +49,7 @@
     "grpc-tools": "^1.12.4",
     "lint-staged": "^13.2.0",
     "prettier": "^2.8.6",
-    "ts-proto": "^1.164.1",
+    "ts-proto": "^2.4.2",
     "tsx": "^4.7.0",
     "typescript": "^5.0.2"
   },

--- a/messages/package-lock.json
+++ b/messages/package-lock.json
@@ -14,10 +14,11 @@
         "google-protobuf": "^3.21.2",
         "npm-run-all": "^4.1.5",
         "openapi3-ts": "^3.0.2",
-        "ts-proto": "^1.164.1",
+        "ts-proto": "^2.4.2",
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@bufbuild/protobuf": "^2.2.2",
         "@types/google-protobuf": "^3.15.6",
         "@types/node": "^14.14.7",
         "@typescript-eslint/eslint-plugin": "^5.44.0",
@@ -32,7 +33,6 @@
         "grpc-tools": "^1.11.3",
         "lint-staged": "^11.0.0",
         "prettier": "^2.8.1",
-        "protobufjs": "^7.2.4",
         "rimraf": "^3.0.2",
         "shelljs": "^0.8.5",
         "sync-directory": "^5.1.7",
@@ -154,6 +154,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.2.tgz",
+      "integrity": "sha512-UNtPCbrwrenpmrXuRwn9jYpPoweNXj8X5sMvYgsqYyaH8jQ6LfUJSk3dJLnBK+6sfYPrF4iAIo5sd5HQ+tg75A=="
     },
     "node_modules/@definitelytyped/header-parser": {
       "version": "0.2.9",
@@ -6411,26 +6416,25 @@
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.176.2",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.176.2.tgz",
-      "integrity": "sha512-lISYoJeutvl79MEJhAafdXbad9L48FjSuy+pg3YlAtX7ZY8LBfu4Wh00ac7DWC9GREzS0SfXeCqWbS2Rb4wEGQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-2.4.2.tgz",
+      "integrity": "sha512-fwZeyFRLcHSDpKnbSnrAeN67v3ujVt6+DVnu2UHBkJm/grvCI4QLMlO9TkoK3XXRlQqI6i17b0c4v9uDRzsWuQ==",
       "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
         "case-anything": "^2.1.13",
-        "protobufjs": "^7.2.4",
         "ts-poet": "^6.7.0",
-        "ts-proto-descriptors": "1.16.0"
+        "ts-proto-descriptors": "2.0.0"
       },
       "bin": {
         "protoc-gen-ts_proto": "protoc-gen-ts_proto"
       }
     },
     "node_modules/ts-proto-descriptors": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.16.0.tgz",
-      "integrity": "sha512-3yKuzMLpltdpcyQji1PJZRfoo4OJjNieKTYkQY8pF7xGKsYz/RHe3aEe4KiRxcinoBmnEhmuI+yJTxLb922ULA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-2.0.0.tgz",
+      "integrity": "sha512-wHcTH3xIv11jxgkX5OyCSFfw27agpInAd6yh89hKG6zqIXnjW9SYqSER2CVQxdPj4czeOhGagNvZBEbJPy7qkw==",
       "dependencies": {
-        "long": "^5.2.3",
-        "protobufjs": "^7.2.4"
+        "@bufbuild/protobuf": "^2.0.0"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/messages/package.json
+++ b/messages/package.json
@@ -17,10 +17,11 @@
     "google-protobuf": "^3.21.2",
     "npm-run-all": "^4.1.5",
     "openapi3-ts": "^3.0.2",
-    "ts-proto": "^1.164.1",
+    "ts-proto": "^2.4.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@bufbuild/protobuf": "^2.2.2",
     "@types/google-protobuf": "^3.15.6",
     "@types/node": "^14.14.7",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
@@ -35,7 +36,6 @@
     "grpc_tools_node_protoc_ts": "^5.3.2",
     "lint-staged": "^11.0.0",
     "prettier": "^2.8.1",
-    "protobufjs": "^7.2.4",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.5",
     "sync-directory": "^5.1.7",

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -211,8 +211,8 @@ message EditMapCommandWithKeyMessage {
 message ModifyAreaMessage {
   string id = 1;
   optional string name = 2;
-  optional uint32 x = 3;
-  optional uint32 y = 4;
+  optional int32 x = 3;
+  optional int32 y = 4;
   optional uint32 width = 5;
   optional uint32 height = 6;
   repeated google.protobuf.Value properties = 7;
@@ -226,8 +226,8 @@ message DeleteAreaMessage {
 
 message CreateAreaMessage {
   string id = 1;
-  uint32 x = 2;
-  uint32 y = 3;
+  int32 x = 2;
+  int32 y = 3;
   uint32 width = 4;
   uint32 height = 5;
   string name = 6;
@@ -236,8 +236,8 @@ message CreateAreaMessage {
 
 message CreateEntityMessage {
   string id = 1;
-  uint32 x = 2;
-  uint32 y = 3;
+  int32 x = 2;
+  int32 y = 3;
   string collectionName = 4;
   string prefabId = 5;
   repeated google.protobuf.Value properties = 6;
@@ -287,8 +287,8 @@ message DeleteCustomEntityMessage {
 
 message ModifyEntityMessage {
   string id = 1;
-  uint32 x = 2;
-  uint32 y = 3;
+  int32 x = 2;
+  int32 y = 3;
   repeated google.protobuf.Value properties = 4;
   optional bool modifyProperties = 5;
   optional string name = 6;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,11 +1819,11 @@
       "license": "ISC",
       "dependencies": {
         "@anatine/zod-openapi": "^1.3.0",
+        "@bufbuild/protobuf": "^2.2.2",
         "@grpc/grpc-js": "^1.7.1",
         "google-protobuf": "^3.21.0",
         "long": "^5.2.1",
         "openapi3-ts": "^3.0.2",
-        "protobufjs": "^7.2.4",
         "rxjs": "6.6.3",
         "zod": "^3.23.8"
       },
@@ -3960,6 +3960,12 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.2.tgz",
+      "integrity": "sha512-UNtPCbrwrenpmrXuRwn9jYpPoweNXj8X5sMvYgsqYyaH8jQ6LfUJSk3dJLnBK+6sfYPrF4iAIo5sd5HQ+tg75A==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -29808,6 +29814,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@bufbuild/protobuf": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.2.tgz",
+      "integrity": "sha512-UNtPCbrwrenpmrXuRwn9jYpPoweNXj8X5sMvYgsqYyaH8jQ6LfUJSk3dJLnBK+6sfYPrF4iAIo5sd5HQ+tg75A=="
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -34109,12 +34120,12 @@
       "version": "file:libs/messages",
       "requires": {
         "@anatine/zod-openapi": "^1.3.0",
+        "@bufbuild/protobuf": "^2.2.2",
         "@grpc/grpc-js": "^1.7.1",
         "@types/node": "^18.7.17",
         "google-protobuf": "^3.21.0",
         "long": "^5.2.1",
         "openapi3-ts": "^3.0.2",
-        "protobufjs": "^7.2.4",
         "rxjs": "6.6.3",
         "typescript": "^4.7.2",
         "zod": "^3.23.8"

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -1086,6 +1086,19 @@ export class RoomConnection implements RoomConnection {
     }
 
     public emitMapEditorModifyArea(commandId: string, config: AtLeast<AreaData, "id">): void {
+        // We need to round the values because previous versions of WorkAdventure saved them as floats
+        if (config.x !== undefined) {
+            config.x = Math.round(config.x);
+        }
+        if (config.y !== undefined) {
+            config.y = Math.round(config.y);
+        }
+        if (config.width !== undefined) {
+            config.width = Math.round(config.width);
+        }
+        if (config.height !== undefined) {
+            config.height = Math.round(config.height);
+        }
         this.send({
             message: {
                 $case: "editMapCommandMessage",
@@ -1143,6 +1156,18 @@ export class RoomConnection implements RoomConnection {
     }
 
     public emitMapEditorCreateArea(commandId: string, config: AreaData): void {
+        if (config.x !== undefined) {
+            config.x = Math.round(config.x);
+        }
+        if (config.y !== undefined) {
+            config.y = Math.round(config.y);
+        }
+        if (config.width !== undefined) {
+            config.width = Math.round(config.width);
+        }
+        if (config.height !== undefined) {
+            config.height = Math.round(config.height);
+        }
         this.send({
             message: {
                 $case: "editMapCommandMessage",

--- a/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
+++ b/play/src/front/Phaser/Components/MapEditor/AreaPreview.ts
@@ -267,10 +267,10 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
                 counter++;
             }
         }
-        this.x = this.areaData.x + this.areaData.width * 0.5;
-        this.y = this.areaData.y + this.areaData.height * 0.5;
-        this.displayWidth = this.areaData.width;
-        this.displayHeight = this.areaData.height;
+        this.x = Math.floor(this.areaData.x + this.areaData.width * 0.5);
+        this.y = Math.floor(this.areaData.y + this.areaData.height * 0.5);
+        this.displayWidth = Math.floor(this.areaData.width);
+        this.displayHeight = Math.floor(this.areaData.height);
         this.updateSquaresPositions();
     }
 
@@ -309,11 +309,11 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
                 if (this.shiftKey?.isDown) {
                     const topLeftX = Math.floor((dragX - this.displayWidth * 0.5) / 32) * 32;
                     const topLeftY = Math.floor((dragY - this.displayHeight * 0.5) / 32) * 32;
-                    this.x = topLeftX + this.displayWidth * 0.5;
-                    this.y = topLeftY + this.displayHeight * 0.5;
+                    this.x = Math.round(topLeftX + this.displayWidth * 0.5);
+                    this.y = Math.round(topLeftY + this.displayHeight * 0.5);
                 } else {
-                    this.x = dragX;
-                    this.y = dragY;
+                    this.x = Math.round(dragX);
+                    this.y = Math.round(dragY);
                 }
                 this.updateSquaresPositions();
                 this.moved = true;
@@ -342,8 +342,8 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
                 this.updateAreaDataWithSquaresAdjustments();
                 const data: AtLeast<AreaData, "id"> = {
                     id: this.getAreaData().id,
-                    x: this.x - this.displayWidth * 0.5,
-                    y: this.y - this.displayHeight * 0.5,
+                    x: Math.floor(this.x - this.displayWidth * 0.5),
+                    y: Math.floor(this.y - this.displayHeight * 0.5),
                     width: this.displayWidth,
                     height: this.displayHeight,
                 };
@@ -379,13 +379,13 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
 
                     if (newWidth >= 10) {
                         this.displayWidth = newWidth;
-                        this.x = this.squares[Edge.LeftCenter].x + this.displayWidth * 0.5;
+                        this.x = Math.floor(this.squares[Edge.LeftCenter].x + this.displayWidth * 0.5);
                     } else {
                         square.x = oldX;
                     }
                     if (newHeight >= 10) {
                         this.displayHeight = newHeight;
-                        this.y = this.squares[Edge.TopCenter].y + this.displayHeight * 0.5;
+                        this.y = Math.floor(this.squares[Edge.TopCenter].y + this.displayHeight * 0.5);
                     } else {
                         square.y = oldY;
                     }
@@ -424,13 +424,13 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
 
                 if (newWidth >= 10) {
                     this.displayWidth = newWidth;
-                    this.x = newCenterX;
+                    this.x = Math.floor(newCenterX);
                 } else {
                     square.x = oldX;
                 }
                 if (newHeight >= 10) {
                     this.displayHeight = newHeight;
-                    this.y = newCenterY;
+                    this.y = Math.floor(newCenterY);
                 } else {
                     square.y = oldY;
                 }
@@ -447,8 +447,8 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
                 this.updateAreaDataWithSquaresAdjustments();
                 const data: AtLeast<AreaData, "id"> = {
                     id: this.getAreaData().id,
-                    x: this.x - this.displayWidth * 0.5,
-                    y: this.y - this.displayHeight * 0.5,
+                    x: Math.floor(this.x - this.displayWidth * 0.5),
+                    y: Math.floor(this.y - this.displayHeight * 0.5),
                     width: this.displayWidth,
                     height: this.displayHeight,
                 };
@@ -471,10 +471,10 @@ export class AreaPreview extends Phaser.GameObjects.Rectangle {
     private updateAreaDataWithSquaresAdjustments(): void {
         this.areaData = {
             ...this.areaData,
-            x: this.x - this.displayWidth * 0.5,
-            y: this.y - this.displayHeight * 0.5,
-            width: this.displayWidth,
-            height: this.displayHeight,
+            x: Math.floor(this.x - this.displayWidth * 0.5),
+            y: Math.floor(this.y - this.displayHeight * 0.5),
+            width: Math.floor(this.displayWidth),
+            height: Math.floor(this.displayHeight),
         };
     }
 

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/svelte";
 import { Command, PersonalAreaPropertyData, UpdateWAMSettingCommand } from "@workadventure/map-editor";
 import { get, Unsubscriber } from "svelte/store";
 import { EditMapCommandMessage } from "@workadventure/messages";
@@ -144,7 +145,8 @@ export class MapEditorModeManager {
                 this.scene.getGameMap().updateLastCommandIdProperty(command.commandId);
                 return;
             } catch (error) {
-                logger(error);
+                console.error(error);
+                Sentry.captureException(error);
                 return;
             }
         }));
@@ -159,7 +161,8 @@ export class MapEditorModeManager {
                 this.scene.getGameMap().updateLastCommandIdProperty(command.commandId);
                 return;
             } catch (error) {
-                logger(error);
+                console.error(error);
+                Sentry.captureException(error);
                 return;
             }
         }));
@@ -185,7 +188,8 @@ export class MapEditorModeManager {
         } catch (e) {
             this.localCommandsHistory.splice(this.currentCommandIndex, 1);
             this.currentCommandIndex -= 1;
-            logger(e);
+            console.error(e);
+            Sentry.captureException(e);
         }
     }
 
@@ -211,7 +215,8 @@ export class MapEditorModeManager {
         } catch (e) {
             this.localCommandsHistory.splice(this.currentCommandIndex, 1);
             this.currentCommandIndex -= 1;
-            logger(e);
+            console.error(e);
+            Sentry.captureException(e);
         }
     }
 


### PR DESCRIPTION
This version contains a performance fix for Typescript 5.1+.
    
See https://github.com/stephenh/ts-proto/pull/1142