### PR TITLE
Fix actions menu override by chat

### DIFF
--- a/play/src/front/Components/ActionsMenu/ActionsMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/ActionsMenu.svelte
@@ -61,7 +61,7 @@
 
 {#if actionsMenuData}
     <div
-        class="absolute left-0 right-0 m-auto max-w-md z-50 bg-contrast/80 transition-all backdrop-blur rounded-lg pointer-events-auto overflow-hidden top-1/2 -translate-y-1/2"
+        class="absolute max-w-md z-50 bg-contrast/80 transition-all backdrop-blur rounded-lg pointer-events-auto overflow-hidden top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2"
         data-testid="actions-menu"
     >
         {#if actionsMenuData.menuName}
@@ -91,7 +91,7 @@
 
         {#if sortedActions}
             <div
-                class="flex items-center bg-contrast px-2"
+                class="flex items-center bg-contrast p-2"
                 class:margin-close={!actionsMenuData.menuName}
                 class:flex-col={buttonsLayout === "column"}
                 class:flex-row={buttonsLayout === "row"}
@@ -99,7 +99,7 @@
                 {#each sortedActions ?? [] as action (action.uuid)}
                     <button
                         type="button"
-                        class="btn btn-light btn-ghost text-nowrap justify-center m-2 w-full {action.style ?? ''}"
+                        class="btn btn-light btn-ghost text-nowrap justify-center w-full {action.style ?? ''}"
                         class:mx-2={buttonsLayout === "column"}
                         on:click={() => analyticsClient.clickPropertyMapEditor(action.actionName, action.style)}
                         on:click|preventDefault={() => {

--- a/play/src/front/Components/MainLayout.svelte
+++ b/play/src/front/Components/MainLayout.svelte
@@ -229,11 +229,10 @@
             <!--<ActionBar />-->
         </div>
         <ActionBar />
+        {#if $actionsMenuStore}
+            <ActionsMenu />
+        {/if}
     </div>
-
-    {#if $actionsMenuStore}
-        <ActionsMenu />
-    {/if}
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
Center Action menu in canva even if large chat is open

# ✨
![image](https://github.com/user-attachments/assets/f91e3c9e-00ff-4d7c-811f-c7e79e7f5c36)
