### PR TITLE
Enhancing camera layout

### DIFF
--- a/play/src/front/Chat/Components/Room/Application/ApplicationFormWraper.svelte
+++ b/play/src/front/Chat/Components/Room/Application/ApplicationFormWraper.svelte
@@ -203,7 +203,7 @@
     <input
         data-testid="applicationInputLink"
         type="text"
-        class="border rounded w-full !m-0"
+        class="border rounded w-full !m-0 text-black"
         value={property.link}
         bind:this={htmlElementInput}
         on:input={() => {

--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -198,7 +198,7 @@
     }
 </script>
 
-<div class="w-full h-full" bind:clientHeight={maxContainerHeight}>
+<div class="w-full" bind:clientHeight={maxContainerHeight} class:h-full={!isOnOneLine}>
     <div
         bind:clientWidth={containerWidth}
         class={"pointer-events-none gap-4" + (isOnOneLine ? "max-h-full" : "")}

--- a/play/src/front/Components/EmbedScreens/Layouts/PresentationLayout.svelte
+++ b/play/src/front/Components/EmbedScreens/Layouts/PresentationLayout.svelte
@@ -78,8 +78,9 @@
     >
         {#if $streamableCollectionStore.size > 0}
             <div
-                class="justify-end md:justify-center w-full h-full relative"
+                class="justify-end md:justify-center w-full relative"
                 class:max-height-quarter={$isOnOneLine}
+                class:h-full={!$isOnOneLine}
                 bind:this={camContainer}
             >
                 {#if $streamableCollectionStore.size > 0}

--- a/play/src/front/Components/Video/CenteredVideo.svelte
+++ b/play/src/front/Components/Video/CenteredVideo.svelte
@@ -44,6 +44,8 @@
     export let muted = false;
     // If cover is true, the video will be stretched to cover the whole container (and some part of the video might be cropped).
     export let cover = true;
+    // If true, the video will be displayed with a background is it does not cover the whole box
+    export let withBackground = false;
 
     let destroyed = false;
 
@@ -244,7 +246,11 @@
     }
 </script>
 
-<div class="h-full w-full relative" bind:clientWidth={containerWidth} bind:clientHeight={containerHeight}>
+<div
+    class="h-full w-full relative {!cover && withBackground ? 'bg-contrast/80 rounded-lg' : ''}"
+    bind:clientWidth={containerWidth}
+    bind:clientHeight={containerHeight}
+>
     <div
         class={"absolute overflow-hidden border-solid rounded-lg"}
         class:w-full={!videoEnabled}
@@ -269,9 +275,7 @@
                   "px; height: " +
                   Math.ceil(videoHeight) +
                   "px; " +
-                  (verticalAlign === "center"
-                      ? ` top: ${(containerHeight - videoHeight) / 2 - (containerHeight - overlayHeight) / 2}px;`
-                      : "") +
+                  ` top: ${(containerHeight - videoHeight) / 2 - (containerHeight - overlayHeight) / 2}px;` +
                   (cover ? ` left: ${(containerWidth - videoWidth) / 2}px;` : "") +
                   (flipX ? "-webkit-transform: scaleX(-1);transform: scaleX(-1);" : "")
                 : ""}

--- a/play/src/front/Components/Video/CenteredVideo.svelte
+++ b/play/src/front/Components/Video/CenteredVideo.svelte
@@ -308,7 +308,7 @@
 
     <!-- This div represents an overlay on top of the video -->
     <div
-        class={"absolute border-solid " + (videoEnabled ? "" : "bg-contrast/80")}
+        class={"absolute border-solid " + (videoEnabled ? "" : "bg-contrast/80 backdrop-blur")}
         class:w-full={!videoEnabled}
         class:h-full={!videoEnabled}
         class:rounded-lg={!videoEnabled}

--- a/play/src/front/Components/Video/UserName.svelte
+++ b/play/src/front/Components/Video/UserName.svelte
@@ -19,9 +19,7 @@
 {#if isCameraDisabled}
     <div class="{position} z-30 responsive-dimension ">
         <div class="flex justify-between  rounded bg-transparent">
-            <div
-                class="relative  backdrop-blur px-2 py-1 text-white text-sm bold rounded text-nowrap flex flex-col items-center "
-            >
+            <div class="relative px-2 py-1 text-white text-sm bold rounded text-nowrap flex flex-col items-center ">
                 <div class="" style="image-rendering:pixelated">
                     <Woka src={$picture ?? ""} customHeight="100px" customWidth="100px" />
                 </div>

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -27,6 +27,7 @@
     export let isHighlighted = false;
     export let fullScreen = false;
     export let peer: Streamable;
+
     // If true, and if there is not video, the height of the video box will be 11rem
     export let miniMode = false;
 
@@ -151,7 +152,8 @@
             muted={peer.muteAudio}
             {videoUrl}
             {videoConfig}
-            cover={peer.displayMode === "cover"}
+            cover={peer.displayMode === "cover" && !isHighlighted && !fullScreen}
+            withBackground={!isHighlighted}
         >
             <UserName
                 name={$name}


### PR DESCRIPTION
Screen sharing now have a background if they don't cover the media box. Screensharing now stick to the video bar at the top (even if the bar takes less than 25% of the height of the screen)