### PR TITLE
Fixing missing JWT in Jitsi

### DIFF
--- a/play/src/front/Components/Cowebsites/JistiCowebsiteComponent.svelte
+++ b/play/src/front/Components/Cowebsites/JistiCowebsiteComponent.svelte
@@ -26,7 +26,7 @@
     let domain = actualCowebsite.getDomain();
     let jitsiContainer: HTMLDivElement;
     let playerName = gameManager.getPlayerName();
-    let jwt: string | undefined;
+    let jwt: string | undefined = actualCowebsite.jwt;
     let jitsiApi: JitsiApi;
     let screenWakeRelease: (() => Promise<void>) | undefined;
     let jistiMeetLoadedPromise: CancelablePromise<void>;

--- a/play/src/front/WebRtc/CoWebsite/JitsiCoWebsite.ts
+++ b/play/src/front/WebRtc/CoWebsite/JitsiCoWebsite.ts
@@ -130,7 +130,7 @@ export class JitsiCoWebsite extends SimpleCoWebsite {
         // FIXME: unused private variables.
         public roomName: string,
         private playerName: string,
-        private jwt: string | undefined,
+        private _jwt: string | undefined,
         public readonly jitsiConfig: JitsiRoomConfigData | undefined,
         public readonly jitsiInterfaceConfig: object | undefined,
         private domain: string,
@@ -141,5 +141,9 @@ export class JitsiCoWebsite extends SimpleCoWebsite {
 
     getDomain(): string {
         return this.domain;
+    }
+
+    public get jwt(): string | undefined {
+        return this._jwt;
     }
 }


### PR DESCRIPTION
While implementing the new design, we missed re-implementing passing the JWT to Jitsi. This lead to either no moderation rights or to Jitsi asking for a login/password when connecting.

This commit fixes passing the JWT to Jitsi.