### PR TITLE
[New design] Fixing cowebsite unload issues

### DIFF
--- a/maps/tests/CoWebsite/page_with_input.html
+++ b/maps/tests/CoWebsite/page_with_input.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="fr">
+    <head>
+        <meta charset="UTF-8">
+        <title>Page with input</title>
+    </head>
+    <body>
+        <input type="text" id="#text_input" />
+    </body>
+</html>

--- a/play/src/front/Components/Cowebsites/BigBlueButtonCowebsiteComponent.svelte
+++ b/play/src/front/Components/Cowebsites/BigBlueButtonCowebsiteComponent.svelte
@@ -5,6 +5,7 @@
     import { inExternalServiceStore } from "../../Stores/MyMediaStore";
 
     export let actualCowebsite: BBBCoWebsite;
+    export let visible: boolean;
     let screenWakeRelease: (() => Promise<void>) | undefined;
 
     onMount(async () => {
@@ -34,7 +35,7 @@
     });
 </script>
 
-<div class="relative w-full h-full">
+<div class="relative w-full h-full" class:hidden={!visible}>
     <div class="absolute w-full h-full z-0">
         <iframe
             src={actualCowebsite.getUrl().toString()}

--- a/play/src/front/Components/Cowebsites/JistiCowebsiteComponent.svelte
+++ b/play/src/front/Components/Cowebsites/JistiCowebsiteComponent.svelte
@@ -22,6 +22,7 @@
     const debug = Debug("jitsiCowebsite");
 
     export let actualCowebsite: JitsiCoWebsite;
+    export let visible: boolean;
     let domain = actualCowebsite.getDomain();
     let jitsiContainer: HTMLDivElement;
     let playerName = gameManager.getPlayerName();
@@ -191,6 +192,6 @@
     });
 </script>
 
-<div class="relative w-full h-full">
+<div class="relative w-full h-full" class:hidden={!visible}>
     <div bind:this={jitsiContainer} class="absolute w-full h-full z-0" />
 </div>

--- a/play/src/front/Components/Cowebsites/SimpleCowebsiteComponent.svelte
+++ b/play/src/front/Components/Cowebsites/SimpleCowebsiteComponent.svelte
@@ -4,6 +4,7 @@
     import { SimpleCoWebsite } from "../../WebRtc/CoWebsite/SimpleCoWebsite";
 
     export let actualCowebsite: SimpleCoWebsite;
+    export let visible: boolean;
     let iframeSimpleCowebsite: HTMLIFrameElement;
     export let allowApi: boolean;
 
@@ -20,7 +21,7 @@
     });
 </script>
 
-<div class="relative w-full h-full">
+<div class="relative w-full h-full" class:hidden={!visible}>
     <div class="absolute w-full h-full z-0">
         <iframe
             bind:this={iframeSimpleCowebsite}

--- a/play/src/front/Components/EmbedScreens/CoWebsitesContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CoWebsitesContainer.svelte
@@ -16,7 +16,7 @@
     import CoWebsiteTab from "./CoWebsiteTab.svelte";
 
     //let container: HTMLElement;
-    let activeCowebsite = $coWebsites[0];
+    let activeCowebsite: CoWebsite = $coWebsites[0];
     let resizeBar: HTMLElement;
     let unsubscribeCowebsitesUpdate: Unsubscriber | undefined;
 
@@ -279,13 +279,22 @@
         </div>
 
         <div class={$screenOrientationStore === "portrait" ? "flex-1 mb-3" : "h-full object-contain ml-3"}>
-            {#if activeCowebsite instanceof JitsiCoWebsite}
-                <JitsiCowebsiteComponent actualCowebsite={activeCowebsite} />
-            {:else if activeCowebsite instanceof BBBCoWebsite}
-                <BigBlueButtonCowebsiteComponent actualCowebsite={activeCowebsite} />
-            {:else if activeCowebsite instanceof SimpleCoWebsite}
-                <SimpleCowebsiteComponent actualCowebsite={activeCowebsite} allowApi={activeCowebsite.getAllowApi()} />
-            {/if}
+            {#each $coWebsites as coWebsite (coWebsite.getId())}
+                {#if coWebsite instanceof JitsiCoWebsite}
+                    <JitsiCowebsiteComponent actualCowebsite={coWebsite} visible={coWebsite === activeCowebsite} />
+                {:else if coWebsite instanceof BBBCoWebsite}
+                    <BigBlueButtonCowebsiteComponent
+                        actualCowebsite={coWebsite}
+                        visible={coWebsite === activeCowebsite}
+                    />
+                {:else if coWebsite instanceof SimpleCoWebsite}
+                    <SimpleCowebsiteComponent
+                        actualCowebsite={coWebsite}
+                        allowApi={coWebsite.getAllowApi()}
+                        visible={coWebsite === activeCowebsite}
+                    />
+                {/if}
+            {/each}
         </div>
     </div>
     <div

--- a/tests/tests/api_players.spec.ts
+++ b/tests/tests/api_players.spec.ts
@@ -622,7 +622,7 @@ test.describe("API WA.players", () => {
 
     //Swiching tabs and pages
     await page.getByTestId('tab1').click();
-    const event = getCoWebsiteIframe(page).locator('.siteA-page1')
+    const event = getCoWebsiteIframe(page).locator('.siteA-page1');
     await expect(event).toContainText('Site A Page 1');
 
     await getCoWebsiteIframe(page).locator('.link-to-siteA-page2').click();

--- a/tests/tests/scripting_open_cowebsite.spec.ts
+++ b/tests/tests/scripting_open_cowebsite.spec.ts
@@ -1,0 +1,51 @@
+import {expect, test} from '@playwright/test';
+import {maps_domain, play_url, publicTestMapUrl} from "./utils/urls";
+import { getPage} from "./utils/auth";
+import {evaluateScript} from "./utils/scripting";
+import {getCoWebsiteIframe} from "./utils/iframe";
+
+test.describe('Scripting WA.nav.openCoWebsite function', () => {
+    test('one can open several tabs that stay loaded', async ({ browser}) => {
+        const page = await getPage(browser, 'Alice', publicTestMapUrl("tests/E2E/empty.json", "scripting_open_cowebsite"));
+
+        const url = new URL(
+            `//${maps_domain}/tests/CoWebsite/page_with_input.html`,
+            play_url
+        ).toString();
+
+        await evaluateScript(page, async ({url}) => {
+            await WA.nav.openCoWebSite(url);
+            return;
+        }, {
+            url
+        });
+
+        await page.locator('iframe[title="Cowebsite"]').contentFrame().locator('[id="\\#text_input"]').click();
+        await page.locator('iframe[title="Cowebsite"]').contentFrame().locator('[id="\\#text_input"]').fill('tab1');
+        await page.locator('iframe[title="Cowebsite"]').contentFrame().locator('html').click();
+
+        // Open a second tab
+        await evaluateScript(page, async ({url}) => {
+            await WA.nav.openCoWebSite(url);
+            return;
+        }, {
+            url: url
+        });
+
+        // Check that the input field is empty
+        await expect(getCoWebsiteIframe(page).locator('[id="\\#text_input"]')).toHaveValue('');
+        await getCoWebsiteIframe(page).locator('[id="\\#text_input"]').fill('tab2');
+
+        await page.getByTestId('tab1').getByText('Maps', { exact: true }).click();
+        await expect(getCoWebsiteIframe(page).locator('[id="\\#text_input"]')).toHaveValue('tab1');
+        await expect(getCoWebsiteIframe(page).locator('[id="\\#text_input"]')).toBeVisible();
+        await expect(page.locator('iframe[title="Cowebsite"]').nth(1)).toBeHidden();
+
+        await page.getByTestId('tab2').getByText('Maps', { exact: true }).click();
+        await expect(getCoWebsiteIframe(page).locator('[id="\\#text_input"]')).toHaveValue('tab2');
+        await expect(getCoWebsiteIframe(page).locator('[id="\\#text_input"]')).toBeVisible();
+
+        await page.close();
+        await page.context().close();
+    });
+});

--- a/tests/tests/utils/iframe.ts
+++ b/tests/tests/utils/iframe.ts
@@ -2,5 +2,5 @@ import {FrameLocator, Page} from "@playwright/test";
 
 
 export function getCoWebsiteIframe(page: Page): FrameLocator {
-    return page.locator('iframe[title="Cowebsite"]').contentFrame();
+    return page.locator('iframe[title="Cowebsite"]:visible').contentFrame();
 }


### PR DESCRIPTION
When switching tabs, the iframes/Jitsi/BBB were unloaded completely. As a result, a Jitsi meeting would be interupted, or the navigation flow of a cowebsite would be lost.

We now are keeping the iframes opened, but hidden.