### PR TITLE
Change DNS resolve method for IPv6 only server

### DIFF
--- a/libs/map-editor/src/MapFetcher.ts
+++ b/libs/map-editor/src/MapFetcher.ts
@@ -1,5 +1,4 @@
-import { Resolver } from "dns";
-import { promisify } from "util";
+import dnsPromises from "dns/promises";
 import path from "path";
 import ipaddr from "ipaddr.js";
 import axios from "axios";
@@ -143,9 +142,10 @@ class MapFetcher {
         }
 
         let addresses = [];
-        if (!ipaddr.isValid(urlObj.hostname)) {
-            const resolver = new Resolver();
-            addresses = await promisify(resolver.resolve).bind(resolver)(urlObj.hostname);
+        if (urlObj.hostname.startsWith("[") && urlObj.hostname.endsWith("]")) {
+            addresses = [urlObj.hostname.slice(1, -1)];
+        } else if (!ipaddr.isValid(urlObj.hostname)) {
+            addresses = (await dnsPromises.lookup(urlObj.hostname, { all: true })).map((x) => x.address);
         } else {
             addresses = [urlObj.hostname];
         }

--- a/libs/map-editor/tests/MapFetcher.test.ts
+++ b/libs/map-editor/tests/MapFetcher.test.ts
@@ -9,6 +9,7 @@ describe("MapFetcher", () => {
 
     it("should return true on DNS resolving to a local domain", async () => {
         expect(await mapFetcher.isLocalUrl("https://127.0.0.1.nip.io")).toBe(true);
+        expect(await mapFetcher.isLocalUrl("https://fe80--1.sslip.io")).toBe(true);
     });
 
     it("should return true on an IP resolving to a local domain", async () => {
@@ -18,10 +19,12 @@ describe("MapFetcher", () => {
 
     it("should return false on an IP resolving to a global domain", async () => {
         expect(await mapFetcher.isLocalUrl("https://51.12.42.42")).toBe(false);
+        expect(await mapFetcher.isLocalUrl("https://[2606:4700:4700::1111]")).toBe(false);
     });
 
     it("should return false on an DNS resolving to a global domain", async () => {
         expect(await mapFetcher.isLocalUrl("https://maps.workadventu.re")).toBe(false);
+        expect(await mapFetcher.isLocalUrl("https://2606-4700-4700--1111.sslip.io")).toBe(false);
     });
 
     it("should throw error on invalid domain", async () => {

--- a/libs/map-editor/tests/MapFetcher.test.ts
+++ b/libs/map-editor/tests/MapFetcher.test.ts
@@ -15,6 +15,7 @@ describe("MapFetcher", () => {
     it("should return true on an IP resolving to a local domain", async () => {
         expect(await mapFetcher.isLocalUrl("https://127.0.0.1")).toBe(true);
         expect(await mapFetcher.isLocalUrl("https://192.168.0.1")).toBe(true);
+        expect(await mapFetcher.isLocalUrl("https://[fd01::1]")).toBe(true);
     });
 
     it("should return false on an IP resolving to a global domain", async () => {


### PR DESCRIPTION
Close #4557 

`resolve` only use A record in default.
`lookup` is good for resolving IPv4 and IPv6.

Changing to dns.promises is not necessary but I think it is good.