### PR TITLE
Refactoring handling of disabled controls

### DIFF
--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -104,10 +104,10 @@ class IframeListener {
     private readonly _newChatMessageWritingStatusStream: Subject<number> = new Subject();
     public readonly newChatMessageWritingStatusStream = this._newChatMessageWritingStatusStream.asObservable();
 
-    private readonly _disablePlayerControlStream: Subject<void> = new Subject();
+    private readonly _disablePlayerControlStream: Subject<MessageEventSource | null> = new Subject();
     public readonly disablePlayerControlStream = this._disablePlayerControlStream.asObservable();
 
-    private readonly _enablePlayerControlStream: Subject<void> = new Subject();
+    private readonly _enablePlayerControlStream: Subject<MessageEventSource | null> = new Subject();
     public readonly enablePlayerControlStream = this._enablePlayerControlStream.asObservable();
 
     private readonly _disablePlayerProximityMeetingStream: Subject<void> = new Subject();
@@ -399,9 +399,9 @@ class IframeListener {
                     } else if (iframeEvent.type === "loadSound") {
                         this._loadSoundStream.next(iframeEvent.data);
                     } else if (iframeEvent.type === "disablePlayerControls") {
-                        this._disablePlayerControlStream.next();
+                        this._disablePlayerControlStream.next(message.source);
                     } else if (iframeEvent.type === "restorePlayerControls") {
-                        this._enablePlayerControlStream.next();
+                        this._enablePlayerControlStream.next(message.source);
                     } else if (iframeEvent.type === "turnOffMicrophone") {
                         this._turnOffMicrophoneStream.next();
                     } else if (iframeEvent.type === "turnOffWebcam") {

--- a/play/src/front/Components/ActionBar/EmojiSubMenu.svelte
+++ b/play/src/front/Components/ActionBar/EmojiSubMenu.svelte
@@ -4,19 +4,13 @@
     import { clickOutside } from "svelte-outside";
     import { onDestroy } from "svelte";
     import { LL } from "../../../i18n/i18n-svelte";
-    import {
-        emoteDataStore,
-        emoteMenuStore,
-        emoteMenuSubCurrentEmojiSelectedStore,
-        emoteStore,
-    } from "../../Stores/EmoteStore";
+    import { emoteDataStore, emoteMenuStore, emoteMenuSubCurrentEmojiSelectedStore } from "../../Stores/EmoteStore";
     import { mapEditorModeStore } from "../../Stores/MapEditorStore";
     import { inputFormFocusStore } from "../../Stores/UserInputStore";
 
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import XIcon from "../Icons/XIcon.svelte";
     import PenIcon from "../Icons/PenIcon.svelte";
-    import { Emoji } from "../../Stores/Utils/emojiSchema";
     import { activeSecondaryZoneActionBarStore } from "../../Stores/MenuStore";
     import { ArrowAction } from "../../Utils/svelte-floatingui";
     import { showFloatingUi } from "../../Utils/svelte-floatingui-show";
@@ -34,14 +28,6 @@
             //select place to change in emoji sub menu
             emoteMenuSubCurrentEmojiSelectedStore.set(selected);
         } else if (selected != undefined) {
-            //get emoji and play it
-            let emoji: Emoji | null | undefined = $emoteDataStore.get(selected);
-            if (emoji == undefined) {
-                return;
-            }
-            analyticsClient.launchEmote(emoji);
-            emoteStore.set(emoji);
-
             //play UX animation
             focusElement(selected);
         }

--- a/play/src/front/Components/MainLayout.svelte
+++ b/play/src/front/Components/MainLayout.svelte
@@ -61,7 +61,7 @@
                 target.classList.contains("block-user-action"))
         ) {
             try {
-                gameManager.getCurrentGameScene().userInputManager.disableControls();
+                gameManager.getCurrentGameScene().userInputManager.disableControls("textField");
                 keyboardEventIsDisable = true;
             } catch (error) {
                 if (error instanceof GameSceneNotFoundError) {
@@ -76,7 +76,7 @@
     const handleFocusOutEvent = () => {
         if (!keyboardEventIsDisable) return;
         try {
-            gameManager.getCurrentGameScene().userInputManager.restoreControls();
+            gameManager.getCurrentGameScene().userInputManager.restoreControls("textField");
             keyboardEventIsDisable = false;
         } catch (error) {
             if (error instanceof GameSceneNotFoundError) {

--- a/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
@@ -153,7 +153,7 @@ export class ExplorerTool implements MapEditorTool {
         analyticsClient.closeExplorationMode();
 
         // Restore controls of the scene
-        this.scene.userInputManager.restoreControls();
+        this.scene.userInputManager.restoreControls("explorerTool");
 
         // Remove all controls for the exploration mode
         this.scene.input.keyboard?.off("keydown", this.keyDownHandler);
@@ -237,7 +237,7 @@ export class ExplorerTool implements MapEditorTool {
         this.scene.input.setDefaultCursor("grab");
 
         // Disable controls of the scene
-        this.scene.userInputManager.disableControls();
+        this.scene.userInputManager.disableControls("explorerTool");
 
         // Implement all controls for the exploration mode
         this.scene.input.setTopOnly(false);
@@ -273,17 +273,6 @@ export class ExplorerTool implements MapEditorTool {
 
         // Create flash animation
         this.scene.cameras.main.flash();
-
-        // Make that to be sure that when the map explorer is open, the user don't move with the camera or keyboard
-        // See the part of code in UserInputManager.ts that automatically enable the controle when the store is defined to true
-        this.enableUserInputsStoreSubscribe = enableUserInputsStore.subscribe((value) => {
-            if (!value) return;
-            // FIXME: use queue microtask to avoid the setTimeout
-            setTimeout(() => {
-                // Disable controls of the scene
-                this.scene.userInputManager.disableControls();
-            }, 100);
-        });
     }
     public destroy(): void {
         this.clear();

--- a/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
+++ b/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
@@ -7,6 +7,9 @@ import type { GameScene } from "../Game/GameScene";
 import { mapEditorModeStore } from "../../Stores/MapEditorStore";
 import { isActivatable } from "../Game/ActivatableInterface";
 import { mapManagerActivated } from "../../Stores/MenuStore";
+import { Emoji } from "../../Stores/Utils/emojiSchema";
+import { emoteDataStore, emoteStore } from "../../Stores/EmoteStore";
+import { analyticsClient } from "../../Administration/AnalyticsClient";
 
 export class GameSceneUserInputHandler implements UserInputHandlerInterface {
     private gameScene: GameScene;
@@ -81,6 +84,19 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
             }
             case "KeyR": {
                 this.gameScene.CurrentPlayer.rotate();
+                break;
+            }
+            case "Digit1":
+            case "Digit2":
+            case "Digit3":
+            case "Digit4":
+            case "Digit5":
+            case "Digit6": {
+                const emoji: Emoji | null | undefined = get(emoteDataStore).get(Number(event.code.slice(-1)));
+                if (emoji) {
+                    analyticsClient.launchEmote(emoji);
+                    emoteStore.set(emoji);
+                }
                 break;
             }
             default: {

--- a/play/src/front/Phaser/UserInput/UserInputManager.ts
+++ b/play/src/front/Phaser/UserInput/UserInputManager.ts
@@ -23,6 +23,10 @@ export enum UserInputEvent {
     JoystickMove,
 }
 
+// The reason why the controls are disabled
+// The MessageEventSource type means the controls where disabled by the scripting API in the related iframe
+type DisableControlsReason = "store" | "explorerTool" | "errorScreen" | "textField" | MessageEventSource;
+
 //we cannot use a map structure so we have to create a replacement
 export class ActiveEventList {
     private eventMap: Map<UserInputEvent, boolean> = new Map<UserInputEvent, boolean>();
@@ -65,6 +69,7 @@ export class UserInputManager {
 
     private userInputHandler: UserInputHandlerInterface;
     private enableUserInputsStoreUnsubscribe: Unsubscriber;
+    private readonly disableControlsReasons: Set<DisableControlsReason> = new Set();
 
     constructor(scene: Phaser.Scene, userInputHandler: UserInputHandlerInterface) {
         this.scene = scene;
@@ -79,7 +84,7 @@ export class UserInputManager {
         }
 
         this.enableUserInputsStoreUnsubscribe = enableUserInputsStore.subscribe((enable) => {
-            enable ? this.restoreControls() : this.disableControls();
+            enable ? this.restoreControls("store") : this.disableControls("store");
         });
     }
 
@@ -177,16 +182,31 @@ export class UserInputManager {
         ];
     }
 
-    disableControls() {
+    /**
+     * Will disable the controls for the user.
+     * You need to pass the reason why the controls are disabled.
+     * When you restore the controls, you need to pass the same reason.
+     */
+    disableControls(reason: DisableControlsReason) {
         try {
             this.scene.input.keyboard?.disableGlobalCapture();
+            this.disableControlsReasons.add(reason);
         } catch (e) {
             console.warn(e);
         }
         this.isInputDisabled = true;
     }
 
-    restoreControls() {
+    /**
+     * Will restore the controls for the user.
+     * You need to pass the reason why the controls are restored.
+     * Only when there are no more reasons to disable the controls, the controls will be restored.
+     */
+    restoreControls(reason: DisableControlsReason) {
+        this.disableControlsReasons.delete(reason);
+        if (this.disableControlsReasons.size > 0) {
+            return;
+        }
         try {
             this.scene.input.keyboard?.enableGlobalCapture();
         } catch (e) {

--- a/play/src/front/Stores/UserInputStore.ts
+++ b/play/src/front/Stores/UserInputStore.ts
@@ -2,6 +2,8 @@ import { derived, writable } from "svelte/store";
 import { menuInputFocusStore } from "./MenuInputFocusStore";
 import { chatInputFocusStore } from "./ChatStore";
 import { showReportScreenStore, userReportEmpty } from "./ShowReportScreenStore";
+import { emoteMenuStore } from "./EmoteStore";
+import { refreshPromptStore } from "./RefreshPromptStore";
 
 export const inputFormFocusStore = writable(false);
 
@@ -43,6 +45,8 @@ export const enableUserInputsStore = derived(
         showReportScreenStore,
         inputFormFocusStore,
         mapExplorerSearchinputFocusStore,
+        emoteMenuStore,
+        refreshPromptStore,
     ],
     ([
         $menuInputFocusStore,
@@ -50,13 +54,17 @@ export const enableUserInputsStore = derived(
         $showReportScreenStore,
         $inputFormFocusStore,
         $mapExplorerSearchinputFocusStore,
+        $emoteMenuStore,
+        $refreshPromptStore,
     ]) => {
         return (
             !$menuInputFocusStore &&
             !$chatInputFocusStore &&
             !($showReportScreenStore !== userReportEmpty) &&
             !$inputFormFocusStore &&
-            !$mapExplorerSearchinputFocusStore
+            !$mapExplorerSearchinputFocusStore &&
+            !$emoteMenuStore &&
+            !$refreshPromptStore
         );
     }
 );


### PR DESCRIPTION
This should fix bugs were controls are enabled when they should not, etc... So far, when calling disableControls() or restoreControls(), it was easy to overstep one reason with another. For instance, the scripting API could disable controls that would be restored because we are blurring a text control.

Now, there are 2 ways to disable controls.

1. Via the `enableUserInputsStore` derived store. This is the "responsive" way
2. Via disableControls() or restoreControls() (the declarative way). If you use the declarative way, you HAVE to give a "reason"

When you call disableControls with a given reason, controls won't be returned until you call restoreControls() with the same reason.