### PR TITLE
Update node version for back

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,5 +1,5 @@
 # protobuf build
-FROM --platform=$BUILDPLATFORM node:20.8-bullseye-slim AS proto-builder
+FROM --platform=$BUILDPLATFORM node:22.8-bullseye-slim AS proto-builder
 WORKDIR /usr/src
 COPY messages/package-lock.json messages/package.json ./
 RUN npm ci

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -202,7 +202,7 @@ services:
       - "traefik.http.services.maps.loadbalancer.server.port=80"
 
   back:
-    image: thecodingmachine/nodejs:v2-20-bullseye
+    image: thecodingmachine/nodejs:v2-22-bullseye
     command: npm run dev
     working_dir: /usr/src/app/back
     environment:


### PR DESCRIPTION
This pull request updates the Node.js version used in the project to ensure compatibility with newer features and maintain security compliance. The changes affect the Dockerfile and the `docker-compose.yaml` configuration.

### Node.js version upgrade:

* [`back/Dockerfile`](diffhunk://#diff-58c8fd8336c9e74774f45b50482daa3e748c0b06e61fbd3e3d3b33e7e43593e7L2-R2): Updated the Node.js version from `20.8-bullseye-slim` to `22.8-bullseye-slim` in the `proto-builder` stage.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L205-R205): Updated the Node.js base image for the `back` service from `v2-20-bullseye` to `v2-22-bullseye`.