### PR TITLE
Disable user list if Matrix not loaded yet

### DIFF
--- a/play/src/front/Components/ActionBar/MenuIcons/UserListMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/UserListMenuItem.svelte
@@ -5,6 +5,7 @@
     import LL from "../../../../i18n/i18n-svelte";
     import { activeSubMenuStore, menuVisiblilityStore } from "../../../Stores/MenuStore";
     import { chatVisibilityStore } from "../../../Stores/ChatStore";
+    import { gameManager } from "../../../Phaser/Game/GameManager";
 
     export let state: "normal" | "active" | "forbidden" | "disabled" = "normal";
 
@@ -16,6 +17,16 @@
         chatVisibilityStore.set(!$chatVisibilityStore);
         navChat.switchToUserList();
     }
+
+    let chatAvailable = false;
+    gameManager
+        .getChatConnection()
+        .then(() => {
+            chatAvailable = true;
+        })
+        .catch((e: unknown) => {
+            console.error("Could not get chat", e);
+        });
 </script>
 
 <ActionBarButton
@@ -23,7 +34,7 @@
     classList="group/btn-users hidden @sm/actions:flex"
     tooltipTitle={$LL.actionbar.help.users.title()}
     desc={$LL.actionbar.help.users.desc()}
-    {state}
+    state={chatAvailable ? state : "disabled"}
     dataTestId="user-list-button"
     disabledHelp={false}
     media="./static/Videos/UserList.mp4"


### PR DESCRIPTION
When Matrix is not yet loaded, let's make the user list not available. Otherwise, we will display a user list that is partial.