### PR TITLE
Fix credit card detection by Chrome

### DIFF
--- a/play/src/front/Components/Login/LoginScene.svelte
+++ b/play/src/front/Components/Login/LoginScene.svelte
@@ -112,7 +112,8 @@
             <!-- svelte-ignore a11y-autofocus -->
             <input
                 type="text"
-                name="loginSceneName"
+                name="fname"
+                data-testid="loginSceneNameInput"
                 placeholder={$LL.login.input.name.placeholder()}
                 class="w-52 md:w-96 h-12 text text-center bg-contrast rounded border border-solid border-white/20 mt-4 mb-0"
                 autofocus

--- a/play/src/front/Phaser/Entity/RemotePlayer.ts
+++ b/play/src/front/Phaser/Entity/RemotePlayer.ts
@@ -146,19 +146,20 @@ export class RemotePlayer extends Character implements ActivatableInterface {
             actionIcon: banIcon,
             iconColor: "#EF4444",
         });
-        if(!blackListManager.isBlackListed(this.userUuid)){
+        if (!blackListManager.isBlackListed(this.userUuid)) {
             actions.push({
                 actionName: get(LL).chat.userList.TalkTo(),
                 protected: false,
                 priority: 1,
                 style: "bg-white/10 hover:bg-white/30",
                 callback: () => {
-                    if (this.scene.connection != undefined) this.scene.connection.emitAskPosition(this.userUuid, this.scene.roomUrl);
+                    if (this.scene.connection != undefined)
+                        this.scene.connection.emitAskPosition(this.userUuid, this.scene.roomUrl);
                 },
                 actionIcon: walk,
                 iconColor: "#FFFFFF",
             });
-            if(this.chatID != undefined){
+            if (this.chatID != undefined) {
                 actions.push({
                     actionName: get(LL).chat.userList.sendMessage(),
                     protected: false,

--- a/tests/tests/error_pages.spec.ts
+++ b/tests/tests/error_pages.spec.ts
@@ -24,7 +24,7 @@ test.describe('Error pages', () => {
         publicTestMapUrl("does/not/exist", "error_pages")
     );
 
-    await page.fill('input[name="loginSceneName"]', 'Alice');
+    await page.getByTestId('loginSceneNameInput').fill('Alice');
     await page.click('button.loginSceneFormSubmit');
     await page.click('button.selectCharacterSceneFormSubmit');
     await page.click("text=Save");
@@ -37,7 +37,7 @@ test.describe('Error pages', () => {
         Map.url("not-found")
     );
 
-    await page.fill('input[name="loginSceneName"]', 'Alice');
+    await page.getByTestId('loginSceneNameInput').fill('Alice');
     await page.click('button.loginSceneFormSubmit');
     await page.click('button.selectCharacterSceneFormSubmit');
     await page.click("text=Save");
@@ -51,7 +51,7 @@ test.describe('Error pages', () => {
         publicTestMapUrl("tests/MapWithError/error.json", "error_pages")
     );
 
-    await page.fill('input[name="loginSceneName"]', 'Alice');
+    await page.getByTestId('loginSceneNameInput').fill('Alice');
     await page.click('button.loginSceneFormSubmit');
     await page.click('button.selectCharacterSceneFormSubmit');
     await page.click("text=Save");

--- a/tests/tests/utils/auth.ts
+++ b/tests/tests/utils/auth.ts
@@ -39,7 +39,7 @@ async function createUser(
     await page.goto(targetUrl);
 
     // login
-    await page.fill('input[name="loginSceneName"]', name);
+    await page.getByTestId('loginSceneNameInput').fill(name);
     await page.click('button.loginSceneFormSubmit');
     await expect(page.locator('button.selectCharacterSceneFormSubmit')).toBeVisible();
     for (let i = 0; i < selectWoka(name); i++) {


### PR DESCRIPTION
Chome's auto-detection of credit card forms is too aggressive. Change the name of input to "fname" to propose the first name of the user.