### PR TITLE
Fix scroll bar in map editor

### DIFF
--- a/play/src/front/Components/MapEditor/AreaEditor/AreaPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/AreaEditor/AreaPropertiesEditor.svelte
@@ -397,7 +397,7 @@
 {#if $mapEditorSelectedAreaPreviewStore === undefined}
     {$LL.mapEditor.areaEditor.editInstructions()}
 {:else}
-    <div class="overflow-auto space-y-3">
+    <div class="overflow-x-hidden space-y-3">
         <div class="properties-buttons flex flex-row flex-wrap">
             {#if !hasPersonalAreaProperty && !hasRightsProperty}
                 <AddPropertyButtonWrapper


### PR DESCRIPTION
This pull request includes a small but important change to the `AreaPropertiesEditor.svelte` file. The change modifies the CSS class of a `div` element to prevent horizontal overflow.

* [`play/src/front/Components/MapEditor/AreaEditor/AreaPropertiesEditor.svelte`](diffhunk://#diff-fff8759169c5905ab4d0b26a3b6fea765d24978a7594ceaf825d3807973473d3L400-R400): Changed the `div` class from `overflow-auto` to `overflow-x-hidden` to prevent horizontal scrolling.
## Now

<img width="308" alt="image" src="https://github.com/user-attachments/assets/35681e7c-58d7-4d61-92e9-d5745d9d83f2" />

## Before 
<img width="211" alt="image" src="https://github.com/user-attachments/assets/9f5333b5-e91f-45a0-9ff8-f6e9a89d3bee" />
