### PR TITLE
Fix menu apps button

### DIFF
--- a/play/src/front/Components/ActionBar/MenuIcons/AppsMenuContent.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/AppsMenuContent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { setContext } from "svelte";
+    import { get } from "svelte/store";
     import { openedMenuStore, roomListActivated } from "../../../Stores/MenuStore";
     import ActionBarButton from "../ActionBarButton.svelte";
     import ExternalComponents from "../../ExternalModules/ExternalComponents.svelte";
@@ -43,8 +44,10 @@
         resetChatVisibility();
         resetModalVisibility();
 
+        console.log("1showRoomList", get(openedMenuStore));
         roomListVisibilityStore.set(true);
-        openedMenuStore.toggle("appMenu");
+        openedMenuStore.close("appMenu");
+        console.log("2showRoomList", get(openedMenuStore));
     }
 
     function openExternalModuleCalendar() {
@@ -52,7 +55,7 @@
         isCalendarVisibleStore.set(!$isCalendarVisibleStore);
         isTodoListVisibleStore.set(false);
         mapEditorModeStore.switchMode(false);
-        openedMenuStore.toggle("appMenu");
+        openedMenuStore.close("appMenu");
     }
 
     function openExternalModuleTodoList() {
@@ -66,9 +69,11 @@
 
 <!-- Room list part -->
 {#if $roomListActivated}
-    <ActionBarButton on:click={showRoomList} label={$LL.actionbar.help.roomList.title()}>
-        <WorldIcon />
-    </ActionBarButton>
+    <div on:click|stopPropagation={showRoomList} on:keydown|stopPropagation={showRoomList}>
+        <ActionBarButton label={$LL.actionbar.help.roomList.title()}>
+            <WorldIcon />
+        </ActionBarButton>
+    </div>
 {/if}
 
 <!-- Calendar integration -->

--- a/play/src/front/Components/ActionBar/MenuIcons/AppsMenuContent.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/AppsMenuContent.svelte
@@ -44,7 +44,7 @@
         resetModalVisibility();
 
         roomListVisibilityStore.set(true);
-        openedMenuStore.close("appMenu");
+        openedMenuStore.toggle("appMenu");
     }
 
     function openExternalModuleCalendar() {
@@ -52,7 +52,7 @@
         isCalendarVisibleStore.set(!$isCalendarVisibleStore);
         isTodoListVisibleStore.set(false);
         mapEditorModeStore.switchMode(false);
-        openedMenuStore.close("appMenu");
+        openedMenuStore.toggle("appMenu");
     }
 
     function openExternalModuleTodoList() {

--- a/play/src/front/Components/ActionBar/MenuIcons/AppsMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/AppsMenuItem.svelte
@@ -7,6 +7,7 @@
     import LL from "../../../../i18n/i18n-svelte";
     import { isActivatedStore as isCalendarActivatedStore } from "../../../Stores/CalendarStore";
     import { isActivatedStore as isTodoListActivatedStore } from "../../../Stores/TodoListStore";
+    import { roomListVisibilityStore } from "../../../Stores/ModalStore";
     import { externalSvelteComponentService } from "../../../Stores/Utils/externalSvelteComponentService";
     import AppsMenuContent from "./AppsMenuContent.svelte";
     import HeaderMenuItem from "./HeaderMenuItem.svelte";
@@ -24,48 +25,34 @@
         //strategy: 'fixed',
     });
     const extraOpts = {
-        modifiers: [
-            { name: "offset", options: { offset: [0, 14] } },
-            {
-                name: "popper-arrow",
-                options: {
-                    element: ".popper-arrow",
-                    padding: 12,
-                },
-            },
-
-            {
-                name: "flip",
-                options: {
-                    fallbackPlacements: ["top-end", "top-start", "top"],
-                },
-            },
-        ],
+        modifiers: [{ name: "offset", options: { offset: [0, 14] } }],
     };
 </script>
 
 {#if !inProfileMenu}
     <ActionBarButton
         on:click={() => {
+            if ($roomListVisibilityStore) return roomListVisibilityStore.set(false);
             openedMenuStore.toggle("appMenu");
         }}
         classList="group/btn-apps"
         context="actionBar"
         tooltipTitle={$LL.actionbar.help.apps.title()}
         tooltipDesc={$LL.actionbar.help.apps.desc()}
-        disabledHelp={$openedMenuStore === "appMenu"}
-        state={$openedMenuStore === "appMenu" ? "active" : "normal"}
+        disabledHelp={$openedMenuStore === "appMenu" || $roomListVisibilityStore}
+        state={$openedMenuStore === "appMenu" || $roomListVisibilityStore ? "active" : "normal"}
         dataTestId={undefined}
         action={popperRef}
     >
-        {$openedMenuStore}
         <AppsIcon
-            strokeColor={$openedMenuStore === "appMenu" ? "stroke-white fill-white" : "stroke-white fill-transparent"}
+            strokeColor={$openedMenuStore === "appMenu" || $roomListVisibilityStore
+                ? "stroke-white fill-white"
+                : "stroke-white fill-transparent"}
             hover="group-hover/btn-apps:fill-white"
         />
 
         {#if $openedMenuStore === "appMenu" && ($roomListActivated || $isCalendarActivatedStore || $isTodoListActivatedStore || $externalActionBarSvelteComponent.size > 0)}
-            <div class="flex justify-center m-auto popper-tooltip" use:popperContent={extraOpts}>
+            <div class="flex justify-center m-[unset] popper-tooltip" use:popperContent={extraOpts}>
                 <div class="popper-arrow" data-popper-arrow />
                 <div class="bottom-action-bar">
                     <div

--- a/play/src/front/Components/ActionBar/MenuIcons/AppsMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/AppsMenuItem.svelte
@@ -58,6 +58,7 @@
         dataTestId={undefined}
         action={popperRef}
     >
+        {$openedMenuStore}
         <AppsIcon
             strokeColor={$openedMenuStore === "appMenu" ? "stroke-white fill-white" : "stroke-white fill-transparent"}
             hover="group-hover/btn-apps:fill-white"

--- a/play/src/front/Stores/MenuStore.ts
+++ b/play/src/front/Stores/MenuStore.ts
@@ -439,10 +439,12 @@ function createOpenedMenuStore() {
     return {
         subscribe,
         open(menu: Menus) {
+            console.log("open", menu);
             set(menu);
             activeSecondaryZoneActionBarStore.set(undefined);
         },
         close(menu: Menus) {
+            console.log("close", menu);
             if (get({ subscribe }) === menu) {
                 set(undefined);
             }
@@ -451,6 +453,7 @@ function createOpenedMenuStore() {
             set(undefined);
         },
         toggle(menu: Menus) {
+            console.log("toggle", menu);
             if (get({ subscribe }) === menu) {
                 set(undefined);
             } else {


### PR DESCRIPTION
🤩 Now
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/596ce26b-a409-49d7-b0b9-2ee55d0c6580" />

🫣 Before
![image](https://github.com/user-attachments/assets/f8978b86-103d-4371-8424-cef153baac91)

This pull request includes several changes to the `play/src/front` components and stores to improve the handling of the room list visibility and debugging.

Changes in `AppsMenuContent.svelte`:

* Added import for `get` from `svelte/store` to retrieve store values.
* Added `console.log` statements to debug the room list visibility state.
* Wrapped `ActionBarButton` in a `div` with `stopPropagation` modifiers to prevent event propagation.

Changes in `AppsMenuItem.svelte`:

* Imported `roomListVisibilityStore` to manage the visibility state.
* Simplified `modifiers` configuration for the popper element.
* Added conditions to handle the room list visibility state when toggling the menu and updating button states.

Changes in `MenuStore.ts`:

* Added `console.log` statements to log actions performed on the `openedMenuStore` for debugging purposes. [[1]](diffhunk://#diff-54a244ff5f4eb94a783491b53078cf04ffd7acfb7b31b6a9b8eab01157379b33R442-R447) [[2]](diffhunk://#diff-54a244ff5f4eb94a783491b53078cf04ffd7acfb7b31b6a9b8eab01157379b33R456)