### PR TITLE
Fixing the isNaN number for viewport causing blank screen after full screening a cowebsite

### DIFF
--- a/play/src/front/Phaser/Game/CameraManager.ts
+++ b/play/src/front/Phaser/Game/CameraManager.ts
@@ -341,7 +341,7 @@ export class CameraManager extends Phaser.Events.EventEmitter {
      * (tries to put the character in the center of the remaining space if there is a discussion going on.
      */
     public updateCameraOffset(box: Box, instant = false): void {
-        if (this.cameraMode !== CameraMode.Follow) {
+        if (this.cameraMode !== CameraMode.Follow || box.xEnd === undefined || box.yEnd === undefined) {
             return;
         }
         const xCenter = (box.xEnd - box.xStart) / 2 + box.xStart;

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -74,7 +74,6 @@ import type {
     OnConnectInterface,
     PositionInterface,
     RoomJoinedMessageInterface,
-    ViewportInterface,
 } from "../../Connection/ConnexionModels";
 import type { RoomConnection } from "../../Connection/RoomConnection";
 import type { ActionableItem } from "../Items/ActionableItem";
@@ -1310,14 +1309,12 @@ export class GameScene extends DirtyScene {
         if (!camera) {
             return;
         }
-        this.connection?.setViewport(
-            this.validateViewport({
-                left: Math.max(0, camera.scrollX - margin),
-                top: Math.max(0, camera.scrollY - margin),
-                right: camera.scrollX + camera.width + margin,
-                bottom: camera.scrollY + camera.height + margin,
-            })
-        );
+        this.connection?.setViewport({
+            left: Math.max(0, camera.scrollX - margin),
+            top: Math.max(0, camera.scrollY - margin),
+            right: camera.scrollX + camera.width + margin,
+            bottom: camera.scrollY + camera.height + margin,
+        });
     }
 
     public reposition(instant = false): void {
@@ -3550,25 +3547,6 @@ ${escapedMessage}
         // Otherwise, do nothing.
     }
 
-    // We need to store the last valid viewport because in rare circumstances, Phaser can return an invalid camera.
-    private lastValidViewport: ViewportInterface = {
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 100,
-    };
-    private validateViewport(viewport: ViewportInterface): ViewportInterface {
-        if (isNaN(viewport.left) || isNaN(viewport.top) || isNaN(viewport.right) || isNaN(viewport.bottom)) {
-            // If the viewport is invalid, we need to use the last valid one.
-            // This can happen when the camera is not yet initialized.
-            return this.lastValidViewport;
-        } else {
-            // If the viewport is valid, we need to store it for later use.
-            this.lastValidViewport = viewport;
-        }
-        return viewport;
-    }
-
     private doPushPlayerPosition(event: HasPlayerMovedInterface): void {
         this.lastMoveEventSent = event;
         this.lastSentTick = this.currentTick;
@@ -3579,7 +3557,6 @@ ${escapedMessage}
             right: camera.scrollX + camera.width,
             bottom: camera.scrollY + camera.height,
         };
-        viewport = this.validateViewport(viewport);
         if (!this.scene.scene.renderer) {
             // In the very special case where we have no renderer, the viewport will not move along the Woka.
             // We need to adjust it manually. We set it to something very large to make sure the Woka sees

--- a/play/src/front/Stores/CoWebsiteStore.ts
+++ b/play/src/front/Stores/CoWebsiteStore.ts
@@ -81,10 +81,16 @@ export const windowSize = readable({ width: window.innerWidth, height: window.in
 export const coWebsiteRatio = writable(0.5);
 
 export const canvasSize = derived(
-    [coWebsites, windowSize, coWebsiteRatio],
-    ([$coWebsites, $windowSize, $coWebsiteRatio]) => {
+    [coWebsites, windowSize, coWebsiteRatio, fullScreenCowebsite],
+    ([$coWebsites, $windowSize, $coWebsiteRatio, $fullScreenCowebsite]) => {
         if ($coWebsites.length === 0) {
             return { width: window.innerWidth, height: window.innerHeight };
+        }
+        if ($fullScreenCowebsite) {
+            return {
+                width: 0,
+                height: 0,
+            };
         }
         if ($windowSize.width <= $windowSize.height) {
             return {


### PR DESCRIPTION
When resizing the window, if the canvas width is 0, the camera gets a NaN scroll offset.
We fix here the issue by checking we never set a NaN offset to the camera.