### PR TITLE
fixing popup alignment

### DIFF
--- a/play/src/front/Components/ActionBar/SilentBlock.svelte
+++ b/play/src/front/Components/ActionBar/SilentBlock.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <div
-    class="absolute bottom-8 w-4/5 md:w-3/4 left-1/2 max-w-screen-md -translate-x-1/2 z-[250] text-white border border-solid border-danger flex flex-col items-center justify-between bg-no-repeat bg-center bg-danger-1000/70 backdrop-blur rounded-xl text-center"
+    class="absolute bottom-4 w-4/5 md:w-3/4 left-1/2 max-w-screen-md -translate-x-1/2 z-[250] text-white border border-solid border-danger flex flex-col items-center justify-between bg-no-repeat bg-center bg-danger-1000/70 backdrop-blur rounded-xl text-center"
     transition:fly={{ y: 30, duration: 400 }}
 >
     <div class="flex items-center justify-center relative">


### PR DESCRIPTION
This pull request includes a small change to the `SilentBlock.svelte` file. The change adjusts the bottom margin of a `div` element to improve the layout.

* [`play/src/front/Components/ActionBar/SilentBlock.svelte`](diffhunk://#diff-fe2a8c5e8157b8565a54d5a1688000b18449d5055629555b94b4d5dabcfe289bL7-R7): Changed the `bottom` property of the `div` element from `8` to `4` to adjust the vertical positioning.