### PR TITLE
Fix translation of silent zone

### DIFF
--- a/play/src/i18n/en-US/camera.ts
+++ b/play/src/i18n/en-US/camera.ts
@@ -43,7 +43,7 @@ const camera: BaseTranslation = {
     my: {
         silentZone: "Silent zone",
         silentZoneDesc:
-            "Vous êtes dans une zone silencieuse, les autres utilisateurs ne peuvent pas vous parler, votre micro et caméra est désactivé. Bonne pause !",
+            "You are in a silent zone, other users cannot talk to you, your microphone and camera are disabled. Enjoy your break!",
         nameTag: "You",
         loading: "Loading your camera...",
     },


### PR DESCRIPTION
This pull request includes a translation update to the `play/src/i18n/en-US/camera.ts` file. The change updates the description of the silent zone to English.

Translation update:

* [`play/src/i18n/en-US/camera.ts`](diffhunk://#diff-e0f5fa7ef2c87d3cbd20863afc0b7b75f65b41c2c512a2a48159d84ef6a9be3bL46-R46): Updated the `silentZoneDesc` translation from French to English.