### PR TITLE
Adding a new isLogged field in /map

### DIFF
--- a/libs/messages/src/JsonMessages/MapDetailsData.ts
+++ b/libs/messages/src/JsonMessages/MapDetailsData.ts
@@ -240,6 +240,9 @@ export const isMapDetailsData = z.object({
     modules: extendApi(z.array(z.string()).optional().nullable(), {
         description: "List of external-modules to load",
     }),
+    isLogged: extendApi(z.boolean().optional(), {
+        description: "True if the UUID passed in parameter belongs to a legitimate user. Return false for anonymous users.",
+    }),
 });
 
 export type MapDetailsData = z.infer<typeof isMapDetailsData>;

--- a/play/src/front/Components/Login/LoginScene.svelte
+++ b/play/src/front/Components/Login/LoginScene.svelte
@@ -106,7 +106,7 @@
             <input
                 type="text"
                 name="loginSceneName"
-                placeholder="Tapez votre prénom ou pseudo..."
+                placeholder={$LL.login.input.name.placeholder()}
                 class="w-52 md:w-96 h-12 text text-center bg-contrast rounded border border-solid border-white/20 mt-4 mb-0"
                 autofocus
                 maxlength={MAX_USERNAME_LENGTH}

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -697,8 +697,12 @@ class ConnectionManager {
         return response;
     }
 
-    async saveName(name: string): Promise<void> {
-        if (hasCapability("api/save-name") && this.authToken !== undefined) {
+    async saveName(name: string): Promise<boolean> {
+        if (
+            hasCapability("api/save-name") &&
+            this.authToken !== undefined &&
+            (this.currentRoom?.isLogged || !this.currentRoom)
+        ) {
             await axiosToPusher.post(
                 "save-name",
                 {
@@ -711,11 +715,18 @@ class ConnectionManager {
                     },
                 }
             );
+            return true;
+        } else {
+            return false;
         }
     }
 
-    async saveTextures(textures: string[]): Promise<void> {
-        if (hasCapability("api/save-textures") && this.authToken !== undefined) {
+    async saveTextures(textures: string[]): Promise<boolean> {
+        if (
+            hasCapability("api/save-textures") &&
+            this.authToken !== undefined &&
+            (this.currentRoom?.isLogged || !this.currentRoom)
+        ) {
             await axiosToPusher.post(
                 "save-textures",
                 {
@@ -728,11 +739,18 @@ class ConnectionManager {
                     },
                 }
             );
+            return true;
+        } else {
+            return false;
         }
     }
 
-    async saveCompanionTexture(texture: string | null): Promise<void> {
-        if (hasCapability("api/save-textures") && this.authToken !== undefined) {
+    async saveCompanionTexture(texture: string | null): Promise<boolean> {
+        if (
+            hasCapability("api/save-textures") &&
+            this.authToken !== undefined &&
+            (this.currentRoom?.isLogged || !this.currentRoom)
+        ) {
             await axiosToPusher.post(
                 "save-companion-texture",
                 {
@@ -745,6 +763,9 @@ class ConnectionManager {
                     },
                 }
             );
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/play/src/front/Connection/Room.ts
+++ b/play/src/front/Connection/Room.ts
@@ -59,6 +59,7 @@ export class Room {
     private _entityCollectionsUrls: string[] | undefined;
     private _errorSceneLogo: string | undefined;
     private _modules: string[] = [];
+    private _isLogged: boolean | undefined;
 
     private constructor(private roomUrl: URL) {
         this.id = roomUrl.pathname;
@@ -195,6 +196,10 @@ export class Room {
 
                 this._errorSceneLogo = data.errorSceneLogo ?? undefined;
                 this._modules = data.modules ?? [];
+                // If the server returns a value for "isLogged", let's use it.
+                // Even if we are logged in the localUserStore, the user might not be valid for this room.
+                // If no data is passed by the server, fallback to the localUserStore value.
+                this._isLogged = data.isLogged ?? localUserStore.isLogged();
 
                 return new MapDetail(data.mapUrl, data.wamUrl);
             } else if (errorApiDataChecking.success) {
@@ -400,5 +405,12 @@ export class Room {
 
     get modules(): string[] {
         return this._modules;
+    }
+
+    get isLogged(): boolean {
+        if (this._isLogged === undefined) {
+            throw new Error("isLogged not yet initialized.");
+        }
+        return this._isLogged;
     }
 }

--- a/play/src/front/Phaser/Game/GameManager.ts
+++ b/play/src/front/Phaser/Game/GameManager.ts
@@ -105,11 +105,6 @@ export class GameManager {
 
     public setPlayerName(name: string): void {
         this.playerName = name;
-        // Only save the name if the user is not logged in
-        // If the user is logged in, the name will be fetched from the server. No need to save it locally.
-        if (!localUserStore.isLogged() || !hasCapability("api/save-name")) {
-            localUserStore.setName(name);
-        }
     }
 
     public setVisitCardUrl(visitCardUrl: string): void {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2951,7 +2951,7 @@ ${escapedMessage}
                 userRoomToken: this.connection ? this.connection.userRoomToken : "",
                 metadata: this._room.metadata,
                 iframeId: source ? iframeListener.getUIWebsiteIframeIdFromSource(source) : undefined,
-                isLogged: localUserStore.isLogged(),
+                isLogged: this.room.isLogged,
             };
         });
         this.iframeSubscriptionList.push(


### PR DESCRIPTION
The goal of this new field from the AdminAPI is to know if the user is indeed logged in the context of the map the user tries to see.

For instance, in WorkAdventure SAAS, you can be logged in your world, but that does not give you the right to be logged in others worlds. In the other worlds, you should be treated as an anonymous user.

This commit does that in the context of saving woka name and textures.