### PR TITLE
Fixing blacklisting of bubble messages

### DIFF
--- a/play/src/front/WebRtc/BlackListManager.ts
+++ b/play/src/front/WebRtc/BlackListManager.ts
@@ -1,26 +1,24 @@
 import { Subject } from "rxjs";
 
 class BlackListManager {
-    private list: string[] = [];
+    private list: Set<string> = new Set();
     public onBlockStream: Subject<string> = new Subject();
     public onUnBlockStream: Subject<string> = new Subject();
 
     isBlackListed(userUuid: string): boolean {
-        return this.list.find((data) => data === userUuid) !== undefined;
+        return this.list.has(userUuid);
     }
 
     blackList(userUuid: string): void {
         if (this.isBlackListed(userUuid)) return;
-        this.list.push(userUuid);
+        this.list.add(userUuid);
         this.onBlockStream.next(userUuid);
     }
 
     cancelBlackList(userUuid: string): void {
-        this.list.splice(
-            this.list.findIndex((data) => data === userUuid),
-            1
-        );
-        this.onUnBlockStream.next(userUuid);
+        if (this.list.delete(userUuid)) {
+            this.onUnBlockStream.next(userUuid);
+        }
     }
 }
 


### PR DESCRIPTION
When we migrated messages to spaces (instead of WebRTC connection), we forgot to blacklist those messages if they are sent by a blocked user. This commit fixes this.