### PR TITLE
Fix chose hardware scene responsive

### DIFF
--- a/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
+++ b/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
@@ -199,7 +199,7 @@
 
             <!-- MICROPHONE -->
             <div
-                class="flex lg:space-x-4 flex-col lg:flex-row  min-w-[320px]  md:overflow-scroll justify-center  items-center lg:items-stretch lg:px-4 lg:pb-4"
+                class="flex lg:space-x-4 flex-col lg:flex-row min-w-[320px]  md:overflow-scroll justify-center  items-center lg:items-stretch lg:px-4 pb-[15%] sm:pb-[8%] lg:pb-4 "
             >
                 <!-- MICROPHONE -->
                 <SelectMicrophone


### PR DESCRIPTION
We cannot scroll down the hardware selection page:
![image](https://github.com/user-attachments/assets/4d5b9b60-0d96-474c-bac0-e29ba193932d)

I fix it by adding bottom padding.

✨ Now
<img width="479" alt="image" src="https://github.com/user-attachments/assets/d42fc02a-22d2-478a-976c-aba21f7a1f0f" />
