### PR TITLE
Fix buttons on popups

### DIFF
--- a/play/src/front/Chat/Components/Room/CreateFolderModal.svelte
+++ b/play/src/front/Chat/Components/Room/CreateFolderModal.svelte
@@ -124,7 +124,7 @@
                 >{$LL.chat.createFolder.buttons.cancel()}</button
             >
             <button
-                data-testid="btn createFolderButton"
+                data-testid="createFolderButton"
                 class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
                 disabled={createFolderOptions.name === undefined || createFolderOptions.name?.trim().length === 0}
                 on:click={() => createNewFolder(createFolderOptions)}

--- a/play/src/front/Chat/Components/Room/CreateFolderModal.svelte
+++ b/play/src/front/Chat/Components/Room/CreateFolderModal.svelte
@@ -120,11 +120,12 @@
         {#if loadingFolderCreation}
             <p>{$LL.chat.createFolder.loadingCreation()}</p>
         {:else}
-            <button class="flex-1 justify-center" on:click={closeModal}>{$LL.chat.createFolder.buttons.cancel()}</button
+            <button class="btn btn-contrast flex-1 justify-center" on:click={closeModal}
+                >{$LL.chat.createFolder.buttons.cancel()}</button
             >
             <button
-                data-testid="createFolderButton"
-                class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+                data-testid="btn createFolderButton"
+                class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
                 disabled={createFolderOptions.name === undefined || createFolderOptions.name?.trim().length === 0}
                 on:click={() => createNewFolder(createFolderOptions)}
                 >{$LL.chat.createFolder.buttons.create()}

--- a/play/src/front/Chat/Connection/Matrix/AccessSecretStorageDialog.svelte
+++ b/play/src/front/Chat/Connection/Matrix/AccessSecretStorageDialog.svelte
@@ -154,12 +154,12 @@
         {/if}
     </div>
     <svelte:fragment slot="action">
-        <button class="flex-1 justify-center" on:click={cancelAccessSecretStorage}
+        <button class="btn flex-1 justify-center hover:bg-white/10" on:click={cancelAccessSecretStorage}
             >{$LL.chat.e2ee.accessSecretStorage.buttons.cancel()}</button
         >
         <button
             disabled={confirmInputDisabled || isCheckingPassphrase}
-            class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+            class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
             data-testid="confirmAccessSecretStorageButton"
             on:click={() => checkAndSubmitRecoveryOrPassphraseIfValid()}
         >

--- a/play/src/front/Chat/Connection/Matrix/AskStartVerificationModal.svelte
+++ b/play/src/front/Chat/Connection/Matrix/AskStartVerificationModal.svelte
@@ -109,11 +109,11 @@
     </div>
     <svelte:fragment slot="action">
         {#if !errorLabel}
-            <button class="flex-1 justify-center bg-danger-900 mx-4" on:click={refuseToStartVerification}>
+            <button class="btn flex-1 justify-center bg-danger-900" on:click={refuseToStartVerification}>
                 {$LL.chat.askStartVerificationModal.ignore()}
             </button>
             <button
-                class="flex-1 justify-center  bg-secondary mx-4"
+                class="btn btn-secondary flex-1 justify-center  bg-secondary"
                 data-testid="VerifyTheSessionButton"
                 on:click={acceptToStartVerification}
             >

--- a/play/src/front/Chat/Connection/Matrix/ChooseDeviceVerificationMethodModal.svelte
+++ b/play/src/front/Chat/Connection/Matrix/ChooseDeviceVerificationMethodModal.svelte
@@ -29,13 +29,13 @@
     <svelte:fragment slot="action">
         <button
             data-testid="VerifyWithAnotherDeviceButton"
-            class=" bg-secondary flex-1 justify-center mx-4"
+            class="btn btn-secondary bg-secondary flex-1 justify-center"
             on:click={startVerificationWithOtherDevice}
             >{$LL.chat.chooseDeviceVerificationMethodModal.withOtherDevice()}
         </button>
         <button
             data-testid="VerifyWithPassphraseButton"
-            class=" bg-secondary flex-1 justify-center mx-4"
+            class="btn btn-secondary bg-secondary flex-1 justify-center"
             on:click={startVerificationWithPassphrase}
             >{$LL.chat.chooseDeviceVerificationMethodModal.withPassphrase()}
         </button>

--- a/play/src/front/Chat/Connection/Matrix/CreateRecoveryKeyDialog.svelte
+++ b/play/src/front/Chat/Connection/Matrix/CreateRecoveryKeyDialog.svelte
@@ -96,14 +96,14 @@
         {#if generatedSecretStorageKey === undefined}
             <button
                 disabled={passphraseInput === undefined || passphraseInput?.trim().length === 0}
-                class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+                class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
                 on:click={() => generateRecoveryKey(passphraseInput)}
                 >{$LL.chat.e2ee.createRecoveryKey.buttons.generate()}
             </button>
         {:else}
             <button
                 disabled={!isPrivateKeyDownloaded}
-                class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+                class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
                 on:click={closeModalAndContinueToWorkAdventure}
                 >{$LL.chat.e2ee.createRecoveryKey.buttons.continue()}
             </button>

--- a/play/src/front/Components/Menu/ResetKeyStorageConfirmationModal.svelte
+++ b/play/src/front/Components/Menu/ResetKeyStorageConfirmationModal.svelte
@@ -14,11 +14,11 @@
         <p class="w-full text-center">{$LL.menu.chat.resetKeyStorageConfirmationModal.warning()}</p>
     </div>
     <svelte:fragment slot="action">
-        <button class="flex-1 justify-center" on:click={() => closeModal()}
+        <button class="btn flex-1 justify-center" on:click={() => closeModal()}
             >{$LL.menu.chat.resetKeyStorageConfirmationModal.cancel()}
         </button>
         <button
-            class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+            class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
             on:click={() => {
                 closeModal();
                 matrixSecurity.setupNewKeyStorage().catch(() => {


### PR DESCRIPTION
<img width="702" alt="image" src="https://github.com/user-attachments/assets/3efc6d6e-0b59-4108-96b1-70d288ef30ec" />


Before

<img width="501" alt="image" src="https://github.com/user-attachments/assets/b564d0e7-2be4-498b-a582-885b8019248c" />


This pull request standardizes button styling across multiple Svelte components by introducing consistent `btn` and `btn-secondary` classes. These changes enhance the maintainability and visual consistency of the UI.

### Standardization of Button Styling:

* Updated the `cancel` and `create` buttons in `CreateFolderModal.svelte` to use the `btn` and `btn-secondary` classes for consistency. (`[play/src/front/Chat/Components/Room/CreateFolderModal.svelteL123-R128](diffhunk://#diff-ba7219fdf2ca6edf8c929ca16194d2a418106a401ecaac223cbdf13a57d393caL123-R128)`)
* Applied the `btn` and `btn-secondary` classes to buttons in `AccessSecretStorageDialog.svelte` for cancel and confirm actions. (`[play/src/front/Chat/Connection/Matrix/AccessSecretStorageDialog.svelteL157-R162](diffhunk://#diff-d76eb028037a256eeb8784b37a60fec1b55d5fe37069759d41eebcb7e268499fL157-R162)`)
* Standardized the `ignore` and `verify` buttons in `AskStartVerificationModal.svelte` with the `btn` and `btn-secondary` classes. (`[play/src/front/Chat/Connection/Matrix/AskStartVerificationModal.svelteL112-R116](diffhunk://#diff-01c750a740510ad1d559a6e73be2f4071da5b943590c4ba08806cae4e7405fbcL112-R116)`)
* Updated the `VerifyWithAnotherDeviceButton` and `VerifyWithPassphraseButton` in `ChooseDeviceVerificationMethodModal.svelte` to use the `btn` and `btn-secondary` classes. (`[play/src/front/Chat/Connection/Matrix/ChooseDeviceVerificationMethodModal.svelteL32-R38](diffhunk://#diff-1361ca46c9ec1f5f680240eb30ce298d09f077e317e5f35f3c7a2001a923023bL32-R38)`)
* Ensured buttons in `CreateRecoveryKeyDialog.svelte` use the `btn` and `btn-secondary` classes for generating and continuing actions. (`[play/src/front/Chat/Connection/Matrix/CreateRecoveryKeyDialog.svelteL99-R106](diffhunk://#diff-4e7b5497c9add713c171d406e67ca8e4e094b3af396b8878cea9d921de9489c4L99-R106)`)
* Modified the `cancel` and `confirm` buttons in `ResetKeyStorageConfirmationModal.svelte` to adopt the `btn` and `btn-secondary` classes. (`[play/src/front/Components/Menu/ResetKeyStorageConfirmationModal.svelteL17-R21](diffhunk://#diff-e3961f9198b8cc11ab144e42ade412aa5dbb0c91526aefd748e7838f2ceec75aL17-R21)`)