### PR TITLE
Removing RUN_FROM_GITHUB.

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -370,8 +370,7 @@ jobs:
               \"token\": \"${{ secrets.GITLAB_TOKEN_PIPELINE }}\",
               \"ref\": \"${REF}\",
               \"variables\": {
-                \"GITHUB_BRANCH_NAME\": \"${{ github.head_ref }}\",
-                \"RUN_FROM_GITHUB\": \"true\"
+                \"GITHUB_BRANCH_NAME\": \"${{ github.head_ref }}\"
               }
             }")
 


### PR DESCRIPTION
We can detect a Pipeline is running in Gitlab with "$CI_PIPELINE_SOURCE" == "api" so the variable is not needed.