### PR TITLE
Upgrading default resize of cameras container

### DIFF
--- a/play/src/front/Components/EmbedScreens/Layouts/PresentationLayout.svelte
+++ b/play/src/front/Components/EmbedScreens/Layouts/PresentationLayout.svelte
@@ -6,7 +6,7 @@
     import MediaBox from "../../Video/MediaBox.svelte";
     import { inExternalServiceStore, proximityMeetingStore } from "../../../Stores/MyMediaStore";
     import { streamableCollectionStore } from "../../../Stores/StreamableCollectionStore";
-    import { highlightFullScreen, setHeightScreenShare } from "../../../Stores/ActionsCamStore";
+    import { highlightFullScreen } from "../../../Stores/ActionsCamStore";
     import { isOnOneLine } from "../../../Stores/VideoLayoutStore";
     import PictureInPictureActionBar from "../../ActionBar/PictureInPictureActionBar.svelte";
     import { activePictureInPictureStore } from "../../../Stores/PeerStore";
@@ -52,7 +52,6 @@
         if (availableHeight < 0) {
             availableHeight = 0;
         }
-        setHeightScreenShare.set(availableHeight);
     }
 
     $: if ($highlightedEmbedScreen) modifySizeCamIfScreenShare();

--- a/play/src/front/Connection/LocalUserStore.ts
+++ b/play/src/front/Connection/LocalUserStore.ts
@@ -679,7 +679,7 @@ class LocalUserStore {
     getCameraContainerHeight(): number {
         const value = localStorage.getItem(cameraContainerHeightKey);
         if (!value) {
-            return 0.75; // Default value of 75%
+            return 0.2; // Default value of 20%
         }
         return parseFloat(value);
     }

--- a/play/src/front/Stores/ActionsCamStore.ts
+++ b/play/src/front/Stores/ActionsCamStore.ts
@@ -7,4 +7,3 @@ export const rightMode = writable(false);
 export const focusMode = writable(false);
 export const hideMode = writable(false);
 export const highlightFullScreen = writable(false);
-export const setHeightScreenShare = writable(0);


### PR DESCRIPTION
Setting default size to 20% which is the default size of the one line. This way, there is not unexpected resize.Upgrading default resize of cameras container

Setting default size to 20% which is the default size of the one line. This way, there is not unexpected resize by default. The size is anyway stored in LocalStorage. In case the user resizes the view, the new size will be saved.