### PR TITLE
Fixing audio restricted by navigator

### DIFF
--- a/play/src/front/Components/Video/CenteredVideo.svelte
+++ b/play/src/front/Components/Video/CenteredVideo.svelte
@@ -47,6 +47,9 @@
     // If true, the video will be displayed with a background is it does not cover the whole box
     export let withBackground = false;
 
+    // In case the user did not interact yet with the browser, the navigator will deny playing the video if it is not muted.
+    // The parent component can listen to this variable to display a message to the user.
+    export let missingUserActivation = false;
     let destroyed = false;
 
     // Extend the HTMLVideoElement interface to add the setSinkId method.
@@ -63,6 +66,10 @@
     function onLoadVideoElement() {}
 
     $: if (mediaStream && videoElement) {
+        if (navigator.userActivation && !navigator.userActivation.hasBeenActive && !muted) {
+            console.warn("User has not interacted with the browser yet. The video will be muted.");
+            missingUserActivation = true;
+        }
         videoElement.srcObject = mediaStream;
     }
     $: if (videoUrl && videoElement) {
@@ -288,13 +295,13 @@
             class:w-0={!videoEnabled}
             autoplay
             playsinline
-            {muted}
+            muted={muted || missingUserActivation}
             {loop}
         />
     </div>
     {#if displayNoVideoWarning}
         <div
-            class="absolute w-full aspect-video mx-auto flex justify-center items-center bg-danger text-white rounded-lg"
+            class="absolute w-full h-full aspect-video mx-auto flex justify-center items-center bg-danger text-white rounded-lg"
         >
             <div class="text-center">
                 <CameraExclamationIcon />

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -111,6 +111,8 @@
         }
     }
 
+    let missingUserActivation: false;
+
     onDestroy(() => {
         closeFloatingUi?.();
     });
@@ -154,6 +156,7 @@
             {videoConfig}
             cover={peer.displayMode === "cover" && !isHighlighted && !fullScreen}
             withBackground={!isHighlighted}
+            bind:missingUserActivation
         >
             <UserName
                 name={$name}
@@ -243,7 +246,7 @@
     </div>
 
     <button
-        class={isHighlighted || !videoEnabled
+        class={isHighlighted || !videoEnabled || missingUserActivation
             ? "hidden"
             : "absolute top-0 bottom-0 right-0 left-0 m-auto h-14 w-14 z-20 p-4 rounded-full bg-contrast/50 backdrop-blur transition-all opacity-0 group-hover/screenshare:opacity-100 cursor-pointer picture-in-picture:hidden"}
         on:click={() => highlightedEmbedScreen.highlight(peer)}
@@ -251,4 +254,14 @@
     >
         <ArrowsMaximizeIcon />
     </button>
+    {#if missingUserActivation && !peer.muteAudio}
+        <div
+            class="absolute w-full h-full aspect-video mx-auto flex justify-center items-center bg-contrast/50 rounded-lg z-20"
+            on:click={() => (missingUserActivation = false)}
+        >
+            <div class="text-center">
+                <div class="text-lg text-white bold">{$LL.video.click_to_unmute()}</div>
+            </div>
+        </div>
+    {/if}
 </div>

--- a/play/src/i18n/en-US/video.ts
+++ b/play/src/i18n/en-US/video.ts
@@ -7,6 +7,7 @@ const video: BaseTranslation = {
     reduce: "Reduce",
     toggle_fullscreen: "Toggle fullscreen",
     exit_fullscreen: "Exit fullscreen",
+    click_to_unmute: "Click to unmute",
 };
 
 export default video;

--- a/play/src/i18n/fr-FR/video.ts
+++ b/play/src/i18n/fr-FR/video.ts
@@ -7,6 +7,7 @@ const video: DeepPartial<Translation["video"]> = {
     reduce: "Réduire",
     toggle_fullscreen: "Passer en plein écran",
     exit_fullscreen: "Quitter le plein écran",
+    click_to_unmute: "Cliquez pour activer le son",
 };
 
 export default video;


### PR DESCRIPTION
If someone steps into a bubble when arriving in WA, the video would previously not display because the navigator denies playing sound before a user interaction happened on the page.

We are now tracking user interaction with the navigator.userActivation. If the user did not interact with the page, we display a "click to unmute" button.