### PR TITLE
Change external zone name and add slot for apps menu items component

### DIFF
--- a/play/src/front/Components/ActionBar/ActionBarButton.svelte
+++ b/play/src/front/Components/ActionBar/ActionBarButton.svelte
@@ -103,6 +103,7 @@
         </div>
         <div class="text-left leading-4 flex items-center text-nowrap">
             {label ?? tooltipTitle ?? ""}
+            <slot name="end" />
         </div>
     </button>
 {/if}

--- a/play/src/front/Components/ActionBar/MenuIcons/AppsMenuContent.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/AppsMenuContent.svelte
@@ -94,4 +94,4 @@
 </ActionBarButton>
 
 <!-- External module action bar -->
-<ExternalComponents zone="actionBar" />
+<ExternalComponents zone="actionBarAppsMenu" />

--- a/play/src/front/Components/ActionBar/MenuIcons/AppsMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/AppsMenuItem.svelte
@@ -18,7 +18,7 @@
 
     const inProfileMenu = getContext("profileMenu");
 
-    const externalActionBarSvelteComponent = externalSvelteComponentService.getComponentsByZone("actionBar");
+    const externalActionBarSvelteComponent = externalSvelteComponentService.getComponentsByZone("actionBarAppsMenu");
 
     const [floatingUiRef, floatingUiContent, arrowAction] = createFloatingUiActions(
         {

--- a/play/src/front/Stores/Utils/externalSvelteComponentService.ts
+++ b/play/src/front/Stores/Utils/externalSvelteComponentService.ts
@@ -3,7 +3,7 @@ import { writable } from "svelte/store";
 import { ExternalSvelteComponentServiceInterface } from "../../ExternalModule/ExtensionModule";
 
 const externalComponentsByZone = {
-    actionBar: writable(
+    actionBarAppsMenu: writable(
         new Map<
             string,
             { componentType: ComponentType<SvelteComponentTyped>; props?: ComponentProps<SvelteComponentTyped> }


### PR DESCRIPTION
This pull request includes several changes to the `ActionBar` components and the `externalSvelteComponentService` to improve the handling of external components in the action bar menu. The most important changes include adding a new slot to the `ActionBarButton` component, updating the zone name for external components in various files, and modifying the writable store in `externalSvelteComponentService.ts`.

Updates to `ActionBar` components:

* [`play/src/front/Components/ActionBar/ActionBarButton.svelte`](diffhunk://#diff-17f8e3bc39ac689d3b8d1d4df507662dc7c6a94630e7dc3b626cdc327a2e9a4dR106): Added a new slot named "end" to allow additional content to be inserted at the end of the button.

Changes to external components handling:

* [`play/src/front/Components/ActionBar/MenuIcons/AppsMenuContent.svelte`](diffhunk://#diff-88858b97eefb83b256c975afabcfa17a4d298ca6c7e28be6cb66c5bce8317ac7L97-R97): Updated the zone name from "actionBar" to "actionBarAppsMenu" for the `ExternalComponents` component.
* [`play/src/front/Components/ActionBar/MenuIcons/AppsMenuItem.svelte`](diffhunk://#diff-594de228bf4b21b231d5ff85b0fd194acc87297a6e7a632b4d5e5fdcc58f2258L21-R21): Changed the zone name from "actionBar" to "actionBarAppsMenu" when retrieving external components.
* [`play/src/front/Stores/Utils/externalSvelteComponentService.ts`](diffhunk://#diff-1f3539e3c55cda04faa9f33a5c093f2953eb763bdae9256d973dc142e71e76f6L6-R6): Modified the writable store to use "actionBarAppsMenu" instead of "actionBar" for storing external components by zone.