### PR TITLE
[New design] Disabling fullscreen modals

### DIFF
--- a/play/src/front/Components/Modal/Modal.svelte
+++ b/play/src/front/Components/Modal/Modal.svelte
@@ -31,9 +31,10 @@
         if ($modalIframeStore?.allowApi) {
             iframeListener.registerIframe(modalIframe);
         }
-        if ($modalIframeStore?.position == "center") {
+        // Note: the fullscreen functionality is not implemented yet
+        /*if ($modalIframeStore?.position == "center") {
             isFullScreened = true;
-        }
+        }*/
     });
 
     onDestroy(() => {
@@ -60,6 +61,8 @@
         : $modalIframeStore?.position} {isFullScreened ? 'fullscreened' : ''}"
     bind:this={mainModal}
 >
+    @apply flex h-3/4 w-full text-white pointer-events-auto z-[900] right-0 left-0 m-auto absolute top-14;
+
     <div class="w-full h-full bg-contrast/80 backdrop-blur rounded" transition:blur={{ amount: 10, duration: 250 }}>
         <div
             class="flex bg-contrast/80 backdrop-blur p-2 space-x-0 @lg/main-layout:space-x-2 rounded-lg absolute top-4 right-4 z-50 "
@@ -143,6 +146,15 @@
         }
         &.left {
             left: 0;
+        }
+        &.center:not(.fullscreened) {
+            width: 75%;
+            height: 75%;
+            left: 0;
+            right: 0;
+            top: 12.5%;
+            margin-right: auto;
+            margin-left: auto;
         }
     }
 </style>


### PR DESCRIPTION
The fullscreen modal functionality is not ready yet and was started as part of the new design. This commit comments the "fullscreen" parts of the code already implemented to come back to a classic more stable modal.

We will work on the fullscreen feature later, after the new design.