### PR TITLE
:bug: fix co website pop up not close

### DIFF
--- a/play/src/front/Components/PopUp/PopupCowebsite.svelte
+++ b/play/src/front/Components/PopUp/PopupCowebsite.svelte
@@ -19,7 +19,7 @@
 <PopUpContainer>
     {message}
     <svelte:fragment slot="buttons">
-        <button class="btn btn-secondary w-1/2 justify-center responsive-message" on:click={click}>Close</button>
+        <button class="btn btn-secondary btn-sm w-full max-w-96 justify-center" on:click={click}>Open Website</button>
     </svelte:fragment>
 </PopUpContainer>
 

--- a/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
@@ -915,6 +915,7 @@ export class GameMapPropertiesListener {
         }
         */
 
+        popupStore.removePopup(actionTriggerUuid);
         this.coWebsitesActionTriggerByPlace.delete(this.getIdFromPlace(place));
     }
 


### PR DESCRIPTION
This pull request includes changes to the `play/src/front/Components/PopUp/PopupCowebsite.svelte` and `play/src/front/Phaser/Game/GameMapPropertiesListener.ts` files. The most important changes involve updating the button text and styling in the popup component and removing a popup in the game map properties listener.

Changes to `PopupCowebsite.svelte`:

* Updated button text from "Close" to "Open Website" and adjusted button styling for better responsiveness.

Changes to `GameMapPropertiesListener.ts`:

* Added a call to `popupStore.removePopup(actionTriggerUuid)` to remove a popup when an action trigger is deleted.