### PR TITLE
Fixing a rare race-condition when removing woka

### DIFF
--- a/play/src/front/Phaser/Components/TalkIcon.ts
+++ b/play/src/front/Phaser/Components/TalkIcon.ts
@@ -28,6 +28,10 @@ export class TalkIcon extends Phaser.GameObjects.Image {
     }
 
     private showAnimation(show = true, forceClose = false) {
+        if (!this.scene) {
+            // In case the TalkIcon is destroyed because the underlying character was destroyed.
+            return;
+        }
         if (forceClose && !show) {
             this.showAnimationTween?.stop();
         } else if (this.showAnimationTween?.isPlaying()) {


### PR DESCRIPTION
If the speech bubble is triggered after the user is removed, this would crash Phaser because this.scene is not defined anymore.