### PR TITLE
Hot fix CoWebsite

### DIFF
--- a/play/src/front/WebRtc/CoWebsiteManager.ts
+++ b/play/src/front/WebRtc/CoWebsiteManager.ts
@@ -754,6 +754,7 @@ class CoWebsiteManager {
 
     public closeCoWebsite(coWebsite: CoWebsite, withStack = true): void {
         if (get(coWebsites).length === 1) {
+            this.restoreMainSize();
             this.fire();
         }
 


### PR DESCRIPTION
Error when we open the CoWebsite to the max and close it. Error:
phaser.js:193129  Uncaught Error: Framebuffer status: Incomplete Attachment
    at initialize.createResource (phaser.js:193129:19)
    at new initialize (phaser.js:193090:14)
    at initialize.createFramebuffer (phaser.js:181628:27)
    at initialize.resize (phaser.js:176295:41)
    at a.emit (phaser.js:220:33)
    at initialize.resize (phaser.js:180812:14)
    at initialize.onResize (phaser.js:180737:18)
    at a.emit (phaser.js:227:27)
    at initialize.refresh (phaser.js:194945:14)
    at initialize.resize (phaser.js:194833:21)
    at OUA.applyNewSize (WaScaleManager.ts:51:31)
    at A._next (svelte.ts:202:20)
    at A.__tryOrUnsub (Subscriber.js:192:16)
    at A.next (Subscriber.js:130:22)
    at A._next (Subscriber.js:76:26)
    at A.next (Subscriber.js:53:18)
    at A.next (Subject.js:47:25)
    at FUA.fire (CoWebsiteManager.ts:800:24)
    at FUA.closeCoWebsite (CoWebsiteManager.ts:757:18)
    at HTMLButtonElement.<anonymous> (CoWebsiteManager.ts:160:22)