### PR TITLE
Fix error companion loading

### DIFF
--- a/play/src/front/Phaser/Companion/Companion.ts
+++ b/play/src/front/Phaser/Companion/Companion.ts
@@ -6,6 +6,7 @@ import type { PictureStore } from "../../Stores/PictureStore";
 import { TexturesHelper } from "../Helpers/TexturesHelper";
 import { PlayerAnimationTypes } from "../Player/Animation";
 import { ProtobufClientUtils } from "../../Network/ProtobufClientUtils";
+import { debugRepo } from "../../Utils/Debuggers";
 import Sprite = Phaser.GameObjects.Sprite;
 import Container = Phaser.GameObjects.Container;
 
@@ -52,7 +53,7 @@ export class Companion extends Container {
                     this._pictureStore.set(htmlImageElementSrc);
                 });
             })
-            .catch((e) => console.error(e));
+            .catch((_) => debugRepo("No companion texture for this player"));
 
         this.scene.physics.world.enableBody(this);
 

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -78,7 +78,7 @@ export abstract class Character extends Container implements OutlineableInterfac
         moving: boolean,
         frame: string | number,
         isClickable: boolean,
-        companionTexturePromise?: CancelablePromise<string>,
+        companionTexturePromise: CancelablePromise<string>,
         userId?: string | null
     ) {
         super(scene, x, y /*, texture, frame*/);

--- a/play/src/front/Phaser/Entity/RemotePlayer.ts
+++ b/play/src/front/Phaser/Entity/RemotePlayer.ts
@@ -37,7 +37,7 @@ export class RemotePlayer extends Character implements ActivatableInterface {
         direction: PositionMessage_Direction,
         moving: boolean,
         visitCardUrl: string | null,
-        companionTexturePromise?: CancelablePromise<string>,
+        companionTexturePromise: CancelablePromise<string>,
         activationRadius?: number,
         private chatID: string | undefined = undefined
     ) {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3438,7 +3438,7 @@ ${escapedMessage}
                 this.currentPlayerTexturesPromise,
                 PositionMessage_Direction.DOWN,
                 false,
-                gameManager.getCompanionTextureId() ? this.currentCompanionTexturePromise : undefined
+                this.currentCompanionTexturePromise
             );
             this.CurrentPlayer.on(Phaser.Input.Events.POINTER_OVER, (pointer: Phaser.Input.Pointer) => {
                 this.CurrentPlayer.pointerOverOutline(0x365dff);
@@ -3552,7 +3552,9 @@ ${escapedMessage}
                 addPlayerData.visitCardUrl,
                 addPlayerData.companionTexture
                     ? lazyLoadPlayerCompanionTexture(this.superLoad, addPlayerData.companionTexture)
-                    : undefined
+                    : new CancelablePromise<string>((_, reject) =>
+                          reject(new CompanionTextureError("No companion texture"))
+                      )
             );
         } catch (error) {
             if (error instanceof CharacterTextureError) {

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -33,7 +33,7 @@ export class Player extends Character {
         texturesPromise: CancelablePromise<string[]>,
         direction: PositionMessage_Direction,
         moving: boolean,
-        companionTexturePromise?: CancelablePromise<string>
+        companionTexturePromise: CancelablePromise<string>
     ) {
         super(Scene, x, y, texturesPromise, name, direction, moving, 1, true, companionTexturePromise, "me");
         //the current player model should be push away by other players to prevent conflict


### PR DESCRIPTION
At the first connection, if we have a companion defined in the database but not in local storage, it will not be downloaded by the current user but seen by the remote user.

The issue can be resolved by applying this fix.