### PR TITLE
Removing regeneration of the access token in the pusher

### DIFF
--- a/play/src/pusher/services/MatrixProvider.ts
+++ b/play/src/pusher/services/MatrixProvider.ts
@@ -10,7 +10,6 @@ const ADMIN_CHAT_ID = `@${MATRIX_ADMIN_USER}:${MATRIX_DOMAIN}`;
 const limit = pLimit(10);
 class MatrixProvider {
     private accessToken: string | undefined;
-    private lastAccessTokenDate: number = Date.now();
     private roomAreaFolderName = slugify("current visited room");
     private roomAreaFolderID: string | undefined;
 
@@ -48,11 +47,8 @@ class MatrixProvider {
         return email.replace("@", "_");
     }
 
-    async getAccessToken(): Promise<string> {
-        if (
-            (this.accessToken && this.lastAccessTokenDate && Date.now() - this.lastAccessTokenDate > 3_600_000) ||
-            !this.accessToken
-        ) {
+    private async getAccessToken(): Promise<string> {
+        if (!this.accessToken) {
             const response = await axios.post(`${MATRIX_API_URI}_matrix/client/r0/login`, {
                 type: "m.login.password",
                 user: MATRIX_ADMIN_USER,
@@ -60,7 +56,6 @@ class MatrixProvider {
             });
             if (response.status === 200 && response.data.errcode === undefined) {
                 this.accessToken = response.data.access_token;
-                this.lastAccessTokenDate = Date.now();
                 return response.data.access_token;
             } else {
                 throw new Error("Failed with errcode " + response.data.errcode);


### PR DESCRIPTION
The admin user, in the pusher, was regenerating an access token every hour. This is useless because we don't advertise we support refresh tokens. As such, our access token has an infinite life time.

Furthermore, the "admin" user is part of all the rooms it creates itself. It is therefore part of a great number of rooms (at least one per world in SAAS). Each time we log again, this is causing one row PER room to be added in the "device_lists_changes_in_room" table. The table can therefore become really big for no good reasons.

With the current implementation, we connect only once per pusher startup.

Future improvement: only login once and store the access token somewhere (for instance in Redis)