### PR TITLE
Properly encoding the room name in the websocket connection

### DIFF
--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -292,7 +292,7 @@ export class RoomConnection implements RoomConnection {
         }
         url += "&version=" + apiVersionHash;
         url += "&chatID=" + (localUserStore.getChatId() ?? "");
-        url += "&roomName=" + (gameManager.currentStartedRoom.roomName ?? "");
+        url += "&roomName=" + encodeURIComponent(gameManager.currentStartedRoom.roomName ?? "");
 
         if (RoomConnection.websocketFactory) {
             this.socket = RoomConnection.websocketFactory(url);


### PR DESCRIPTION
I think this is the root cause of a nasty issue triggering reconnection to the websocket randomly. Probably due to the fact there is a space in the room name and if the request is large enough, it might be broken on 2 packets leading the web server to believe the content after the space is the HTTP version.