### PR TITLE
Fix jitsi configure popup

### DIFF
--- a/play/src/front/Components/MapEditor/PropertyEditor/JitsiRoomPropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/JitsiRoomPropertyEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher } from "svelte";
     import { JitsiRoomPropertyData } from "@workadventure/map-editor";
-    import { openModal, closeModal } from "svelte-modals";
+    import { openModal } from "svelte-modals";
     import { LL } from "../../../../i18n/i18n-svelte";
     import Input from "../../Input/Input.svelte";
     import InputSwitch from "../../Input/InputSwitch.svelte";
@@ -35,10 +35,11 @@
             visibilityValue: jitsiConfigModalOpened,
             config: property.jitsiRoomConfig,
             jitsiRoomAdminTag: property.jitsiRoomAdminTag,
+            onSave: (config) => {
+                property.jitsiRoomConfig = structuredClone(config);
+                dispatch("change");
+            },
         });
-        () => {
-            closeModal();
-        };
         jitsiConfigModalOpened = true;
     }
 </script>
@@ -131,7 +132,7 @@
                             bind:value={property.trigger}
                             onChange={onTriggerValueChange}
                         >
-                            <option value={undefined}
+                            <option value="immediately"
                                 >{$LL.mapEditor.properties.jitsiProperties.triggerShowImmediately()}</option
                             >
                             <option value="onicon">{$LL.mapEditor.properties.jitsiProperties.triggerOnClick()}</option>
@@ -154,8 +155,12 @@
                     </div>
                 {/if}
 
-                <button on:click={OpenPopup}>{$LL.mapEditor.properties.jitsiProperties.moreOptionsLabel()} </button>
-
+                <button
+                    class="btn bg-transparent rounded-md hover:!bg-white/10 transition-all border !border-white py-2"
+                    on:click={OpenPopup}
+                >
+                    {$LL.mapEditor.properties.jitsiProperties.moreOptionsLabel()}
+                </button>
                 <!-- <JitsiRoomConfigEditor
                     bind:isOpen={jitsiConfigModalOpened}
                     bind:visibilityValue={jitsiConfigModalOpened}


### PR DESCRIPTION

<img width="702" alt="image" src="https://github.com/user-attachments/assets/6f5ca96d-fb82-497d-94ce-7615e5004e9a" />


This pull request includes several changes to the `JitsiRoomConfigEditor.svelte` and `JitsiRoomPropertyEditor.svelte` files to enhance the user interface and improve functionality. The most important changes include replacing the `Popup` component with a new `PopUpContainer`, adding a new `onSave` function, and updating button styles.

### Enhancements to user interface and functionality:

* Replaced `Popup` component with `PopUpContainer` and updated the modal structure to improve the user interface in `JitsiRoomConfigEditor.svelte`. [[1]](diffhunk://#diff-f21aaa0df1e62e759bb9c5cb2b304cffb0819be0eff1de0bfd7dad54c93624bfL2-R11) [[2]](diffhunk://#diff-f21aaa0df1e62e759bb9c5cb2b304cffb0819be0eff1de0bfd7dad54c93624bfL65-R79)
* Added a new `onSave` function to handle saving the configuration and closing the modal in `JitsiRoomConfigEditor.svelte`.
* Updated button styles and added a new button for saving and closing the modal in `JitsiRoomConfigEditor.svelte`.

### Code simplification and cleanup:

* Removed unused imports and functions in `JitsiRoomConfigEditor.svelte` to simplify the codebase. [[1]](diffhunk://#diff-f21aaa0df1e62e759bb9c5cb2b304cffb0819be0eff1de0bfd7dad54c93624bfL2-R11) [[2]](diffhunk://#diff-f21aaa0df1e62e759bb9c5cb2b304cffb0819be0eff1de0bfd7dad54c93624bfL38-R48)
* Removed the `closeModal` import from `JitsiRoomPropertyEditor.svelte` as it is no longer needed.

### Additional improvements:

* Updated the `OpenPopup` button style in `JitsiRoomPropertyEditor.svelte` to enhance the user interface.
* Changed the default value for the trigger option to "immediately" in `JitsiRoomPropertyEditor.svelte`.