### PR TITLE
Fix mobile status

### DIFF
--- a/play/src/front/Rules/StatusRules/ExtensionModuleStatusSynchronization.ts
+++ b/play/src/front/Rules/StatusRules/ExtensionModuleStatusSynchronization.ts
@@ -1,12 +1,8 @@
 import { AvailabilityStatus } from "@workadventure/messages";
-import { statusChanger } from "../../Components/ActionBar/AvailabilityStatus/statusChanger";
 import { resetAllStatusStoreExcept } from "./statusChangerFunctions";
 
 export const ExtensionModuleStatusSynchronization = {
     onStatusChange: (status: AvailabilityStatus) => {
-        if (statusChanger.getActualStatus() === status) {
-            return;
-        }
         if (
             status === AvailabilityStatus.BUSY ||
             status === AvailabilityStatus.BACK_IN_A_MOMENT ||

--- a/play/src/front/Rules/StatusRules/statusChangerFunctions.ts
+++ b/play/src/front/Rules/StatusRules/statusChangerFunctions.ts
@@ -1,3 +1,4 @@
+import { get } from "svelte/store";
 import {
     bubbleModalVisibility,
     changeStatusConfirmationModalVisibility,
@@ -14,6 +15,7 @@ export const hideBubbleConfirmationModal = () => {
 };
 
 export const resetAllStatusStoreExcept = (status: RequestedStatus | null = null) => {
+    if (get(requestedStatusStore) === status) return;
     requestedStatusStore.set(status);
     localUserStore.setRequestedStatus(status);
 };


### PR DESCRIPTION
When the status is defined by external module and change to an "online" status. On mobile, it's not working. Force to change the status and check if the status was moved or not.