### PR TITLE
Fix error with tap to open Jitsi

### DIFF
--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -609,7 +609,7 @@ export class AreasPropertiesListener {
                 JitsiPopup,
                 {
                     message: message,
-                    callback: () => {
+                    click: () => {
                         openJitsiRoomFunction().catch((e) => console.error(e));
                     },
                     userInputManager: this.scene.userInputManager,


### PR DESCRIPTION
This pull request includes a change to the `AreasPropertiesListener` class in the `play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts` file. The change involves modifying the property name in an object passed to `JitsiPopup`.

Codebase simplification:

* [`play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts`](diffhunk://#diff-6cb7f31512546ca20d9ff27648454e6bc123eae4ed5a07005ab183f187472c5eL612-R612): Changed the property name from `callback` to `click` in the object passed to `JitsiPopup`.