### PR TITLE
Upgrading hyper-express to 6.17.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14832,36 +14832,47 @@
       }
     },
     "node_modules/hyper-express": {
-      "version": "6.17.2",
-      "resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.17.2.tgz",
-      "integrity": "sha512-zibRNaNA3ExaYIiypHPEbFCZ3fOT2zSCnn3v78lUOrvQGqeb7VVzKuQKmJUsbkzpp7tKZoDxM4l5avpQHm35dA==",
+      "version": "6.17.3",
+      "resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.17.3.tgz",
+      "integrity": "sha512-fNFrRVEAIqjADtAq2F5wFRBlpo3G63QgK9PsNklsKLpM2S3fNlFaojafv926mlEW+C4zZ1VI8Tm5PCJOaIWJMQ==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "^1.3.7",
-        "busboy": "^1.0.0",
-        "cookie": "^0.4.1",
-        "cookie-signature": "^1.1.0",
-        "mime-types": "^2.1.33",
+        "busboy": "^1.6.0",
+        "cookie": "^1.0.1",
+        "cookie-signature": "^1.2.1",
+        "mime-types": "^2.1.35",
+        "negotiator": "^1.0.0",
         "range-parser": "^1.2.1",
         "type-is": "^1.6.18",
         "typed-emitter": "^2.1.0",
-        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.48.0"
+        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.51.0"
       }
     },
     "node_modules/hyper-express/node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
       }
     },
     "node_modules/hyper-express/node_modules/cookie-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.0.tgz",
-      "integrity": "sha512-R0BOPfLGTitaKhgKROKZQN6iyq2iDQcH1DOF8nJoaWapguX5bC2w+Q/I9NmmM5lfcvEarnLZr+cCvmEYYSXvYA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/hyper-express/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/i18next": {
@@ -26586,7 +26597,7 @@
         "google-protobuf": "^3.21.0",
         "highlight-words": "^1.2.2",
         "highlight.js": "^11.10.0",
-        "hyper-express": "^6.17.2",
+        "hyper-express": "^6.17.3",
         "jsonwebtoken": "^9.0.0",
         "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#v1827.0.0+142c4410",
         "live-directory": "moufmouf/live-directory#hot_reload_param",
@@ -38779,30 +38790,35 @@
       "dev": true
     },
     "hyper-express": {
-      "version": "6.17.2",
-      "resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.17.2.tgz",
-      "integrity": "sha512-zibRNaNA3ExaYIiypHPEbFCZ3fOT2zSCnn3v78lUOrvQGqeb7VVzKuQKmJUsbkzpp7tKZoDxM4l5avpQHm35dA==",
+      "version": "6.17.3",
+      "resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.17.3.tgz",
+      "integrity": "sha512-fNFrRVEAIqjADtAq2F5wFRBlpo3G63QgK9PsNklsKLpM2S3fNlFaojafv926mlEW+C4zZ1VI8Tm5PCJOaIWJMQ==",
       "requires": {
-        "accepts": "^1.3.7",
-        "busboy": "^1.0.0",
-        "cookie": "^0.4.1",
-        "cookie-signature": "^1.1.0",
-        "mime-types": "^2.1.33",
+        "busboy": "^1.6.0",
+        "cookie": "^1.0.1",
+        "cookie-signature": "^1.2.1",
+        "mime-types": "^2.1.35",
+        "negotiator": "^1.0.0",
         "range-parser": "^1.2.1",
         "type-is": "^1.6.18",
         "typed-emitter": "^2.1.0",
-        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.48.0"
+        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.51.0"
       },
       "dependencies": {
         "cookie": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+          "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="
         },
         "cookie-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.0.tgz",
-          "integrity": "sha512-R0BOPfLGTitaKhgKROKZQN6iyq2iDQcH1DOF8nJoaWapguX5bC2w+Q/I9NmmM5lfcvEarnLZr+cCvmEYYSXvYA=="
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+          "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+        },
+        "negotiator": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+          "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
         }
       }
     },
@@ -47279,7 +47295,7 @@
         "google-protobuf": "^3.21.0",
         "highlight-words": "^1.2.2",
         "highlight.js": "^11.10.0",
-        "hyper-express": "^6.17.2",
+        "hyper-express": "^6.17.3",
         "jsdom": "^20.0.1",
         "jsonwebtoken": "^9.0.0",
         "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#v1827.0.0+142c4410",

--- a/play/package.json
+++ b/play/package.json
@@ -137,7 +137,7 @@
     "google-protobuf": "^3.21.0",
     "highlight-words": "^1.2.2",
     "highlight.js": "^11.10.0",
-    "hyper-express": "^6.17.2",
+    "hyper-express": "^6.17.3",
     "jsonwebtoken": "^9.0.0",
     "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#v1827.0.0+142c4410",
     "live-directory": "moufmouf/live-directory#hot_reload_param",


### PR DESCRIPTION
In the hope this will fix the µWebSockets bug with HTTP header too large / HTTP version not supported.