### PR TITLE
Fix chat blocking the loading of the page.

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -176,6 +176,7 @@ import { faviconManager } from "../../WebRtc/FaviconManager";
 import { ScriptingOutputAudioStreamManager } from "../../WebRtc/AudioStream/ScriptingOutputAudioStreamManager";
 import { ScriptingInputAudioStreamManager } from "../../WebRtc/AudioStream/ScriptingInputAudioStreamManager";
 import { enableUserInputsStore } from "../../Stores/UserInputStore";
+import { raceTimeout } from "../../Utils/PromiseUtils";
 import { GameMapFrontWrapper } from "./GameMap/GameMapFrontWrapper";
 import { gameManager } from "./GameManager";
 import { EmoteManager } from "./EmoteManager";
@@ -880,7 +881,9 @@ export class GameScene extends DirtyScene {
             ...scriptPromises,
             this.CurrentPlayer.getTextureLoadedPromise() as Promise<unknown>,
             this.gameMapFrontWrapper.initializedPromise.promise,
-            gameManager.getChatConnection(),
+            // Wait at most 5 seconds for the chat connection to be established
+            // If not, we can still proceed starting the scene without chat fully loaded
+            raceTimeout(gameManager.getChatConnection(), 5_000),
         ])
             .then(() => {
                 this.initUserPermissionsOnEntity();

--- a/play/src/front/Utils/PromiseUtils.ts
+++ b/play/src/front/Utils/PromiseUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns a promise that resolves after the given number of milliseconds.
+ */
+export function setTimeoutPromise(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(), ms);
+    });
+}
+
+/**
+ * Returns a promise that resolves when the promise passed in parameter resolves or when the given number of milliseconds has passed.
+ */
+export function raceTimeout<T>(promise: Promise<T>, ms: number): Promise<T | void> {
+    return Promise.race([promise, setTimeoutPromise(ms)]);
+}


### PR DESCRIPTION
In some conditions, Matrix initialization can block for a very long time (or simply never return) because f issues with Rust crypto initialization. This would prevent users from accessing the map.

In the commit, we prevent Matrix from locking the loading of the screen. After 5 seconds, even if the chat is not initalized, we continue initializing the GameScene.