### PR TITLE
Adding the ability to start videos from the scripting API

### DIFF
--- a/docs/developer/map-scripting/references/api-sound.md
+++ b/docs/developer/map-scripting/references/api-sound.md
@@ -16,6 +16,13 @@ Please note that `loadSound` returns an object of the `Sound` class
 
 The `Sound` class that represents a loaded sound contains two methods: `play(soundConfig : SoundConfig|undefined)` and `stop()`
 
+```ts
+class Sound {
+    play(soundConfig : SoundConfig|undefined): void;
+    stop(): void;
+}
+```
+
 The parameter soundConfig is optional, if you call play without a Sound config the sound will be played with the basic configuration.
 
 Example:

--- a/docs/developer/map-scripting/references/api-ui.md
+++ b/docs/developer/map-scripting/references/api-ui.md
@@ -552,3 +552,50 @@ WA.ui.banner.openBanner({
 WA.ui.banner.closeBanner();
 ```
 
+## Play a video
+
+:::caution
+The "play a video" API is **experimental**. It means the compatibility with future versions of WorkAdventure is not
+guaranteed and we might break the signature of these methods at any moment. Use at your own risk.
+:::
+
+Plays a video. The video will be displayed as if it was a user talking to us.
+
+```ts
+WA.ui.playVideo(videoUrl: string, config: VideoConfig = {
+  loop: true,
+}): Promise<Video>;
+
+interface VideoConfig {
+  loop?: boolean;
+  name:? string;
+  avatar:? string;
+}
+```
+
+Arguments: 
+
+- `videoUrl`: the URL of the video to play.
+- `config`: an object with the following optional properties:
+  - `loop`: whether the video should loop or not. Default is `true`.
+  - `name`: The name displayed at the bottom left of the video.
+  - `avatar`: The avatar displayed at the bottom left of the video.
+
+Return value:
+
+- a `Promise` that resolves to a `Video` object. The `Video` object has a `stop` method that can be used to stop the video.
+
+```ts
+interface Video {
+  stop(): void;
+}
+```
+
+Example:
+
+```ts
+const video = await WA.ui.playVideo('https://example.com/video.mp4', { loop: true });
+
+// Later, stop the video
+await video.stop();
+```

--- a/play/src/front/Api/Events/IframeEvent.ts
+++ b/play/src/front/Api/Events/IframeEvent.ts
@@ -69,6 +69,7 @@ import { isPlaySoundInBubbleEvent } from "./ProximityMeeting/PlaySoundInBubbleEv
 import { isStartStreamInBubbleEvent } from "./ProximityMeeting/StartStreamInBubbleEvent";
 import { isAppendPCMDataEvent } from "./ProximityMeeting/AppendPCMDataEvent";
 import { isWamMapDataEvent } from "./WamMapDataEvent";
+import { isPlayVideoEvent } from "./Ui/PlayVideoEvent";
 
 export interface TypedMessageEvent<T> extends MessageEvent {
     data: T;
@@ -719,6 +720,14 @@ export const iframeQueryMapTypeGuards = {
     getWamMapData: {
         query: z.undefined(),
         answer: isWamMapDataEvent,
+    },
+    playVideo: {
+        query: isPlayVideoEvent,
+        answer: z.string(),
+    },
+    stopVideo: {
+        query: z.string(),
+        answer: z.undefined(),
     },
 };
 

--- a/play/src/front/Api/Events/Ui/PlayVideoEvent.ts
+++ b/play/src/front/Api/Events/Ui/PlayVideoEvent.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const isVideoConfig = z.object({
+    /**
+     * Whether the video should loop.
+     */
+    loop: z.boolean().optional(),
+    /**
+     * The name displayed at the bottom left of the video.
+     */
+    name: z.string().optional(),
+    /**
+     * A link to the avatar of the speaker, displayed at the bottom left of the video.
+     */
+    avatar: z.string().optional(),
+});
+
+export const isPlayVideoEvent = z.object({
+    url: z.string(),
+    config: z.optional(isVideoConfig),
+});
+
+/**
+ * A message sent from the iFrame to the game to add a message in the chat.
+ */
+export type PlayVideoEvent = z.infer<typeof isPlayVideoEvent>;
+export type VideoConfig = z.infer<typeof isVideoConfig>;

--- a/play/src/front/Api/Iframe/Ui/Video.ts
+++ b/play/src/front/Api/Iframe/Ui/Video.ts
@@ -1,0 +1,13 @@
+import { queryWorkadventure } from "../IframeApiContribution";
+
+export class Video {
+    constructor(private id: string) {}
+
+    public async stop() {
+        await queryWorkadventure({
+            type: "stopVideo",
+            data: this.id,
+        });
+        return;
+    }
+}

--- a/play/src/front/Api/Iframe/ui.ts
+++ b/play/src/front/Api/Iframe/ui.ts
@@ -4,7 +4,8 @@ import { v4 } from "uuid";
 import type { RequireOnlyOne } from "../types";
 import type { ActionsMenuActionClickedEvent } from "../Events/ActionsMenuActionClickedEvent";
 import type { AddPlayerEvent } from "../Events/AddPlayerEvent";
-import { IframeApiContribution, sendToWorkadventure } from "./IframeApiContribution";
+import { VideoConfig } from "../Events/Ui/PlayVideoEvent";
+import { IframeApiContribution, queryWorkadventure, sendToWorkadventure } from "./IframeApiContribution";
 import { apiCallback } from "./registeredCallbacks";
 import type { ButtonClickedCallback, ButtonDescriptor } from "./Ui/ButtonDescriptor";
 import { Popup } from "./Ui/Popup";
@@ -18,6 +19,7 @@ import modal from "./Ui/Modal";
 import type { WorkadventureModalCommands } from "./Ui/Modal";
 import buttonActionBar, { WorkAdventureButtonActionBarCommands } from "./Ui/ButtonActionBar";
 import banner, { WorkadventureBannerCommands } from "./Ui/Banner";
+import { Video } from "./Ui/Video";
 
 let popupId = 0;
 const popups: Map<number, Popup> = new Map<number, Popup>();
@@ -338,6 +340,24 @@ export class WorkAdventureUiCommands extends IframeApiContribution<WorkAdventure
 
     get banner(): WorkadventureBannerCommands {
         return banner;
+    }
+
+    /**
+     * Plays a video as if the video was a player talking to us.
+     */
+    public async playVideo(videoUrl: string, config: VideoConfig = {}): Promise<Video> {
+        if (config.loop === undefined) {
+            config.loop = true;
+        }
+        const id = await queryWorkadventure({
+            type: "playVideo",
+            data: {
+                url: videoUrl,
+                config: config,
+            },
+        });
+
+        return new Video(id);
     }
 }
 

--- a/play/src/front/Components/Video/CenteredVideo.svelte
+++ b/play/src/front/Components/Video/CenteredVideo.svelte
@@ -5,6 +5,7 @@
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import CameraExclamationIcon from "../Icons/CameraExclamationIcon.svelte";
     import LL from "../../../i18n/i18n-svelte";
+    import { VideoConfig } from "../../Api/Events/Ui/PlayVideoEvent";
 
     /**
      * This component is in charge of displaying a <video> element in the center of the
@@ -24,6 +25,9 @@
 
     export let videoEnabled = false;
     export let mediaStream: MediaStream | undefined = undefined;
+
+    export let videoUrl: string | undefined = undefined;
+    export let videoConfig: VideoConfig | undefined = undefined;
 
     // When expectVideoOutput switches to "true", the video stream should display something.
     // We are waiting for 3 seconds after the switch. If no video frame has arrived
@@ -50,10 +54,15 @@
 
     let videoElement: HTMLVideoElementExt;
 
+    let loop: boolean = videoConfig?.loop ?? false;
+
     function onLoadVideoElement() {}
 
     $: if (mediaStream && videoElement) {
         videoElement.srcObject = mediaStream;
+    }
+    $: if (videoUrl && videoElement) {
+        videoElement.src = videoUrl;
     }
 
     let containerWidth: number;
@@ -106,7 +115,7 @@
     let displayNoVideoWarning = false;
 
     $: {
-        if (expectVideoOutput && videoElement) {
+        if (expectVideoOutput && videoElement && mediaStream) {
             expectVideoWithin3Seconds();
         }
         if (!expectVideoOutput && noVideoTimeout) {
@@ -257,6 +266,7 @@
             autoplay
             playsinline
             {muted}
+            {loop}
         />
     </div>
     {#if displayNoVideoWarning}

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -16,6 +16,7 @@
     import ArrowsMaximizeIcon from "../Icons/ArrowsMaximizeIcon.svelte";
     import ArrowsMinimizeIcon from "../Icons/ArrowsMinimizeIcon.svelte";
     import { createFlotingUiActions } from "../../Utils/svelte-floatingui";
+    import { VideoConfig } from "../../Api/Events/Ui/PlayVideoEvent";
     import ActionMediaBox from "./ActionMediaBox.svelte";
     import UserName from "./UserName.svelte";
     import UpDownChevron from "./UpDownChevron.svelte";
@@ -36,6 +37,14 @@
     let streamStore: Readable<MediaStream | undefined> | undefined = undefined;
     if (peer.media.type === "mediaStore") {
         streamStore = peer.media.streamStore;
+    }
+
+    // In the case of a video started from the scripting API, we can have a URL instead of a MediaStream
+    let videoUrl: string | undefined = undefined;
+    let videoConfig: VideoConfig | undefined = undefined;
+    if (peer.media.type === "scripting") {
+        videoUrl = peer.media.url;
+        videoConfig = peer.media.config;
     }
 
     let volumeStore = peer.volumeStore;
@@ -106,6 +115,8 @@
             isTalking={showVoiceIndicator}
             {flipX}
             {muted}
+            {videoUrl}
+            {videoConfig}
         >
             <UserName
                 name={$name}

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -210,6 +210,7 @@ import { DEPTH_BUBBLE_CHAT_SPRITE, DEPTH_WHITE_MASK } from "./DepthIndexes";
 import { ScriptingEventsManager } from "./ScriptingEventsManager";
 import { FollowManager } from "./FollowManager";
 import { uiWebsiteManager } from "./UI/UIWebsiteManager";
+import { ScriptingVideoManager } from "./ScriptingVideoManager";
 import EVENT_TYPE = Phaser.Scenes.Events;
 import Texture = Phaser.Textures.Texture;
 import Sprite = Phaser.GameObjects.Sprite;
@@ -321,6 +322,7 @@ export class GameScene extends DirtyScene {
     private scriptingOutputAudioStreamManager: ScriptingOutputAudioStreamManager | undefined;
     private scriptingInputAudioStreamManager: ScriptingInputAudioStreamManager | undefined;
     private proximitySpaceManager: ProximitySpaceManager | undefined;
+    private scriptingVideoManager: ScriptingVideoManager | undefined;
     private objectsByType = new Map<string, ITiledMapObject[]>();
     private embeddedWebsiteManager!: EmbeddedWebsiteManager;
     private areaManager!: DynamicAreaManager;
@@ -1100,6 +1102,7 @@ export class GameScene extends DirtyScene {
         this.playerVariablesManager?.close();
         this.scriptingEventsManager?.close();
         this.embeddedWebsiteManager?.close();
+        this.scriptingVideoManager?.close();
         this.areaManager?.close();
         this.playersEventDispatcher.cleanup();
         this.playersMovementEventDispatcher.cleanup();
@@ -1807,6 +1810,8 @@ export class GameScene extends DirtyScene {
                     iframeListener
                 );
                 this.proximitySpaceManager = new ProximitySpaceManager(this.connection, this._proximityChatRoom);
+
+                this.scriptingVideoManager = new ScriptingVideoManager();
 
                 userMessageManager.setReceiveBanListener(this.bannedUser.bind(this));
 

--- a/play/src/front/Phaser/Game/ScriptingVideoManager.ts
+++ b/play/src/front/Phaser/Game/ScriptingVideoManager.ts
@@ -1,0 +1,25 @@
+import { iframeListener } from "../../Api/IframeListener";
+import { PlayVideoEvent } from "../../Api/Events/Ui/PlayVideoEvent";
+import { scriptingVideoStore } from "../../Stores/ScriptingVideoStore";
+
+/**
+ * Handles calls to WA.ui.playVideo() and video.stop()
+ */
+export class ScriptingVideoManager {
+    constructor() {
+        iframeListener.registerAnswerer("playVideo", (event: PlayVideoEvent, source) => {
+            const streamable = scriptingVideoStore.addVideo(event.url, event.config ?? {});
+
+            return streamable.uniqueId;
+        });
+
+        iframeListener.registerAnswerer("stopVideo", (videoId: string, source) => {
+            scriptingVideoStore.removeVideo(videoId);
+        });
+    }
+
+    public close(): void {
+        iframeListener.unregisterAnswerer("playVideo");
+        iframeListener.unregisterAnswerer("stopVideo");
+    }
+}

--- a/play/src/front/Stores/ScriptingVideoStore.ts
+++ b/play/src/front/Stores/ScriptingVideoStore.ts
@@ -1,0 +1,50 @@
+import { writable } from "svelte/store";
+import { v4 } from "uuid";
+import { VideoConfig } from "../Api/Events/Ui/PlayVideoEvent";
+import { Streamable } from "./StreamableCollectionStore";
+
+function createStreamableFromVideo(url: string, config: VideoConfig): Streamable {
+    return {
+        uniqueId: v4(),
+        media: {
+            type: "scripting",
+            url,
+            config,
+        },
+        volumeStore: undefined,
+        hasVideo: writable(true),
+        hasAudio: writable(false),
+        isMuted: writable(false),
+        statusStore: writable("connected"),
+        getExtendedSpaceUser: () => undefined,
+        name: writable(config.name ?? ""),
+        showVoiceIndicator: writable(false),
+        pictureStore: writable(config.avatar),
+    };
+}
+
+function createScriptingVideoStore() {
+    const { subscribe, update } = writable<Map<string, Streamable>>(new Map<string, Streamable>());
+
+    return {
+        subscribe,
+
+        addVideo: (url: string, config: VideoConfig): Streamable => {
+            const streamable = createStreamableFromVideo(url, config);
+            update((streamables) => {
+                streamables.set(streamable.uniqueId, streamable);
+                return streamables;
+            });
+            return streamable;
+        },
+
+        removeVideo: (id: string): void => {
+            return update((streamables) => {
+                streamables.delete(id);
+                return streamables;
+            });
+        },
+    };
+}
+
+export const scriptingVideoStore = createScriptingVideoStore();

--- a/tests/tests/scripting_startVideo.spec.ts
+++ b/tests/tests/scripting_startVideo.spec.ts
@@ -1,0 +1,22 @@
+import {expect, test} from '@playwright/test';
+import {evaluateScript} from "./utils/scripting";
+import {publicTestMapUrl} from "./utils/urls";
+import { getPage } from './utils/auth';
+
+test.describe('Scripting WA.ui.playVideo functions', () => {
+    test('can start and stop', async ({ browser}, { project }) => {
+        const page = await getPage(browser, 'Alice', publicTestMapUrl("tests/E2E/empty.json", "scripting_start_video"));
+
+        await evaluateScript(page, async () => {
+            window.myVideo = await WA.ui.playVideo("https://2050today.org/wp-content/uploads/2020/07/Video-Placeholder.mp4?_=6", { name:"Bob" });
+        });
+
+        await expect(page.getByText('Bob')).toBeVisible();
+
+        await evaluateScript(page, async () => {
+            window.myVideo.stop();
+        });
+
+        await expect(page.getByText('Bob')).toBeHidden();
+    });
+});


### PR DESCRIPTION
The videos start just like if a real user was talking to you.

Usage:

```ts
WA.ui.playVideo(videoUrl: string, config: VideoConfig = {
  loop: true,
}): Promise<Video>;

interface VideoConfig {
  loop?: boolean;
  name:? string;
  avatar:? string;
}
```