### PR TITLE
Displaying the camera feedback only when hovering over the camera button

### DIFF
--- a/play/src/front/Components/ActionBar/ActionBarButton.svelte
+++ b/play/src/front/Components/ActionBar/ActionBarButton.svelte
@@ -71,9 +71,11 @@
             on:click|preventDefault={() => handleClick()}
             on:mouseenter={() => {
                 helpActive = true;
+                dispatch("mouseenter");
             }}
             on:mouseleave={() => {
                 helpActive = false;
+                dispatch("mouseleave");
             }}
             data-testid={dataTestId}
         >

--- a/play/src/front/Components/ActionBar/MenuIcons/CameraMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/CameraMenuItem.svelte
@@ -6,7 +6,12 @@
     import CamOnIcon from "../../Icons/CamOnIcon.svelte";
     import ActionBarButton from "../ActionBarButton.svelte";
     import CamOffIcon from "../../Icons/CamOffIcon.svelte";
-    import { availabilityStatusStore, requestedCameraState, silentStore } from "../../../Stores/MediaStore";
+    import {
+        availabilityStatusStore,
+        mouseIsHoveringCameraButton,
+        requestedCameraState,
+        silentStore,
+    } from "../../../Stores/MediaStore";
     import LL from "../../../../i18n/i18n-svelte";
     import { openedMenuStore } from "../../../Stores/MenuStore";
 
@@ -49,6 +54,8 @@
     disabledHelp={$openedMenuStore !== undefined}
     state={$cameraButtonStateStore}
     dataTestId="camera-button"
+    on:mouseenter={() => mouseIsHoveringCameraButton.set(true)}
+    on:mouseleave={() => mouseIsHoveringCameraButton.set(false)}
 >
     {#if $requestedCameraState && !$silentStore}
         <CamOnIcon />

--- a/play/src/front/Components/App.svelte
+++ b/play/src/front/Components/App.svelte
@@ -22,7 +22,6 @@
     import { iframeListener } from "../Api/IframeListener";
     import { desktopApi } from "../Api/Desktop";
     import { canvasSize, coWebsiteManager, coWebsites, fullScreenCowebsite } from "../Stores/CoWebsiteStore";
-    import { mouseInCameraTriggerArea } from "../Stores/MediaStore";
     import GameOverlay from "./GameOverlay.svelte";
     import CoWebsitesContainer from "./EmbedScreens/CoWebsitesContainer.svelte";
 
@@ -209,7 +208,6 @@
 
     let canvasSizeUnsubscriber: Unsubscriber;
     onMount(() => {
-        document.addEventListener("mousemove", detectInCameraArea);
         canvasSizeUnsubscriber = canvasSize.subscribe(({ width, height }) => {
             if (width < 1 || height < 1) {
                 return;
@@ -220,26 +218,8 @@
     });
 
     onDestroy(() => {
-        document.removeEventListener("mousemove", detectInCameraArea);
         canvasSizeUnsubscriber?.();
     });
-
-    let lastInTriggerArea = false;
-    // We are tracking if the mouse cursor gets near the camera trigger area
-    const detectInCameraArea = (event: MouseEvent) => {
-        // Note: in phone mode, the camera is at the bottom. But we don't need to track that because in phone mode,
-        // you cannot "hover" over the area where the camera is.
-        const rect = gameDiv.getBoundingClientRect();
-
-        const inTopCenter =
-            event.x - rect.left > rect.width / 4 &&
-            event.x + rect.left < (rect.width * 3) / 4 &&
-            event.y - rect.top < rect.height / 4;
-        if (inTopCenter !== lastInTriggerArea) {
-            lastInTriggerArea = inTopCenter;
-            mouseInCameraTriggerArea.set(inTopCenter);
-        }
-    };
 </script>
 
 <div

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -183,9 +183,9 @@ const deviceChanged10SecondsAgoStore = readable(false, function start(set) {
 });
 
 /**
- * A store containing whether the mouse is getting close the bottom right corner.
+ * A store containing if the mouse is over the camera button
  */
-export const mouseInCameraTriggerArea = writable(false);
+export const mouseIsHoveringCameraButton = writable(false);
 
 export const cameraNoEnergySavingStore = writable<boolean>(false);
 
@@ -271,7 +271,7 @@ export const cameraEnergySavingStore = derived(
         userMoved5SecondsAgoStore,
         peerStore,
         enabledWebCam10secondsAgoStore,
-        mouseInCameraTriggerArea,
+        mouseIsHoveringCameraButton,
         cameraNoEnergySavingStore,
         streamingMegaphoneStore,
         devicesNotLoaded,


### PR DESCRIPTION
Previously, we were displaying the feedback when the mouse was getting close to the camera. It was a behaviour taken from the very early designs of WorkAdventure when the camera and microphone buttons were attached to the video stream. We don't need this behaviour anymore.