### PR TITLE
Fixing mime-type when uploading ZIP

### DIFF
--- a/map-storage/src/Upload/S3FileSystem.ts
+++ b/map-storage/src/Upload/S3FileSystem.ts
@@ -204,7 +204,7 @@ export class S3FileSystem implements FileSystemInterface {
                     Body: await zipEntry.buffer(),
                     // TODO: the stream() + contentLength would be optimal, but it seems to fail with MinIO or other S3-compatible providers
                     //Body: zipEntry.stream(),
-                    //ContentType: mime.getType(targetFilePath) ?? undefined,
+                    ContentType: mime.getType(targetFilePath) ?? undefined,
                     //ContentLength: zipEntry.uncompressedSize,
                 })
             );


### PR DESCRIPTION
When uploading a ZIP in the map-storage, a previous change lost the Mime-type of the files stored. This is a fix to restore the type of the files when uploading a Zip.