### PR TITLE
Fix refresh screen design

### DIFF
--- a/play/src/front/Components/RefreshPrompt.svelte
+++ b/play/src/front/Components/RefreshPrompt.svelte
@@ -7,15 +7,16 @@
 
     onMount(() => {
         setInterval(() => {
-            if (timeToRefreshSeconds === 0) {
+            if (timeToRefreshSeconds <= 0) {
                 window.location.reload();
+            } else {
+                timeToRefreshSeconds--;
             }
-            timeToRefreshSeconds--;
         }, 1000);
     });
 </script>
 
-<div class="grid place-items-center h-dvh refresh">
+<div class="grid place-items-center h-dvh refresh min-w-full w-screen bg-contrast">
     <div class="px-10 py-80 flex items-center flex-col">
         <p class="test-class">{$LL.mapEditor.map.refreshPrompt()}</p>
         <button
@@ -31,7 +32,6 @@
     .refresh {
         pointer-events: auto;
         color: white;
-        background-color: rgb(15 31 45);
         z-index: 10000 !important;
         position: absolute !important;
         font-family: "Roboto", sans-serif;


### PR DESCRIPTION
This pull request updates the `RefreshPrompt.svelte` component to improve functionality and enhance styling consistency. The most important changes include fixing a bug in the refresh timer logic and updating the component's layout and styling.

### Bug Fix:
* Updated the refresh timer condition to check if `timeToRefreshSeconds` is less than or equal to zero (`<= 0`) instead of strictly equal to zero (`=== 0`). This ensures the page reloads correctly even if the timer overshoots.

### Styling Enhancements:
* Added `min-w-full w-screen bg-contrast` to the main container's class list to ensure full-width coverage and better visual contrast.
* Removed the `background-color` property from the `.refresh` class to allow the new `bg-contrast` class to handle background styling consistently.