### PR TITLE
Remove scale on popup

### DIFF
--- a/play/src/front/Components/PopUp/PopUpContainer.svelte
+++ b/play/src/front/Components/PopUp/PopUpContainer.svelte
@@ -42,10 +42,4 @@
             opacity: 1;
         }
     }
-
-    @media (max-width: 768px) {
-        .responsive {
-            scale: 0.6;
-        }
-    }
 </style>


### PR DESCRIPTION
This pull request includes a single change to the `PopUpContainer.svelte` file. The change removes the media query that scales down elements with the class `responsive` on screens with a maximum width of 768px.

* [`play/src/front/Components/PopUp/PopUpContainer.svelte`](diffhunk://#diff-b77acbc976b66ece90e3764f6dd2f11aa4d23cf4a0ea6e8e384175ccf8fbeb5dL45-L50): Removed the media query that scales elements with the class `responsive` to 0.6 on screens with a maximum width of 768px.