### PR TITLE
In PiP, disabling audio feedback

### DIFF
--- a/play/src/front/Components/Video/PictureInPicture/PictureInPictureAudioWrapper.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/PictureInPictureAudioWrapper.svelte
@@ -7,7 +7,7 @@
     export let peer: Streamable;
 
     let streamStore: Readable<MediaStream | undefined> | undefined = undefined;
-    if (peer.media.type === "mediaStore") {
+    if (peer.media.type === "mediaStore" && !peer.muteAudio) {
         streamStore = peer.media.streamStore;
     }
 </script>


### PR DESCRIPTION
In PictureInPicture mode, the audio comes out of an <audio> tag. We were playing the audio for all streams, even our own local stream, which caused an unwanted audio feedback.

Close #4792