### PR TITLE
Making sure the game can load when Matrix chat slow

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1573,6 +1573,7 @@ export class GameScene extends DirtyScene {
 
                 this._spaceRegistry = new SpaceRegistry(this.connection);
                 this.allUserSpace = this._spaceRegistry.joinSpace(WORLD_SPACE_NAME);
+                this.worldUserProvider = new WorldUserProvider(this.allUserSpace);
 
                 gameManager
                     .getChatConnection()
@@ -1589,8 +1590,7 @@ export class GameScene extends DirtyScene {
                             userProviders.push(new ChatUserProvider(chatConnection));
                         }
 
-                        if (allUserSpace && this._room.isChatOnlineListEnabled) {
-                            this.worldUserProvider = new WorldUserProvider(allUserSpace);
+                        if (allUserSpace && this._room.isChatOnlineListEnabled && this.worldUserProvider) {
                             userProviders.push(this.worldUserProvider);
                         }
 


### PR DESCRIPTION
When the Matrix Chat connection is slow to resolve, we make sure the game does not crash. In particular, we wait for the Matrix chat connection to make it possible to click on the chat button in the action bar.