### PR TITLE
Increasing OpenID timeout to 50 seconds

### DIFF
--- a/play/src/pusher/services/OpenIDClient.ts
+++ b/play/src/pusher/services/OpenIDClient.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import type { Client, IntrospectionResponse, OpenIDCallbackChecks } from "openid-client";
-import { Issuer, generators } from "openid-client";
+import { Issuer, generators, custom } from "openid-client";
 import { v4 } from "uuid";
 import type { Request, Response } from "express";
 import {
@@ -15,6 +15,10 @@ import {
     SECRET_KEY,
     OPID_TAGS_CLAIM,
 } from "../enums/EnvironmentVariable";
+
+custom.setHttpOptionsDefaults({
+    timeout: 50000,
+});
 
 class OpenIDClient {
     private issuerPromise: Promise<Client> | null = null;


### PR DESCRIPTION
The openid-client v5 version we use has a default timeout of 3.5 seconds.
This can be a bit low for some environments.

This PR increases the timeout to 50 seconds which should be more than enough for everyone.