### PR TITLE
Adding back setting renderer via tag

### DIFF
--- a/play/src/front/Components/App.svelte
+++ b/play/src/front/Components/App.svelte
@@ -22,6 +22,7 @@
     import { iframeListener } from "../Api/IframeListener";
     import { desktopApi } from "../Api/Desktop";
     import { canvasSize, coWebsiteManager, coWebsites, fullScreenCowebsite } from "../Stores/CoWebsiteStore";
+    import { urlManager } from "../Url/UrlManager";
     import GameOverlay from "./GameOverlay.svelte";
     import CoWebsitesContainer from "./EmbedScreens/CoWebsitesContainer.svelte";
 
@@ -82,11 +83,16 @@
 
         // the ?phaserMode=canvas parameter can be used to force Canvas usage
         const params = new URLSearchParams(document.location.search.substring(1));
-        const phaserMode = params.get("phaserMode");
+        let phaserMode: string | null | undefined = params.get("phaserMode");
+
+        if (phaserMode === null) {
+            phaserMode = urlManager.getHashParameter("phaserMode");
+        }
+
         let mode: number;
         switch (phaserMode) {
             case "auto":
-            case null:
+            case undefined:
                 mode = Phaser.AUTO;
                 break;
             case "canvas":


### PR DESCRIPTION
While migrating to the new design, we lost the ability to configure the renderer via the `#phaserMode=` hash parameter. This commit adds the feature back.

Close https://github.com/workadventure/workadventure/issues/4801