### PR TITLE
Making terms and condition more visible

### DIFF
--- a/play/src/front/Components/Login/LoginScene.svelte
+++ b/play/src/front/Components/Login/LoginScene.svelte
@@ -133,6 +133,15 @@
                 >{$LL.login.continue()}</button
             >
         </section>
+        {#if legalString}
+            <section class="terms-and-conditions h-fit text-center w-full">
+                <p class="text-white text-xs italic opacity-50">
+                    {@html $LL.login.terms({
+                        links: legalString,
+                    })}
+                </p>
+            </section>
+        {/if}
     </div>
     {#if logo !== logoImg && gameManager.currentStartedRoom.showPoweredBy !== false}
         <section class="text-right flex powered-by justify-center items-end">
@@ -145,14 +154,3 @@
     style={getBackgroundColor() != undefined ? `background-color: ${getBackgroundColor()};` : ""}
 />
 <div class="absolute left-0 top-0 w-full h-full bg-cover z-10" style="background-image: url('{bgMap}');" />
-
-{#if legalString}
-    <section class="terms-and-conditions h-fit absolute z-40 bottom-0 text-center w-full">
-        <a style="display: none;" href="traduction">Need for traduction</a>
-        <p class="text-white text-xs italic opacity-50">
-            {@html $LL.login.terms({
-                links: legalString,
-            })}
-        </p>
-    </section>
-{/if}


### PR DESCRIPTION
Moving those below the continue button instead of at the very bottom of the screen.

Before:
![image](https://github.com/user-attachments/assets/738efa08-d42c-463a-a6ae-f41624c1a261)

After:
![image](https://github.com/user-attachments/assets/484ef95a-8a92-4d7d-bcb8-a9f2be1e25e0)
