### PR TITLE
Fixing build on forks

### DIFF
--- a/.github/workflows/build-multi-arch-image.yml
+++ b/.github/workflows/build-multi-arch-image.yml
@@ -26,6 +26,9 @@ on:
       context:
         required: true
         type: string
+      short_name:
+        required: true
+        type: string
       sentry_project:
         required: false
         type: string
@@ -42,6 +45,7 @@ jobs:
       image-name: ${{ inputs.ghcr-dev-build-image-name }}
       dockerfile: ${{ inputs.dockerfile }}
       context: ${{ inputs.context }}
+      short_name: ${{ inputs.short_name }}
       sentry_project: ${{ inputs.sentry_project }}
       push-to-registry: ${{ inputs.push-to-registry }}
 
@@ -55,6 +59,7 @@ jobs:
       image-name: ${{ inputs.ghcr-dev-build-image-name }}
       dockerfile: ${{ inputs.dockerfile }}
       context: ${{ inputs.context }}
+      short_name: ${{ inputs.short_name }}
       sentry_project: ${{ inputs.sentry_project }}
       push-to-registry: ${{ inputs.push-to-registry }}
 

--- a/.github/workflows/build-single-image.yml
+++ b/.github/workflows/build-single-image.yml
@@ -20,6 +20,9 @@ on:
       context:
         required: true
         type: string
+      short_name:
+        required: true
+        type: string
       sentry_project:
         required: false
         type: string
@@ -87,16 +90,16 @@ jobs:
             "SENTRY_ORG=${{ secrets.SENTRY_ORG }}"
             "SENTRY_ENVIRONMENT=${{ github.event_name == 'release' && 'production' || env.GITHUB_REF_NAME == 'master' && 'staging' || 'testing' }}"
             "SENTRY_RELEASE=${{ github.event_name == 'release' && env.GITHUB_REF_NAME || format('{0}@{1}', env.GITHUB_REF_NAME_SLUG, env.GITHUB_SHA) }}"
-          outputs: ${{ inputs.push-to-registry != true && format('type=docker,dest=/tmp/{0}.tar', inputs.sentry_project) || '' }}
+          outputs: ${{ inputs.push-to-registry != true && format('type=docker,dest=/tmp/{0}.tar', inputs.short_name) || '' }}
 
       - name: Zip image
         if: ${{ inputs.push-to-registry != true }}
-        run: gzip ${{ inputs.sentry_project }}.tar
+        run: gzip ${{ inputs.short_name }}.tar
         working-directory: /tmp
 
       - name: Upload image as artifact
         if: ${{ inputs.push-to-registry != true }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.sentry_project }}
-          path: /tmp/${{ inputs.sentry_project }}.tar.gz
+          name: ${{ inputs.short_name }}
+          path: /tmp/${{ inputs.short_name }}.tar.gz

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -23,6 +23,7 @@ jobs:
       # FIXME: Final build should only build on master or tags
       final_build: ${{ github.event_name == 'push' || github.event_name == 'release' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'linked_to_saas_branch'))) }}
       dockerfile: play/Dockerfile
+      short_name: play
       # sentry_project: play
       # We only push to the registry if we are in the WorkAdventure organization. Otherwise, we will use artifacts because GITHUB_TOKEN from a public fork have no write access, even to the local user repository.
       push-to-registry: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'workadventure') || (github.event_name != 'pull_request' && github.repository_owner == 'workadventure') }}
@@ -37,6 +38,7 @@ jobs:
       dockerio-image-name: 'thecodingmachine/workadventure-back'
       final_build: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'linked_to_saas_branch')) }}
       dockerfile: back/Dockerfile
+      short_name: back
       sentry_project: back
       # We only push to the registry if we are in the WorkAdventure organization. Otherwise, we will use artifacts because GITHUB_TOKEN from a public fork have no write access, even to the local user repository.
       push-to-registry: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'workadventure') || (github.event_name != 'pull_request' && github.repository_owner == 'workadventure') }}
@@ -51,6 +53,7 @@ jobs:
       dockerio-image-name: 'thecodingmachine/workadventure-uploader'
       final_build: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'linked_to_saas_branch')) }}
       dockerfile: uploader/Dockerfile
+      short_name: uploader
       sentry_project: uploader
       # We only push to the registry if we are in the WorkAdventure organization. Otherwise, we will use artifacts because GITHUB_TOKEN from a public fork have no write access, even to the local user repository.
       push-to-registry: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'workadventure') || (github.event_name != 'pull_request' && github.repository_owner == 'workadventure') }}
@@ -65,6 +68,7 @@ jobs:
       dockerio-image-name: 'thecodingmachine/workadventure-maps'
       final_build: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'linked_to_saas_branch')) }}
       dockerfile: maps/Dockerfile
+      short_name: maps
       sentry_project: maps
       # We only push to the registry if we are in the WorkAdventure organization. Otherwise, we will use artifacts because GITHUB_TOKEN from a public fork have no write access, even to the local user repository.
       push-to-registry: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'workadventure') || (github.event_name != 'pull_request' && github.repository_owner == 'workadventure') }}
@@ -79,6 +83,7 @@ jobs:
       dockerio-image-name: 'thecodingmachine/workadventure-map-storage'
       final_build: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'linked_to_saas_branch')) }}
       dockerfile: map-storage/Dockerfile
+      short_name: map-storage
       sentry_project: map-storage
       # We only push to the registry if we are in the WorkAdventure organization. Otherwise, we will use artifacts because GITHUB_TOKEN from a public fork have no write access, even to the local user repository.
       push-to-registry: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'workadventure') || (github.event_name != 'pull_request' && github.repository_owner == 'workadventure') }}


### PR DESCRIPTION
A bug was previosuly introduced when we removed pushing to Sentry the play image. This triggered the play ZIP to have no name because the Sentry project was used as a base for the ZIP name (which should be unrelated)