### PR TITLE
Fixing the way we request video frame callbacks

### DIFF
--- a/play/src/front/Components/Video/CenteredVideo.svelte
+++ b/play/src/front/Components/Video/CenteredVideo.svelte
@@ -144,11 +144,15 @@
         if (expectVideoOutput && videoElement && mediaStream) {
             expectVideoWithin3Seconds();
         }
+    }
+    $: {
         if (!expectVideoOutput && noVideoTimeout) {
             clearTimeout(noVideoTimeout);
             noVideoTimeout = undefined;
         }
     }
+
+    let callbackId: number | undefined;
 
     function expectVideoWithin3Seconds() {
         if ("requestVideoFrameCallback" in videoElement) {
@@ -162,11 +166,19 @@
                 analyticsClient.noVideoStreamReceived();
             }, 3000);
 
-            videoElement.requestVideoFrameCallback(() => {
+            if (callbackId !== undefined) {
+                // We need to cancel the previous callback if it exists.
+                videoElement.cancelVideoFrameCallback(callbackId);
+            }
+            callbackId = videoElement.requestVideoFrameCallback(() => {
                 // A video frame was displayed. No need to display a warning.
                 displayNoVideoWarning = false;
                 clearTimeout(noVideoTimeout);
                 noVideoTimeout = undefined;
+                if (callbackId !== undefined) {
+                    // We need to cancel the previous callback if it exists.
+                    videoElement.cancelVideoFrameCallback(callbackId);
+                }
             });
         }
     }


### PR DESCRIPTION
Video frame callbacks are requested to display warning messages if we don't receive video within 3 seconds. Previously, we did not unsubscribe the callback causing unnecessary calls and weird errors.

Also fixing a reactive bug.