### PR TITLE
Switching the build output of iframe_api to IIFE

### DIFF
--- a/play/iframe-api.vite.config.ts
+++ b/play/iframe-api.vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import { resolve } from "path";
+import { defineConfig } from "vite";
 
 export default defineConfig({
     publicDir: false,
@@ -10,7 +10,7 @@ export default defineConfig({
         lib: {
             entry: resolve(__dirname, "src/iframe_api.ts"),
             name: "iframe_api",
-            formats: ["cjs"],
+            formats: ["iife"],
             fileName: () => "iframe_api.js",
         },
     },


### PR DESCRIPTION
The previous CJS module system was polluting the global scope with minified variables names that should not be there. We are using an IIFE here to avoid global pollution.