### PR TITLE
Fixing map-storage upload and delete for S3-compatible systems

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -266,6 +266,8 @@ services:
       ENABLE_BASIC_AUTHENTICATION: "true"
       AUTHENTICATION_USER: "john.doe"
       AUTHENTICATION_PASSWORD: "password"
+      ENABLE_BEARER_AUTHENTICATION: "true"
+      AUTHENTICATION_TOKEN: "123"
       API_URL: back:50051
       # Sentry integration
       SENTRY_DSN: $SENTRY_DSN_MAPSTORAGE

--- a/map-storage/package.json
+++ b/map-storage/package.json
@@ -47,7 +47,7 @@
     "front:test:unit": "vitest"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.810.0",
+    "@aws-sdk/client-s3": "^3.817.0",
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.8",
     "@sentry/node": "^7.48.0",

--- a/map-storage/src/Services/S3Client.ts
+++ b/map-storage/src/Services/S3Client.ts
@@ -8,6 +8,7 @@ import {
     AWS_URL,
     S3_UPLOAD_CONCURRENCY_LIMIT,
 } from "../Enum/EnvironmentVariable";
+import { createS3ClientWithMD5 } from "../Upload/S3ClientWithMD5";
 
 let s3: S3 | undefined;
 
@@ -24,9 +25,10 @@ export function getS3Client(): S3 {
     if (AWS_URL) {
         config.endpoint = AWS_URL;
         config.forcePathStyle = true;
+        return (s3 = createS3ClientWithMD5(config));
+    } else {
+        return (s3 = new S3(config));
     }
-
-    return (s3 = new S3(config));
 }
 
 export function hasS3Bucket(): boolean {

--- a/map-storage/src/Upload/S3ClientWithMD5.ts
+++ b/map-storage/src/Upload/S3ClientWithMD5.ts
@@ -1,0 +1,62 @@
+/**
+ * This is a workaround for S3 compatible providers that do not support the new checksum algorithms by AWS yet.
+ *
+ * See https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/MD5_FALLBACK.md
+ * This is because the AWS SDK for JavaScript v3 uses CRC32 checksums by default, but this doesn't work
+ * with other providers like old minio, Oracle S3..., that still requires MD5 checksums.
+ */
+
+import { createHash } from "crypto";
+import { S3 } from "@aws-sdk/client-s3";
+import { HttpRequest } from "@smithy/types";
+
+type Args = {
+    request: HttpRequest;
+};
+
+/**
+ * Creates an S3 client that uses MD5 checksums for DeleteObjects operations
+ */
+export function createS3ClientWithMD5(configuration = {}) {
+    const client = new S3(configuration);
+
+    // Add middleware to remove any SDK-added checksums and add MD5 instead
+    // This happens at the 'build' stage, before the request is signed
+    client.middlewareStack.add(
+        (next, context) => async (args) => {
+            const typedArgs = args as Args;
+
+            // Check if this is a DeleteObjects command
+            const isDeleteObjects = context.commandName === "DeleteObjectsCommand";
+            if (!isDeleteObjects) {
+                return next(args);
+            }
+
+            const headers = typedArgs.request.headers;
+
+            // Remove any checksum headers
+            Object.keys(headers).forEach((header) => {
+                if (
+                    header.toLowerCase().startsWith("x-amz-checksum-") ||
+                    header.toLowerCase().startsWith("x-amz-sdk-checksum-")
+                ) {
+                    delete headers[header];
+                }
+            });
+
+            // Add MD5
+            if (typedArgs.request.body) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                const bodyContent = Buffer.from(typedArgs.request.body);
+                // Create a new hash instance for each request
+                headers["Content-MD5"] = createHash("md5").update(bodyContent).digest("base64");
+            }
+
+            return await next(args);
+        },
+        {
+            step: "build",
+        }
+    );
+    return client;
+}

--- a/map-storage/src/Upload/S3FileSystem.ts
+++ b/map-storage/src/Upload/S3FileSystem.ts
@@ -200,9 +200,11 @@ export class S3FileSystem implements FileSystemInterface {
                 new PutObjectCommand({
                     Bucket: this.bucketName,
                     Key: targetFilePath,
-                    Body: zipEntry.stream(),
-                    ContentType: mime.getType(targetFilePath) ?? undefined,
-                    ContentLength: zipEntry.uncompressedSize,
+                    Body: await zipEntry.buffer(),
+                    // TODO: the stream() + contentLength would be optimal, but it seems to fail with MinIO or other S3-compatible providers
+                    //Body: zipEntry.stream(),
+                    //ContentType: mime.getType(targetFilePath) ?? undefined,
+                    //ContentLength: zipEntry.uncompressedSize,
                 })
             );
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3727,7 +3727,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.810.0",
+        "@aws-sdk/client-s3": "^3.817.0",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.8",
         "@sentry/node": "^7.48.0",
@@ -4777,32 +4777,32 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.810.0.tgz",
-      "integrity": "sha512-wM8M0BrqRkbZ9fGaLmAl24CUgVmmLjiKuNTqGOHsdCIc7RV+IGv5CnGK7ciOltAttrFBxvDlhy2lg5F8gNw8Bg==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.817.0.tgz",
+      "integrity": "sha512-nZyjhlLMEXDs0ofWbpikI8tKoeKuuSgYcIb6eEZJk90Nt5HkkXn6nkWOs/kp2FdhpoGJyTILOVsDgdm7eutnLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/credential-provider-node": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/credential-provider-node": "3.817.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
         "@aws-sdk/middleware-expect-continue": "3.804.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.810.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.816.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-location-constraint": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-sdk-s3": "3.810.0",
+        "@aws-sdk/middleware-sdk-s3": "3.816.0",
         "@aws-sdk/middleware-ssec": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.816.0",
         "@aws-sdk/region-config-resolver": "3.808.0",
-        "@aws-sdk/signature-v4-multi-region": "3.810.0",
+        "@aws-sdk/signature-v4-multi-region": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-endpoints": "3.808.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.810.0",
+        "@aws-sdk/util-user-agent-node": "3.816.0",
         "@aws-sdk/xml-builder": "3.804.0",
         "@smithy/config-resolver": "^4.1.2",
         "@smithy/core": "^3.3.3",
@@ -4844,23 +4844,23 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.810.0.tgz",
-      "integrity": "sha512-Txp/3jHqkfA4BTklQEOGiZ1yTUxg+hITislfaWEzJ904vlDt4DvAljTlhfaz7pceCLA2+LhRlYZYSv7t5b0Ltw==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.817.0.tgz",
+      "integrity": "sha512-fCh5rUHmWmWDvw70NNoWpE5+BRdtNi45kDnIoeoszqVg7UKF79SlG+qYooUT52HKCgDNHqgbWaXxMOSqd2I/OQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.816.0",
         "@aws-sdk/region-config-resolver": "3.808.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-endpoints": "3.808.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.810.0",
+        "@aws-sdk/util-user-agent-node": "3.816.0",
         "@smithy/config-resolver": "^4.1.2",
         "@smithy/core": "^3.3.3",
         "@smithy/fetch-http-handler": "^5.0.2",
@@ -4893,9 +4893,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.810.0.tgz",
-      "integrity": "sha512-s2IJk+qa/15YZcv3pbdQNATDR+YdYnHf94MrAeVAWubtRLnzD8JciC+gh4LSPp7JzrWSvVOg2Ut1S+0y89xqCg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.816.0.tgz",
+      "integrity": "sha512-Lx50wjtyarzKpMFV6V+gjbSZDgsA/71iyifbClGUSiNPoIQ4OCV0KVOmAAj7mQRVvGJqUMWKVM+WzK79CjbjWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
@@ -4937,12 +4937,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.810.0.tgz",
-      "integrity": "sha512-iwHqF+KryKONfbdFk3iKhhPk4fHxh5QP5fXXR//jhYwmszaLOwc7CLCE9AxhgiMzAs+kV8nBFQZvdjFpPzVGOA==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.816.0.tgz",
+      "integrity": "sha512-wUJZwRLe+SxPxRV9AENYBLrJZRrNIo+fva7ZzejsC83iz7hdfq6Rv6B/aHEdPwG/nQC4+q7UUvcRPlomyrpsBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -4953,12 +4953,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.810.0.tgz",
-      "integrity": "sha512-SKzjLd+8ugif7yy9sOAAdnPE1vCBHQe6jKgs2AadMpCmWm34DiHz/KuulHdvURUGMIi7CvmaC8aH77twDPYbtg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.816.0.tgz",
+      "integrity": "sha512-gcWGzMQ7yRIF+ljTkR8Vzp7727UY6cmeaPrFQrvcFB8PhOqWpf7g0JsgOf5BSaP8CkkSQcTQHc0C5ZYAzUFwPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/fetch-http-handler": "^5.0.2",
         "@smithy/node-http-handler": "^4.0.4",
@@ -4974,18 +4974,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.810.0.tgz",
-      "integrity": "sha512-H2QCSnxWJ/mj8HTcyHmCmyQ5bO/+imRi4mlBIpUyKjiYKro52WD3gXlGgPIDo2q3UFIHq37kmYvS00i+qIY9tw==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.817.0.tgz",
+      "integrity": "sha512-kyEwbQyuXE+phWVzloMdkFv6qM6NOon+asMXY5W0fhDKwBz9zQLObDRWBrvQX9lmqq8BbDL1sCfZjOh82Y+RFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/credential-provider-env": "3.810.0",
-        "@aws-sdk/credential-provider-http": "3.810.0",
-        "@aws-sdk/credential-provider-process": "3.810.0",
-        "@aws-sdk/credential-provider-sso": "3.810.0",
-        "@aws-sdk/credential-provider-web-identity": "3.810.0",
-        "@aws-sdk/nested-clients": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/credential-provider-env": "3.816.0",
+        "@aws-sdk/credential-provider-http": "3.816.0",
+        "@aws-sdk/credential-provider-process": "3.816.0",
+        "@aws-sdk/credential-provider-sso": "3.817.0",
+        "@aws-sdk/credential-provider-web-identity": "3.817.0",
+        "@aws-sdk/nested-clients": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/credential-provider-imds": "^4.0.4",
         "@smithy/property-provider": "^4.0.2",
@@ -4998,17 +4998,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.810.0.tgz",
-      "integrity": "sha512-9E3Chv3x+RBM3N1bwLCyvXxoiPAckCI74wG7ePN4F3b/7ieIkbEl/3Hd67j1fnt62Xa1cjUHRu2tz5pdEv5G1Q==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.817.0.tgz",
+      "integrity": "sha512-b5mz7av0Lhavs1Bz3Zb+jrs0Pki93+8XNctnVO0drBW98x1fM4AR38cWvGbM/w9F9Q0/WEH3TinkmrMPrP4T/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.810.0",
-        "@aws-sdk/credential-provider-http": "3.810.0",
-        "@aws-sdk/credential-provider-ini": "3.810.0",
-        "@aws-sdk/credential-provider-process": "3.810.0",
-        "@aws-sdk/credential-provider-sso": "3.810.0",
-        "@aws-sdk/credential-provider-web-identity": "3.810.0",
+        "@aws-sdk/credential-provider-env": "3.816.0",
+        "@aws-sdk/credential-provider-http": "3.816.0",
+        "@aws-sdk/credential-provider-ini": "3.817.0",
+        "@aws-sdk/credential-provider-process": "3.816.0",
+        "@aws-sdk/credential-provider-sso": "3.817.0",
+        "@aws-sdk/credential-provider-web-identity": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/credential-provider-imds": "^4.0.4",
         "@smithy/property-provider": "^4.0.2",
@@ -5021,12 +5021,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.810.0.tgz",
-      "integrity": "sha512-42kE6MLdsmMGp1id3Gisal4MbMiF7PIc0tAznTeIuE8r7cIF8yeQWw/PBOIvjyI57DxbyKzLUAMEJuigUpApCw==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.816.0.tgz",
+      "integrity": "sha512-9Tm+AxMoV2Izvl5b9tyMQRbBwaex8JP06HN7ZeCXgC5sAsSN+o8dsThnEhf8jKN+uBpT6CLWKN1TXuUMrAmW1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -5038,14 +5038,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.810.0.tgz",
-      "integrity": "sha512-8WjX6tz+FCvM93Y33gsr13p/HiiTJmVn5AK1O8PTkvHBclQDzmtAW5FdPqTpAJGswLW2FB0xRqdsSMN2dQEjNw==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.817.0.tgz",
+      "integrity": "sha512-gFUAW3VmGvdnueK1bh6TOcRX+j99Xm0men1+gz3cA4RE+rZGNy1Qjj8YHlv0hPwI9OnTPZquvPzA5fkviGREWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.810.0",
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/token-providers": "3.810.0",
+        "@aws-sdk/client-sso": "3.817.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/token-providers": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -5057,13 +5057,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.810.0.tgz",
-      "integrity": "sha512-uKQJY0AcPyrvMmfGLo36semgjqJ4vmLTqOSW9u40qQDspRnG73/P09lAO2ntqKlhwvMBt3XfcNnOpyyhKRcOfA==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.817.0.tgz",
+      "integrity": "sha512-A2kgkS9g6NY0OMT2f2EdXHpL17Ym81NhbGnQ8bRXPqESIi7TFypFD2U6osB2VnsFv+MhwM+Ke4PKXSmLun22/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/nested-clients": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/nested-clients": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -5107,15 +5107,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.810.0.tgz",
-      "integrity": "sha512-lF5fse+26hluElOtDZMsi5EH50G13OEqglFgpSc6xWnqNhbDc+CnPQRMwTVlOJBDR1/YVbJ15LOKf4pkat46Eg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.816.0.tgz",
+      "integrity": "sha512-kftcwDxB/VoCBsUiRgkm5CIuKbTfCN1WLPbis9LRwX3kQhKgGVxG2gG78SHk4TBB0qviWVAd/t+i/KaUgwiAcA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/is-array-buffer": "^4.0.0",
         "@smithy/node-config-provider": "^4.1.1",
@@ -5189,12 +5189,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.810.0.tgz",
-      "integrity": "sha512-CmQHPVopJYDiGQOmqn5AcmhksQ9qNETF0VgU251Q4tsP9s3R9nBR1r2bZwLt5+dCtf9UCa7cBw4jXKHtH38JTg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.816.0.tgz",
+      "integrity": "sha512-jJ+EAXM7gnOwiCM6rrl4AUNY5urmtIsX7roTkxtb4DevJxcS+wFYRRg3/j33fQbuxQZrvk21HqxyZYx5UH70PA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-arn-parser": "3.804.0",
         "@smithy/core": "^3.3.3",
@@ -5228,12 +5228,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.810.0.tgz",
-      "integrity": "sha512-gLMJcqgIq7k9skX8u0Yyi+jil4elbsmLf3TuDuqNdlqiZ44/AKdDFfU3mU5tRUtMfP42a3gvb2U3elP0BIeybQ==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.816.0.tgz",
+      "integrity": "sha512-bHRSlWZ0xDsFR8E2FwDb//0Ff6wMkVx4O+UKsfyNlAbtqCiiHRt5ANNfKPafr95cN2CCxLxiPvFTFVblQM5TsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-endpoints": "3.808.0",
         "@smithy/core": "^3.3.3",
@@ -5246,23 +5246,23 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.810.0.tgz",
-      "integrity": "sha512-w+tGXFSQjzvJ3j2sQ4GJRdD+YXLTgwLd9eG/A+7pjrv2yLLV70M4HqRrFqH06JBjqT5rsOxonc/QSjROyxk+IA==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.817.0.tgz",
+      "integrity": "sha512-vQ2E06A48STJFssueJQgxYD8lh1iGJoLJnHdshRDWOQb8gy1wVQR+a7MkPGhGR6lGoS0SCnF/Qp6CZhnwLsqsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.816.0",
         "@aws-sdk/region-config-resolver": "3.808.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-endpoints": "3.808.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.810.0",
+        "@aws-sdk/util-user-agent-node": "3.816.0",
         "@smithy/config-resolver": "^4.1.2",
         "@smithy/core": "^3.3.3",
         "@smithy/fetch-http-handler": "^5.0.2",
@@ -5312,12 +5312,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.810.0.tgz",
-      "integrity": "sha512-6F6evHRrA0OG/H67YuZBcI7EH4A0O5dIhczo2N0AK9z495uSIv+0xUrSrDhFTZxZjo6gkADIXroRjP1kwqK6ew==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.816.0.tgz",
+      "integrity": "sha512-idcr9NW86sSIXASSej3423Selu6fxlhhJJtMgpAqoCH/HJh1eQrONJwNKuI9huiruPE8+02pwxuePvLW46X2mw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.810.0",
+        "@aws-sdk/middleware-sdk-s3": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/signature-v4": "^5.1.0",
@@ -5329,12 +5329,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.810.0.tgz",
-      "integrity": "sha512-fdgHRCDpnzsD+0km7zuRbHRysJECfS8o9T9/pZ6XAr1z2FNV/UveHtnUYq0j6XpDMrIm0/suvXbshIjQU+a+sw==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.817.0.tgz",
+      "integrity": "sha512-CYN4/UO0VaqyHf46ogZzNrVX7jI3/CfiuktwKlwtpKA6hjf2+ivfgHSKzPpgPBcSEfiibA/26EeLuMnB6cpSrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/nested-clients": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/nested-clients": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -5410,12 +5411,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.810.0.tgz",
-      "integrity": "sha512-T56/ANEGNuvhqVoWZdr+0ZY2hjV93cH2OfGHIlVTVSAMACWG54XehDPESEso1CJNhJGYZPsE+FE42HGCk/XDMg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.816.0.tgz",
+      "integrity": "sha512-Q6dxmuj4hL7pudhrneWEQ7yVHIQRBFr0wqKLF1opwOi1cIePuoEbPyJ2jkel6PDEv1YMfvsAKaRshp6eNA8VHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/node-config-provider": "^4.1.1",
         "@smithy/types": "^4.2.0",
@@ -9233,12 +9234,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
-      "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.3.tgz",
+      "integrity": "sha512-AqXFf6DXnuRBXy4SoK/n1mfgHaKaq36bmkphmD1KO0nHq6xK/g9KHSW4HEsPQUBCGdIEfuJifGHwxFXPIFay9Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9271,15 +9272,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.2.tgz",
-      "integrity": "sha512-7r6mZGwb5LmLJ+zPtkLoznf2EtwEuSWdtid10pjGl/7HefCE4mueOkrfki8JCUm99W6UfP47/r3tbxx9CfBN5A==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.3.tgz",
+      "integrity": "sha512-N5e7ofiyYDmHxnPnqF8L4KtsbSDwyxFRfDK9bp1d9OyPO4ytRLd0/XxCqi5xVaaqB65v4woW8uey6jND6zxzxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/types": "^4.2.0",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9287,17 +9288,17 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.3.3.tgz",
-      "integrity": "sha512-CiJNc0b/WdnttAfQ6uMkxPQ3Z8hG/ba8wF89x9KtBBLDdZk6CX52K4F8hbe94uNbc8LDUuZFtbqfdhM3T21naw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-dDYISQo7k0Ml/rXlFIjkTmTcQze/LxhtIRAEmZ6HJ/EI0inVxVEVnrUXJ7jPx6ZP0GHUhFm40iQcCgS5apXIXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.5",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/middleware-serde": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.3",
+        "@smithy/util-stream": "^4.2.1",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -9306,15 +9307,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.4.tgz",
-      "integrity": "sha512-jN6M6zaGVyB8FmNGG+xOPQB4N89M1x97MMdMnm1ESjljLS3Qju/IegQizKujaNcy2vXAvrz0en8bobe6E55FEA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.5.tgz",
+      "integrity": "sha512-saEAGwrIlkb9XxX/m5S5hOtzjoJPEK6Qw2f9pYTbIsMPOFyGSXBBTw95WbOyru8A1vIS2jVCCU1Qhz50QWG3IA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/property-provider": "^4.0.3",
+        "@smithy/types": "^4.3.0",
+        "@smithy/url-parser": "^4.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9392,14 +9393,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
-      "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.3.tgz",
+      "integrity": "sha512-yBZwavI31roqTndNI7ONHqesfH01JmjJK6L3uUpZAhyAmr86LN5QiPzfyZGIxQmed8VEK2NRSQT3/JX5V1njfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/querystring-builder": "^4.0.3",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -9423,12 +9424,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
-      "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.3.tgz",
+      "integrity": "sha512-W5Uhy6v/aYrgtjh9y0YP332gIQcwccQ+EcfWhllL0B9rPae42JngTTUpb8W6wuxaNFzqps4xq5klHckSSOy5fw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -9452,12 +9453,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
-      "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.3.tgz",
+      "integrity": "sha512-1Bo8Ur1ZGqxvwTqBmv6DZEn0rXtwJGeqiiO2/JFcCtz3nBakOqeXbJBElXJMMzd0ghe8+eB6Dkw98nMYctgizg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9491,13 +9492,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
-      "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.3.tgz",
+      "integrity": "sha512-NE/Zph4BP5u16bzYq2csq9qD0T6UBLeg4AuNrwNJ7Gv9uLYaGEgelZUOdRndGdMGcUfSGvNlXGb2aA2hPCwJ6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9505,18 +9506,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.6.tgz",
-      "integrity": "sha512-Zdieg07c3ua3ap5ungdcyNnY1OsxmsXXtKDTk28+/YbwIPju0Z1ZX9X5AnkjmDE3+AbqgvhtC/ZuCMSr6VSfPw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.7.tgz",
+      "integrity": "sha512-KDzM7Iajo6K7eIWNNtukykRT4eWwlHjCEsULZUaSfi/SRSBK8BPRqG5FsVfp58lUxcvre8GT8AIPIqndA0ERKw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.3.3",
-        "@smithy/middleware-serde": "^4.0.5",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/core": "^3.4.0",
+        "@smithy/middleware-serde": "^4.0.6",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/shared-ini-file-loader": "^4.0.3",
+        "@smithy/types": "^4.3.0",
+        "@smithy/url-parser": "^4.0.3",
+        "@smithy/util-middleware": "^4.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9524,18 +9525,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.7.tgz",
-      "integrity": "sha512-lFIFUJ0E/4I0UaIDY5usNUzNKAghhxO0lDH4TZktXMmE+e4ActD9F154Si0Unc01aCPzcwd+NcOwQw6AfXXRRQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.8.tgz",
+      "integrity": "sha512-e2OtQgFzzlSG0uCjcJmi02QuFSRTrpT11Eh2EcqqDFy7DYriteHZJkkf+4AsxsrGDugAtPFcWBz1aq06sSX5fQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/service-error-classification": "^4.0.3",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/service-error-classification": "^4.0.4",
+        "@smithy/smithy-client": "^4.3.0",
+        "@smithy/types": "^4.3.0",
+        "@smithy/util-middleware": "^4.0.3",
+        "@smithy/util-retry": "^4.0.4",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -9544,13 +9545,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.5.tgz",
-      "integrity": "sha512-yREC3q/HXqQigq29xX3hiy6tFi+kjPKXoYUQmwQdgPORLbQ0n6V2Z/Iw9Nnlu66da9fM/WhDtGvYvqwecrCljQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.6.tgz",
+      "integrity": "sha512-YECyl7uNII+jCr/9qEmCu8xYL79cU0fqjo0qxpcVIU18dAPHam/iYwcknAu4Jiyw1uN+sAx7/SMf/Kmef/Jjsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9558,12 +9559,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
-      "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.3.tgz",
+      "integrity": "sha512-baeV7t4jQfQtFxBADFmnhmqBmqR38dNU5cvEgHcMK/Kp3D3bEI0CouoX2Sr/rGuntR+Eg0IjXdxnGGTc6SbIkw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9571,14 +9572,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.1.tgz",
-      "integrity": "sha512-1slS5jf5icHETwl5hxEVBj+mh6B+LbVW4yRINsGtUKH+nxM5Pw2H59+qf+JqYFCHp9jssG4vX81f5WKnjMN3Vw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.2.tgz",
+      "integrity": "sha512-SUvNup8iU1v7fmM8XPk+27m36udmGCfSz+VZP5Gb0aJ3Ne0X28K/25gnsrg3X1rWlhcnhzNUUysKW/Ied46ivQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/property-provider": "^4.0.3",
+        "@smithy/shared-ini-file-loader": "^4.0.3",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9586,15 +9587,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
-      "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.5.tgz",
+      "integrity": "sha512-T7QglZC1vS7SPT44/1qSIAQEx5bFKb3LfO6zw/o4Xzt1eC5HNoH1TkS4lMYA9cWFbacUhx4hRl/blLun4EOCkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/abort-controller": "^4.0.3",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/querystring-builder": "^4.0.3",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9602,12 +9603,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
-      "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.3.tgz",
+      "integrity": "sha512-Wcn17QNdawJZcZZPBuMuzyBENVi1AXl4TdE0jvzo4vWX2x5df/oMlmr/9M5XAAC6+yae4kWZlOYIsNsgDrMU9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9615,12 +9616,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
-      "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.1.tgz",
+      "integrity": "sha512-Vsay2mzq05DwNi9jK01yCFtfvu9HimmgC7a4HTs7lhX12Sx8aWsH0mfz6q/02yspSp+lOB+Q2HJwi4IV2GKz7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9628,12 +9629,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
-      "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.3.tgz",
+      "integrity": "sha512-UUzIWMVfPmDZcOutk2/r1vURZqavvQW0OHvgsyNV0cKupChvqg+/NKPRMaMEe+i8tP96IthMFeZOZWpV+E4RAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-uri-escape": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -9642,12 +9643,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
-      "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.3.tgz",
+      "integrity": "sha512-K5M4ZJQpFCblOJ5Oyw7diICpFg1qhhR47m2/5Ef1PhGE19RaIZf50tjYFrxa6usqcuXyTiFPGo4d1geZdH4YcQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9655,24 +9656,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.3.tgz",
-      "integrity": "sha512-FTbcajmltovWMjj3tksDQdD23b2w6gH+A0DYA1Yz3iSpjDj8fmkwy62UnXcWMy4d5YoMoSyLFHMfkEVEzbiN8Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.4.tgz",
+      "integrity": "sha512-W5ScbQ1bTzgH91kNEE2CvOzM4gXlDOqdow4m8vMFSIXCel2scbHwjflpVNnC60Y3F1m5i7w2gQg9lSnR+JsJAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0"
+        "@smithy/types": "^4.3.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
-      "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.3.tgz",
+      "integrity": "sha512-vHwlrqhZGIoLwaH8vvIjpHnloShqdJ7SUPNM2EQtEox+yEDFTVQ7E+DLZ+6OhnYEgFUwPByJyz6UZaOu2tny6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9680,16 +9681,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.0.tgz",
-      "integrity": "sha512-4t5WX60sL3zGJF/CtZsUQTs3UrZEDO2P7pEaElrekbLqkWPYkgqNW1oeiNYC6xXifBnT9dVBOnNQRvOE9riU9w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.1.tgz",
+      "integrity": "sha512-zy8Repr5zvT0ja+Tf5wjV/Ba6vRrhdiDcp/ww6cvqYbSEudIkziDe3uppNRlFoCViyJXdPnLcwyZdDLA4CHzSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.3",
         "@smithy/util-uri-escape": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -9699,17 +9700,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.6.tgz",
-      "integrity": "sha512-WEqP0wQ1N/lVS4pwNK1Vk+0i6QIr66cq/xbu1dVy1tM0A0qYwAYyz0JhbquzM5pMa8s89lyDBtoGKxo7iG74GA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.3.0.tgz",
+      "integrity": "sha512-DNsRA38pN6tYHUjebmwD9e4KcgqTLldYQb2gC6K+oxXYdCTxPn6wV9+FvOa6wrU2FQEnGJoi+3GULzOTKck/tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.3.3",
-        "@smithy/middleware-endpoint": "^4.1.6",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
+        "@smithy/core": "^3.4.0",
+        "@smithy/middleware-endpoint": "^4.1.7",
+        "@smithy/middleware-stack": "^4.0.3",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
+        "@smithy/util-stream": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9717,9 +9718,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
-      "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.0.tgz",
+      "integrity": "sha512-+1iaIQHthDh9yaLhRzaoQxRk+l9xlk+JjMFxGRhNLz+m9vKOkjNeU8QuB4w3xvzHyVR/BVlp/4AXDHjoRIkfgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -9729,13 +9730,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
-      "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.3.tgz",
+      "integrity": "sha512-n5/DnosDu/tweOqUUNtUbu7eRIR4J/Wz9nL7V5kFYQQVb8VYdj7a4G5NJHCw6o21ul7CvZoJkOpdTnsQDLT0tQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/querystring-parser": "^4.0.3",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9806,14 +9807,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.14.tgz",
-      "integrity": "sha512-l7QnMX8VcDOH6n/fBRu4zqguSlOBZxFzWqp58dXFSARFBjNlmEDk5G/z4T7BMGr+rI0Pg8MkhmMUfEtHFgpy2g==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.15.tgz",
+      "integrity": "sha512-bJJ/B8owQbHAflatSq92f9OcV8858DJBQF1Y3GRjB8psLyUjbISywszYPFw16beREHO/C3I3taW4VGH+tOuwrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
+        "@smithy/property-provider": "^4.0.3",
+        "@smithy/smithy-client": "^4.3.0",
+        "@smithy/types": "^4.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -9822,17 +9823,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.14.tgz",
-      "integrity": "sha512-Ujs1gsWDo3m/T63VWBTBmHLTD2UlU6J6FEokLCEp7OZQv45jcjLHoxTwgWsi8ULpsYozvH4MTWkRP+bhwr0vDg==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.15.tgz",
+      "integrity": "sha512-8CUrEW2Ni5q+NmYkj8wsgkfqoP7l4ZquptFbq92yQE66xevc4SxqP2zH6tMtN158kgBqBDsZ+qlrRwXWOjCR8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.1.2",
-        "@smithy/credential-provider-imds": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
+        "@smithy/config-resolver": "^4.1.3",
+        "@smithy/credential-provider-imds": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/property-provider": "^4.0.3",
+        "@smithy/smithy-client": "^4.3.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9840,13 +9841,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.4.tgz",
-      "integrity": "sha512-VfFATC1bmZLV2858B/O1NpMcL32wYo8DPPhHxYxDCodDl3f3mSZ5oJheW1IF91A0EeAADz2WsakM/hGGPGNKLg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.5.tgz",
+      "integrity": "sha512-PjDpqLk24/vAl340tmtCA++Q01GRRNH9cwL9qh46NspAX9S+IQVcK+GOzPt0GLJ6KYGyn8uOgo2kvJhiThclJw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/types": "^4.2.0",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9866,12 +9867,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
-      "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.3.tgz",
+      "integrity": "sha512-iIsC6qZXxkD7V3BzTw3b1uK8RVC1M8WvwNxK1PKrH9FnxntCd30CSunXjL/8iJBE8Z0J14r2P69njwIpRG4FBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9879,13 +9880,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.3.tgz",
-      "integrity": "sha512-DPuYjZQDXmKr/sNvy9Spu8R/ESa2e22wXZzSAY6NkjOLj6spbIje/Aq8rT97iUMdDj0qHMRIe+bTxvlU74d9Ng==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.4.tgz",
+      "integrity": "sha512-Aoqr9W2jDYGrI6OxljN8VmLDQIGO4VdMAUKMf9RGqLG8hn6or+K41NEy1Y5dtum9q8F7e0obYAuKl2mt/GnpZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.3",
-        "@smithy/types": "^4.2.0",
+        "@smithy/service-error-classification": "^4.0.4",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9893,14 +9894,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
-      "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.1.tgz",
+      "integrity": "sha512-W3IR0x5DY6iVtjj5p902oNhD+Bz7vs5S+p6tppbPa509rV9BdeXZjGuRSCtVEad9FA0Mba+tNUtUmtnSI1nwUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/types": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.0.3",
+        "@smithy/node-http-handler": "^4.0.5",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-hex-encoding": "^4.0.0",
@@ -33566,31 +33567,31 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.810.0.tgz",
-      "integrity": "sha512-wM8M0BrqRkbZ9fGaLmAl24CUgVmmLjiKuNTqGOHsdCIc7RV+IGv5CnGK7ciOltAttrFBxvDlhy2lg5F8gNw8Bg==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.817.0.tgz",
+      "integrity": "sha512-nZyjhlLMEXDs0ofWbpikI8tKoeKuuSgYcIb6eEZJk90Nt5HkkXn6nkWOs/kp2FdhpoGJyTILOVsDgdm7eutnLA==",
       "requires": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/credential-provider-node": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/credential-provider-node": "3.817.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
         "@aws-sdk/middleware-expect-continue": "3.804.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.810.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.816.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-location-constraint": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-sdk-s3": "3.810.0",
+        "@aws-sdk/middleware-sdk-s3": "3.816.0",
         "@aws-sdk/middleware-ssec": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.816.0",
         "@aws-sdk/region-config-resolver": "3.808.0",
-        "@aws-sdk/signature-v4-multi-region": "3.810.0",
+        "@aws-sdk/signature-v4-multi-region": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-endpoints": "3.808.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.810.0",
+        "@aws-sdk/util-user-agent-node": "3.816.0",
         "@aws-sdk/xml-builder": "3.804.0",
         "@smithy/config-resolver": "^4.1.2",
         "@smithy/core": "^3.3.3",
@@ -33629,22 +33630,22 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.810.0.tgz",
-      "integrity": "sha512-Txp/3jHqkfA4BTklQEOGiZ1yTUxg+hITislfaWEzJ904vlDt4DvAljTlhfaz7pceCLA2+LhRlYZYSv7t5b0Ltw==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.817.0.tgz",
+      "integrity": "sha512-fCh5rUHmWmWDvw70NNoWpE5+BRdtNi45kDnIoeoszqVg7UKF79SlG+qYooUT52HKCgDNHqgbWaXxMOSqd2I/OQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.816.0",
         "@aws-sdk/region-config-resolver": "3.808.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-endpoints": "3.808.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.810.0",
+        "@aws-sdk/util-user-agent-node": "3.816.0",
         "@smithy/config-resolver": "^4.1.2",
         "@smithy/core": "^3.3.3",
         "@smithy/fetch-http-handler": "^5.0.2",
@@ -33674,9 +33675,9 @@
       }
     },
     "@aws-sdk/core": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.810.0.tgz",
-      "integrity": "sha512-s2IJk+qa/15YZcv3pbdQNATDR+YdYnHf94MrAeVAWubtRLnzD8JciC+gh4LSPp7JzrWSvVOg2Ut1S+0y89xqCg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.816.0.tgz",
+      "integrity": "sha512-Lx50wjtyarzKpMFV6V+gjbSZDgsA/71iyifbClGUSiNPoIQ4OCV0KVOmAAj7mQRVvGJqUMWKVM+WzK79CjbjWA==",
       "requires": {
         "@aws-sdk/types": "3.804.0",
         "@smithy/core": "^3.3.3",
@@ -33702,11 +33703,11 @@
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.810.0.tgz",
-      "integrity": "sha512-iwHqF+KryKONfbdFk3iKhhPk4fHxh5QP5fXXR//jhYwmszaLOwc7CLCE9AxhgiMzAs+kV8nBFQZvdjFpPzVGOA==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.816.0.tgz",
+      "integrity": "sha512-wUJZwRLe+SxPxRV9AENYBLrJZRrNIo+fva7ZzejsC83iz7hdfq6Rv6B/aHEdPwG/nQC4+q7UUvcRPlomyrpsBA==",
       "requires": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -33714,11 +33715,11 @@
       }
     },
     "@aws-sdk/credential-provider-http": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.810.0.tgz",
-      "integrity": "sha512-SKzjLd+8ugif7yy9sOAAdnPE1vCBHQe6jKgs2AadMpCmWm34DiHz/KuulHdvURUGMIi7CvmaC8aH77twDPYbtg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.816.0.tgz",
+      "integrity": "sha512-gcWGzMQ7yRIF+ljTkR8Vzp7727UY6cmeaPrFQrvcFB8PhOqWpf7g0JsgOf5BSaP8CkkSQcTQHc0C5ZYAzUFwPg==",
       "requires": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/fetch-http-handler": "^5.0.2",
         "@smithy/node-http-handler": "^4.0.4",
@@ -33731,17 +33732,17 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.810.0.tgz",
-      "integrity": "sha512-H2QCSnxWJ/mj8HTcyHmCmyQ5bO/+imRi4mlBIpUyKjiYKro52WD3gXlGgPIDo2q3UFIHq37kmYvS00i+qIY9tw==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.817.0.tgz",
+      "integrity": "sha512-kyEwbQyuXE+phWVzloMdkFv6qM6NOon+asMXY5W0fhDKwBz9zQLObDRWBrvQX9lmqq8BbDL1sCfZjOh82Y+RFw==",
       "requires": {
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/credential-provider-env": "3.810.0",
-        "@aws-sdk/credential-provider-http": "3.810.0",
-        "@aws-sdk/credential-provider-process": "3.810.0",
-        "@aws-sdk/credential-provider-sso": "3.810.0",
-        "@aws-sdk/credential-provider-web-identity": "3.810.0",
-        "@aws-sdk/nested-clients": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/credential-provider-env": "3.816.0",
+        "@aws-sdk/credential-provider-http": "3.816.0",
+        "@aws-sdk/credential-provider-process": "3.816.0",
+        "@aws-sdk/credential-provider-sso": "3.817.0",
+        "@aws-sdk/credential-provider-web-identity": "3.817.0",
+        "@aws-sdk/nested-clients": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/credential-provider-imds": "^4.0.4",
         "@smithy/property-provider": "^4.0.2",
@@ -33751,16 +33752,16 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.810.0.tgz",
-      "integrity": "sha512-9E3Chv3x+RBM3N1bwLCyvXxoiPAckCI74wG7ePN4F3b/7ieIkbEl/3Hd67j1fnt62Xa1cjUHRu2tz5pdEv5G1Q==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.817.0.tgz",
+      "integrity": "sha512-b5mz7av0Lhavs1Bz3Zb+jrs0Pki93+8XNctnVO0drBW98x1fM4AR38cWvGbM/w9F9Q0/WEH3TinkmrMPrP4T/w==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.810.0",
-        "@aws-sdk/credential-provider-http": "3.810.0",
-        "@aws-sdk/credential-provider-ini": "3.810.0",
-        "@aws-sdk/credential-provider-process": "3.810.0",
-        "@aws-sdk/credential-provider-sso": "3.810.0",
-        "@aws-sdk/credential-provider-web-identity": "3.810.0",
+        "@aws-sdk/credential-provider-env": "3.816.0",
+        "@aws-sdk/credential-provider-http": "3.816.0",
+        "@aws-sdk/credential-provider-ini": "3.817.0",
+        "@aws-sdk/credential-provider-process": "3.816.0",
+        "@aws-sdk/credential-provider-sso": "3.817.0",
+        "@aws-sdk/credential-provider-web-identity": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/credential-provider-imds": "^4.0.4",
         "@smithy/property-provider": "^4.0.2",
@@ -33770,11 +33771,11 @@
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.810.0.tgz",
-      "integrity": "sha512-42kE6MLdsmMGp1id3Gisal4MbMiF7PIc0tAznTeIuE8r7cIF8yeQWw/PBOIvjyI57DxbyKzLUAMEJuigUpApCw==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.816.0.tgz",
+      "integrity": "sha512-9Tm+AxMoV2Izvl5b9tyMQRbBwaex8JP06HN7ZeCXgC5sAsSN+o8dsThnEhf8jKN+uBpT6CLWKN1TXuUMrAmW1A==",
       "requires": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -33783,13 +33784,13 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.810.0.tgz",
-      "integrity": "sha512-8WjX6tz+FCvM93Y33gsr13p/HiiTJmVn5AK1O8PTkvHBclQDzmtAW5FdPqTpAJGswLW2FB0xRqdsSMN2dQEjNw==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.817.0.tgz",
+      "integrity": "sha512-gFUAW3VmGvdnueK1bh6TOcRX+j99Xm0men1+gz3cA4RE+rZGNy1Qjj8YHlv0hPwI9OnTPZquvPzA5fkviGREWg==",
       "requires": {
-        "@aws-sdk/client-sso": "3.810.0",
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/token-providers": "3.810.0",
+        "@aws-sdk/client-sso": "3.817.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/token-providers": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -33798,12 +33799,12 @@
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.810.0.tgz",
-      "integrity": "sha512-uKQJY0AcPyrvMmfGLo36semgjqJ4vmLTqOSW9u40qQDspRnG73/P09lAO2ntqKlhwvMBt3XfcNnOpyyhKRcOfA==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.817.0.tgz",
+      "integrity": "sha512-A2kgkS9g6NY0OMT2f2EdXHpL17Ym81NhbGnQ8bRXPqESIi7TFypFD2U6osB2VnsFv+MhwM+Ke4PKXSmLun22/A==",
       "requires": {
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/nested-clients": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/nested-clients": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -33836,14 +33837,14 @@
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.810.0.tgz",
-      "integrity": "sha512-lF5fse+26hluElOtDZMsi5EH50G13OEqglFgpSc6xWnqNhbDc+CnPQRMwTVlOJBDR1/YVbJ15LOKf4pkat46Eg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.816.0.tgz",
+      "integrity": "sha512-kftcwDxB/VoCBsUiRgkm5CIuKbTfCN1WLPbis9LRwX3kQhKgGVxG2gG78SHk4TBB0qviWVAd/t+i/KaUgwiAcA==",
       "requires": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/is-array-buffer": "^4.0.0",
         "@smithy/node-config-provider": "^4.1.1",
@@ -33898,11 +33899,11 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.810.0.tgz",
-      "integrity": "sha512-CmQHPVopJYDiGQOmqn5AcmhksQ9qNETF0VgU251Q4tsP9s3R9nBR1r2bZwLt5+dCtf9UCa7cBw4jXKHtH38JTg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.816.0.tgz",
+      "integrity": "sha512-jJ+EAXM7gnOwiCM6rrl4AUNY5urmtIsX7roTkxtb4DevJxcS+wFYRRg3/j33fQbuxQZrvk21HqxyZYx5UH70PA==",
       "requires": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-arn-parser": "3.804.0",
         "@smithy/core": "^3.3.3",
@@ -33929,11 +33930,11 @@
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.810.0.tgz",
-      "integrity": "sha512-gLMJcqgIq7k9skX8u0Yyi+jil4elbsmLf3TuDuqNdlqiZ44/AKdDFfU3mU5tRUtMfP42a3gvb2U3elP0BIeybQ==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.816.0.tgz",
+      "integrity": "sha512-bHRSlWZ0xDsFR8E2FwDb//0Ff6wMkVx4O+UKsfyNlAbtqCiiHRt5ANNfKPafr95cN2CCxLxiPvFTFVblQM5TsQ==",
       "requires": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-endpoints": "3.808.0",
         "@smithy/core": "^3.3.3",
@@ -33943,22 +33944,22 @@
       }
     },
     "@aws-sdk/nested-clients": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.810.0.tgz",
-      "integrity": "sha512-w+tGXFSQjzvJ3j2sQ4GJRdD+YXLTgwLd9eG/A+7pjrv2yLLV70M4HqRrFqH06JBjqT5rsOxonc/QSjROyxk+IA==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.817.0.tgz",
+      "integrity": "sha512-vQ2E06A48STJFssueJQgxYD8lh1iGJoLJnHdshRDWOQb8gy1wVQR+a7MkPGhGR6lGoS0SCnF/Qp6CZhnwLsqsQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.816.0",
         "@aws-sdk/region-config-resolver": "3.808.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-endpoints": "3.808.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.810.0",
+        "@aws-sdk/util-user-agent-node": "3.816.0",
         "@smithy/config-resolver": "^4.1.2",
         "@smithy/core": "^3.3.3",
         "@smithy/fetch-http-handler": "^5.0.2",
@@ -34001,11 +34002,11 @@
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.810.0.tgz",
-      "integrity": "sha512-6F6evHRrA0OG/H67YuZBcI7EH4A0O5dIhczo2N0AK9z495uSIv+0xUrSrDhFTZxZjo6gkADIXroRjP1kwqK6ew==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.816.0.tgz",
+      "integrity": "sha512-idcr9NW86sSIXASSej3423Selu6fxlhhJJtMgpAqoCH/HJh1eQrONJwNKuI9huiruPE8+02pwxuePvLW46X2mw==",
       "requires": {
-        "@aws-sdk/middleware-sdk-s3": "3.810.0",
+        "@aws-sdk/middleware-sdk-s3": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/signature-v4": "^5.1.0",
@@ -34014,11 +34015,12 @@
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.810.0.tgz",
-      "integrity": "sha512-fdgHRCDpnzsD+0km7zuRbHRysJECfS8o9T9/pZ6XAr1z2FNV/UveHtnUYq0j6XpDMrIm0/suvXbshIjQU+a+sw==",
+      "version": "3.817.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.817.0.tgz",
+      "integrity": "sha512-CYN4/UO0VaqyHf46ogZzNrVX7jI3/CfiuktwKlwtpKA6hjf2+ivfgHSKzPpgPBcSEfiibA/26EeLuMnB6cpSrQ==",
       "requires": {
-        "@aws-sdk/nested-clients": "3.810.0",
+        "@aws-sdk/core": "3.816.0",
+        "@aws-sdk/nested-clients": "3.817.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -34074,11 +34076,11 @@
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.810.0.tgz",
-      "integrity": "sha512-T56/ANEGNuvhqVoWZdr+0ZY2hjV93cH2OfGHIlVTVSAMACWG54XehDPESEso1CJNhJGYZPsE+FE42HGCk/XDMg==",
+      "version": "3.816.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.816.0.tgz",
+      "integrity": "sha512-Q6dxmuj4hL7pudhrneWEQ7yVHIQRBFr0wqKLF1opwOi1cIePuoEbPyJ2jkel6PDEv1YMfvsAKaRshp6eNA8VHg==",
       "requires": {
-        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.816.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/node-config-provider": "^4.1.1",
         "@smithy/types": "^4.2.0",
@@ -36716,11 +36718,11 @@
       }
     },
     "@smithy/abort-controller": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
-      "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.3.tgz",
+      "integrity": "sha512-AqXFf6DXnuRBXy4SoK/n1mfgHaKaq36bmkphmD1KO0nHq6xK/g9KHSW4HEsPQUBCGdIEfuJifGHwxFXPIFay9Q==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
@@ -36742,41 +36744,41 @@
       }
     },
     "@smithy/config-resolver": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.2.tgz",
-      "integrity": "sha512-7r6mZGwb5LmLJ+zPtkLoznf2EtwEuSWdtid10pjGl/7HefCE4mueOkrfki8JCUm99W6UfP47/r3tbxx9CfBN5A==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.3.tgz",
+      "integrity": "sha512-N5e7ofiyYDmHxnPnqF8L4KtsbSDwyxFRfDK9bp1d9OyPO4ytRLd0/XxCqi5xVaaqB65v4woW8uey6jND6zxzxQ==",
       "requires": {
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/types": "^4.2.0",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.3",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/core": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.3.3.tgz",
-      "integrity": "sha512-CiJNc0b/WdnttAfQ6uMkxPQ3Z8hG/ba8wF89x9KtBBLDdZk6CX52K4F8hbe94uNbc8LDUuZFtbqfdhM3T21naw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-dDYISQo7k0Ml/rXlFIjkTmTcQze/LxhtIRAEmZ6HJ/EI0inVxVEVnrUXJ7jPx6ZP0GHUhFm40iQcCgS5apXIXA==",
       "requires": {
-        "@smithy/middleware-serde": "^4.0.5",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/middleware-serde": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.3",
+        "@smithy/util-stream": "^4.2.1",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.4.tgz",
-      "integrity": "sha512-jN6M6zaGVyB8FmNGG+xOPQB4N89M1x97MMdMnm1ESjljLS3Qju/IegQizKujaNcy2vXAvrz0en8bobe6E55FEA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.5.tgz",
+      "integrity": "sha512-saEAGwrIlkb9XxX/m5S5hOtzjoJPEK6Qw2f9pYTbIsMPOFyGSXBBTw95WbOyru8A1vIS2jVCCU1Qhz50QWG3IA==",
       "requires": {
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/property-provider": "^4.0.3",
+        "@smithy/types": "^4.3.0",
+        "@smithy/url-parser": "^4.0.3",
         "tslib": "^2.6.2"
       }
     },
@@ -36831,13 +36833,13 @@
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
-      "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.3.tgz",
+      "integrity": "sha512-yBZwavI31roqTndNI7ONHqesfH01JmjJK6L3uUpZAhyAmr86LN5QiPzfyZGIxQmed8VEK2NRSQT3/JX5V1njfQ==",
       "requires": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/querystring-builder": "^4.0.3",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
       }
@@ -36854,11 +36856,11 @@
       }
     },
     "@smithy/hash-node": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
-      "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.3.tgz",
+      "integrity": "sha512-W5Uhy6v/aYrgtjh9y0YP332gIQcwccQ+EcfWhllL0B9rPae42JngTTUpb8W6wuxaNFzqps4xq5klHckSSOy5fw==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -36875,11 +36877,11 @@
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
-      "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.3.tgz",
+      "integrity": "sha512-1Bo8Ur1ZGqxvwTqBmv6DZEn0rXtwJGeqiiO2/JFcCtz3nBakOqeXbJBElXJMMzd0ghe8+eB6Dkw98nMYctgizg==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
@@ -36902,186 +36904,186 @@
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
-      "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.3.tgz",
+      "integrity": "sha512-NE/Zph4BP5u16bzYq2csq9qD0T6UBLeg4AuNrwNJ7Gv9uLYaGEgelZUOdRndGdMGcUfSGvNlXGb2aA2hPCwJ6g==",
       "requires": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.6.tgz",
-      "integrity": "sha512-Zdieg07c3ua3ap5ungdcyNnY1OsxmsXXtKDTk28+/YbwIPju0Z1ZX9X5AnkjmDE3+AbqgvhtC/ZuCMSr6VSfPw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.7.tgz",
+      "integrity": "sha512-KDzM7Iajo6K7eIWNNtukykRT4eWwlHjCEsULZUaSfi/SRSBK8BPRqG5FsVfp58lUxcvre8GT8AIPIqndA0ERKw==",
       "requires": {
-        "@smithy/core": "^3.3.3",
-        "@smithy/middleware-serde": "^4.0.5",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/core": "^3.4.0",
+        "@smithy/middleware-serde": "^4.0.6",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/shared-ini-file-loader": "^4.0.3",
+        "@smithy/types": "^4.3.0",
+        "@smithy/url-parser": "^4.0.3",
+        "@smithy/util-middleware": "^4.0.3",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.7.tgz",
-      "integrity": "sha512-lFIFUJ0E/4I0UaIDY5usNUzNKAghhxO0lDH4TZktXMmE+e4ActD9F154Si0Unc01aCPzcwd+NcOwQw6AfXXRRQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.8.tgz",
+      "integrity": "sha512-e2OtQgFzzlSG0uCjcJmi02QuFSRTrpT11Eh2EcqqDFy7DYriteHZJkkf+4AsxsrGDugAtPFcWBz1aq06sSX5fQ==",
       "requires": {
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/service-error-classification": "^4.0.3",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/service-error-classification": "^4.0.4",
+        "@smithy/smithy-client": "^4.3.0",
+        "@smithy/types": "^4.3.0",
+        "@smithy/util-middleware": "^4.0.3",
+        "@smithy/util-retry": "^4.0.4",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       }
     },
     "@smithy/middleware-serde": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.5.tgz",
-      "integrity": "sha512-yREC3q/HXqQigq29xX3hiy6tFi+kjPKXoYUQmwQdgPORLbQ0n6V2Z/Iw9Nnlu66da9fM/WhDtGvYvqwecrCljQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.6.tgz",
+      "integrity": "sha512-YECyl7uNII+jCr/9qEmCu8xYL79cU0fqjo0qxpcVIU18dAPHam/iYwcknAu4Jiyw1uN+sAx7/SMf/Kmef/Jjsg==",
       "requires": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-stack": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
-      "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.3.tgz",
+      "integrity": "sha512-baeV7t4jQfQtFxBADFmnhmqBmqR38dNU5cvEgHcMK/Kp3D3bEI0CouoX2Sr/rGuntR+Eg0IjXdxnGGTc6SbIkw==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/node-config-provider": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.1.tgz",
-      "integrity": "sha512-1slS5jf5icHETwl5hxEVBj+mh6B+LbVW4yRINsGtUKH+nxM5Pw2H59+qf+JqYFCHp9jssG4vX81f5WKnjMN3Vw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.2.tgz",
+      "integrity": "sha512-SUvNup8iU1v7fmM8XPk+27m36udmGCfSz+VZP5Gb0aJ3Ne0X28K/25gnsrg3X1rWlhcnhzNUUysKW/Ied46ivQ==",
       "requires": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/property-provider": "^4.0.3",
+        "@smithy/shared-ini-file-loader": "^4.0.3",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
-      "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.5.tgz",
+      "integrity": "sha512-T7QglZC1vS7SPT44/1qSIAQEx5bFKb3LfO6zw/o4Xzt1eC5HNoH1TkS4lMYA9cWFbacUhx4hRl/blLun4EOCkg==",
       "requires": {
-        "@smithy/abort-controller": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/abort-controller": "^4.0.3",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/querystring-builder": "^4.0.3",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/property-provider": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
-      "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.3.tgz",
+      "integrity": "sha512-Wcn17QNdawJZcZZPBuMuzyBENVi1AXl4TdE0jvzo4vWX2x5df/oMlmr/9M5XAAC6+yae4kWZlOYIsNsgDrMU9A==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/protocol-http": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
-      "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.1.tgz",
+      "integrity": "sha512-Vsay2mzq05DwNi9jK01yCFtfvu9HimmgC7a4HTs7lhX12Sx8aWsH0mfz6q/02yspSp+lOB+Q2HJwi4IV2GKz7A==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/querystring-builder": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
-      "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.3.tgz",
+      "integrity": "sha512-UUzIWMVfPmDZcOutk2/r1vURZqavvQW0OHvgsyNV0cKupChvqg+/NKPRMaMEe+i8tP96IthMFeZOZWpV+E4RAw==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-uri-escape": "^4.0.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
-      "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.3.tgz",
+      "integrity": "sha512-K5M4ZJQpFCblOJ5Oyw7diICpFg1qhhR47m2/5Ef1PhGE19RaIZf50tjYFrxa6usqcuXyTiFPGo4d1geZdH4YcQ==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/service-error-classification": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.3.tgz",
-      "integrity": "sha512-FTbcajmltovWMjj3tksDQdD23b2w6gH+A0DYA1Yz3iSpjDj8fmkwy62UnXcWMy4d5YoMoSyLFHMfkEVEzbiN8Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.4.tgz",
+      "integrity": "sha512-W5ScbQ1bTzgH91kNEE2CvOzM4gXlDOqdow4m8vMFSIXCel2scbHwjflpVNnC60Y3F1m5i7w2gQg9lSnR+JsJAA==",
       "requires": {
-        "@smithy/types": "^4.2.0"
+        "@smithy/types": "^4.3.0"
       }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
-      "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.3.tgz",
+      "integrity": "sha512-vHwlrqhZGIoLwaH8vvIjpHnloShqdJ7SUPNM2EQtEox+yEDFTVQ7E+DLZ+6OhnYEgFUwPByJyz6UZaOu2tny6A==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/signature-v4": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.0.tgz",
-      "integrity": "sha512-4t5WX60sL3zGJF/CtZsUQTs3UrZEDO2P7pEaElrekbLqkWPYkgqNW1oeiNYC6xXifBnT9dVBOnNQRvOE9riU9w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.1.tgz",
+      "integrity": "sha512-zy8Repr5zvT0ja+Tf5wjV/Ba6vRrhdiDcp/ww6cvqYbSEudIkziDe3uppNRlFoCViyJXdPnLcwyZdDLA4CHzSg==",
       "requires": {
         "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.3",
         "@smithy/util-uri-escape": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/smithy-client": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.6.tgz",
-      "integrity": "sha512-WEqP0wQ1N/lVS4pwNK1Vk+0i6QIr66cq/xbu1dVy1tM0A0qYwAYyz0JhbquzM5pMa8s89lyDBtoGKxo7iG74GA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.3.0.tgz",
+      "integrity": "sha512-DNsRA38pN6tYHUjebmwD9e4KcgqTLldYQb2gC6K+oxXYdCTxPn6wV9+FvOa6wrU2FQEnGJoi+3GULzOTKck/tg==",
       "requires": {
-        "@smithy/core": "^3.3.3",
-        "@smithy/middleware-endpoint": "^4.1.6",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
+        "@smithy/core": "^3.4.0",
+        "@smithy/middleware-endpoint": "^4.1.7",
+        "@smithy/middleware-stack": "^4.0.3",
+        "@smithy/protocol-http": "^5.1.1",
+        "@smithy/types": "^4.3.0",
+        "@smithy/util-stream": "^4.2.1",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
-      "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.0.tgz",
+      "integrity": "sha512-+1iaIQHthDh9yaLhRzaoQxRk+l9xlk+JjMFxGRhNLz+m9vKOkjNeU8QuB4w3xvzHyVR/BVlp/4AXDHjoRIkfgQ==",
       "requires": {
         "tslib": "^2.6.2"
       }
     },
     "@smithy/url-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
-      "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.3.tgz",
+      "integrity": "sha512-n5/DnosDu/tweOqUUNtUbu7eRIR4J/Wz9nL7V5kFYQQVb8VYdj7a4G5NJHCw6o21ul7CvZoJkOpdTnsQDLT0tQ==",
       "requires": {
-        "@smithy/querystring-parser": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/querystring-parser": "^4.0.3",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
@@ -37129,38 +37131,38 @@
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.14.tgz",
-      "integrity": "sha512-l7QnMX8VcDOH6n/fBRu4zqguSlOBZxFzWqp58dXFSARFBjNlmEDk5G/z4T7BMGr+rI0Pg8MkhmMUfEtHFgpy2g==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.15.tgz",
+      "integrity": "sha512-bJJ/B8owQbHAflatSq92f9OcV8858DJBQF1Y3GRjB8psLyUjbISywszYPFw16beREHO/C3I3taW4VGH+tOuwrQ==",
       "requires": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
+        "@smithy/property-provider": "^4.0.3",
+        "@smithy/smithy-client": "^4.3.0",
+        "@smithy/types": "^4.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.14.tgz",
-      "integrity": "sha512-Ujs1gsWDo3m/T63VWBTBmHLTD2UlU6J6FEokLCEp7OZQv45jcjLHoxTwgWsi8ULpsYozvH4MTWkRP+bhwr0vDg==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.15.tgz",
+      "integrity": "sha512-8CUrEW2Ni5q+NmYkj8wsgkfqoP7l4ZquptFbq92yQE66xevc4SxqP2zH6tMtN158kgBqBDsZ+qlrRwXWOjCR8A==",
       "requires": {
-        "@smithy/config-resolver": "^4.1.2",
-        "@smithy/credential-provider-imds": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
+        "@smithy/config-resolver": "^4.1.3",
+        "@smithy/credential-provider-imds": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/property-provider": "^4.0.3",
+        "@smithy/smithy-client": "^4.3.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-endpoints": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.4.tgz",
-      "integrity": "sha512-VfFATC1bmZLV2858B/O1NpMcL32wYo8DPPhHxYxDCodDl3f3mSZ5oJheW1IF91A0EeAADz2WsakM/hGGPGNKLg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.5.tgz",
+      "integrity": "sha512-PjDpqLk24/vAl340tmtCA++Q01GRRNH9cwL9qh46NspAX9S+IQVcK+GOzPt0GLJ6KYGyn8uOgo2kvJhiThclJw==",
       "requires": {
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/types": "^4.2.0",
+        "@smithy/node-config-provider": "^4.1.2",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
@@ -37173,32 +37175,32 @@
       }
     },
     "@smithy/util-middleware": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
-      "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.3.tgz",
+      "integrity": "sha512-iIsC6qZXxkD7V3BzTw3b1uK8RVC1M8WvwNxK1PKrH9FnxntCd30CSunXjL/8iJBE8Z0J14r2P69njwIpRG4FBQ==",
       "requires": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-retry": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.3.tgz",
-      "integrity": "sha512-DPuYjZQDXmKr/sNvy9Spu8R/ESa2e22wXZzSAY6NkjOLj6spbIje/Aq8rT97iUMdDj0qHMRIe+bTxvlU74d9Ng==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.4.tgz",
+      "integrity": "sha512-Aoqr9W2jDYGrI6OxljN8VmLDQIGO4VdMAUKMf9RGqLG8hn6or+K41NEy1Y5dtum9q8F7e0obYAuKl2mt/GnpZg==",
       "requires": {
-        "@smithy/service-error-classification": "^4.0.3",
-        "@smithy/types": "^4.2.0",
+        "@smithy/service-error-classification": "^4.0.4",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
-      "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.1.tgz",
+      "integrity": "sha512-W3IR0x5DY6iVtjj5p902oNhD+Bz7vs5S+p6tppbPa509rV9BdeXZjGuRSCtVEad9FA0Mba+tNUtUmtnSI1nwUw==",
       "requires": {
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/types": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.0.3",
+        "@smithy/node-http-handler": "^4.0.5",
+        "@smithy/types": "^4.3.0",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-hex-encoding": "^4.0.0",
@@ -46801,7 +46803,7 @@
     "map-storage": {
       "version": "file:map-storage",
       "requires": {
-        "@aws-sdk/client-s3": "^3.810.0",
+        "@aws-sdk/client-s3": "^3.817.0",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.8",
         "@sentry/cli": "^2.17.2",


### PR DESCRIPTION
S3-compatible systems have an issue with the new AWS-SDK. The DeleteObjectCommands expects an MD5 checksum that is not passed anymore, and using streams + content-length instead of buffers causes the ZIP upload to fail.

Adding a "middleware" to fix the DeleteObjectsIssue and reverting back to loading files in a buffer before sending them over S3.