### PR TITLE
Adding a new MAP_EDITOR_ALLOW_ALL_USERS env var

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -95,10 +95,13 @@ PLAYER_VARIABLES_MAX_TTL=-1
 
 # MAP EDITOR SETTINGS
 ENABLE_MAP_EDITOR=true
-# If you want to allow only some users to access the map editor, you can set the list of authorized users here, email separated by commas. (Only possible if OpenID Connect is configured)
-# Leave blank if you want to allow all users to access the map editor.
+# If you want to allow only some users to access the map editor, you can set the list of authorized users here, email separated by commas. (Only possible if OpenID Connect is configured with the email scope)
 # This variable is ignored if an AdminAPI is configured
 MAP_EDITOR_ALLOWED_USERS=
+# If you want to allow all users to access the map editor, you can set this variable to "true".
+# Default value is true.
+# This variable is ignored if an AdminAPI is configured
+MAP_EDITOR_ALLOW_ALL_USERS=true
 
 # AWS environement variable for uploader
 # AWS_ACCESS_KEY_ID=minio-access-key

--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -245,10 +245,13 @@ SECURITY_EMAIL=
 ENABLE_MAP_EDITOR=true
 # Enable broadcast areas in map editor (beta)
 FEATURE_FLAG_BROADCAST_AREAS=
-# If you want to allow only some users to access the map editor, you can set the list of authorized users here, email separated by commas. (Only possible if OpenID Connect is configured)
-# Leave blank if you want to allow all users to access the map editor.
+# If you want to allow only some users to access the map editor, you can set the list of authorized users here, email separated by commas. (Only possible if OpenID Connect is configured with the email scope)
 # This variable is ignored if an AdminAPI is configured
 MAP_EDITOR_ALLOWED_USERS=
+# If you want to allow all users to access the map editor, you can set this variable to "true".
+# Default value is true.
+# This variable is ignored if an AdminAPI is configured
+MAP_EDITOR_ALLOW_ALL_USERS=true
 
 # You MUST decide an authentication strategy for the map-storage container.
 # At least one of ENABLE_BEARER_AUTHENTICATION, ENABLE_BASIC_AUTHENTICATION or ENABLE_DIGEST_AUTHENTICATION must be set to true.

--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -36,6 +36,7 @@ services:
       - JITSI_PRIVATE_MODE
       - ENABLE_MAP_EDITOR
       - MAP_EDITOR_ALLOWED_USERS
+      - MAP_EDITOR_ALLOW_ALL_USERS
       - PUSHER_URL=https://${DOMAIN}/
       - ICON_URL=/icon
       - TURN_SERVER

--- a/docker-compose-oidc.yaml
+++ b/docker-compose-oidc.yaml
@@ -8,7 +8,7 @@ services:
       OPID_CLIENT_SECRET: authorization-code-client-secret
       OPID_CLIENT_ISSUER: http://oidc.workadventure.localhost
       OPID_SCOPE: profile openid email tags-scope
-      MAP_EDITOR_ALLOWED_USERS: noUserAllowed
+      MAP_EDITOR_ALLOW_ALL_USERS: "false"
 
   # A mock server to test OpenID connect connectivity
   oidc-server-mock:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -30,7 +30,8 @@ services:
       STARTUP_COMMAND_3: ""
       STARTUP_COMMAND_4: ""
       STARTUP_COMMAND_5: ""
-      MAP_EDITOR_ALLOWED_USERS: noAllowedUser
+      MAP_EDITOR_ALLOWED_USERS: ""
+      MAP_EDITOR_ALLOW_ALL_USERS: "false"
       OPID_SCOPE: profile openid email tags-scope
       # Increasing Woka speed to make tests faster
       WOKA_SPEED: 27

--- a/docs/others/self-hosting/self-hosted-access.md
+++ b/docs/others/self-hosting/self-hosted-access.md
@@ -14,3 +14,5 @@ mechanism, but you can plug it into any "OpenID connect" compatible back end. Be
 When OpenID connect authentication is set up, you should modify the value of the `MAP_EDITOR_ALLOWED_USERS` environment
 variable (typically defined in your `.env` file) to add the list of users that are allowed to use the map editor.
 The list of users is a comma-separated list of email addresses.
+Then, set the `MAP_EDITOR_ALLOW_ALL_USERS` environment variable to `false`. This will ensure that only the users
+defined in `MAP_EDITOR_ALLOWED_USERS` will be able to access the map editor.

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -506,7 +506,7 @@ export class RoomConnection implements RoomConnection {
                             ? roomJoinedMessage.activatedInviteUser
                             : true
                     );
-                    this.canEdit = roomJoinedMessage.canEdit || this.isAdmin();
+                    this.canEdit = roomJoinedMessage.canEdit;
                     mapEditorActivated.set(ENABLE_MAP_EDITOR && this.canEdit);
 
                     // If there are scripts from the admin, run it

--- a/play/src/pusher/enums/EnvironmentVariable.ts
+++ b/play/src/pusher/enums/EnvironmentVariable.ts
@@ -97,6 +97,7 @@ export const ROOM_API_SECRET_KEY = env.ROOM_API_SECRET_KEY;
 // Map editor
 export const ENABLE_MAP_EDITOR: boolean = env.ENABLE_MAP_EDITOR;
 export const MAP_EDITOR_ALLOWED_USERS: string[] = env.MAP_EDITOR_ALLOWED_USERS;
+export const MAP_EDITOR_ALLOW_ALL_USERS: boolean = env.MAP_EDITOR_ALLOW_ALL_USERS;
 
 // Integration tools
 export const KLAXOON_ENABLED = env.KLAXOON_ENABLED;

--- a/play/src/pusher/enums/EnvironmentVariableValidator.ts
+++ b/play/src/pusher/enums/EnvironmentVariableValidator.ts
@@ -120,6 +120,11 @@ export const EnvironmentVariables = z.object({
         .string()
         .optional()
         .transform((val) => toArray(val)),
+    MAP_EDITOR_ALLOW_ALL_USERS: BoolAsString.optional()
+        .transform((val) => toBool(val, true))
+        .describe(
+            'If set to true, all users can edit the map. If set to false, only the users in MAP_EDITOR_ALLOWED_USERS or users with the "admin" or "editor" tag can edit the map. Note: this setting is ignored if an Admin API is configured.'
+        ),
     WOKA_SPEED: PositiveIntAsString.optional().transform((val) => toNumber(val, 9)),
     FEATURE_FLAG_BROADCAST_AREAS: BoolAsString.optional().transform((val) => toBool(val, false)),
 

--- a/play/src/pusher/services/LocalAdmin.ts
+++ b/play/src/pusher/services/LocalAdmin.ts
@@ -27,6 +27,7 @@ import {
     GOOGLE_SLIDES_ENABLED,
     INTERNAL_MAP_STORAGE_URL,
     KLAXOON_ENABLED,
+    MAP_EDITOR_ALLOW_ALL_USERS,
     MAP_EDITOR_ALLOWED_USERS,
     OPID_WOKA_NAME_POLICY,
     PUBLIC_MAP_STORAGE_URL,
@@ -61,7 +62,10 @@ class LocalAdmin implements AdminInterface {
         if (
             match &&
             ENABLE_MAP_EDITOR &&
-            (MAP_EDITOR_ALLOWED_USERS.length === 0 || MAP_EDITOR_ALLOWED_USERS.includes(userIdentifier))
+            (MAP_EDITOR_ALLOW_ALL_USERS ||
+                MAP_EDITOR_ALLOWED_USERS.includes(userIdentifier) ||
+                tags?.includes("admin") ||
+                tags?.includes("editor"))
         ) {
             canEdit = true;
         }
@@ -79,12 +83,6 @@ class LocalAdmin implements AdminInterface {
             companionTexture = await localCompanionService.fetchCompanionDetails(companionTextureId);
             if (companionTexture === undefined) {
                 isCompanionTextureValid = false;
-            }
-        }
-
-        if (tags) {
-            if (tags?.includes("admin") || tags?.includes("editor")) {
-                canEdit = true;
             }
         }
 
@@ -226,7 +224,7 @@ class LocalAdmin implements AdminInterface {
 
         let mapUrl = undefined;
         let wamUrl = undefined;
-        const canEdit = ENABLE_MAP_EDITOR;
+        let canEdit = false;
 
         let match = /\/~\/(.+)/.exec(roomUrl.pathname);
         if (match) {
@@ -236,6 +234,7 @@ class LocalAdmin implements AdminInterface {
                 });
             }
             wamUrl = `${PUBLIC_MAP_STORAGE_URL}/${match[1]}`;
+            canEdit = ENABLE_MAP_EDITOR;
         } else {
             match = /\/_\/[^/]+\/(.+)/.exec(roomUrl.pathname);
             if (!match) {


### PR DESCRIPTION
This environment variable defines if all users can edit the map or not. It is only taken into account for installs that don't have an Admin API attached.

Default value is "true" to keep compatibility with previous behaviour.

This fixes issues where a public map (with no WAM file attached) would have the map editor enabled despite being not editable.