### PR TITLE
Fixing height of container in PiP mode

### DIFF
--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -239,8 +239,7 @@
     <div
         bind:clientWidth={containerWidth}
         class="pointer-events-auto"
-        style={`gap: ${gap}px; ` +
-            (!isOnOneLine || (isOnOneLine && oneLineMode === "vertical") ? "height: " + containerHeight + "px;" : "")}
+        style={`gap: ${gap}px; ` + (!isOnOneLine ? "height: " + containerHeight + "px;" : "")}
         class:hidden={$highlightFullScreen && $highlightedEmbedScreen && oneLineMode !== "vertical"}
         class:flex={true}
         class:max-h-full={isOnOneLine && oneLineMode === "horizontal"}


### PR DESCRIPTION
The height of the container in Picture in Picture mode was overhidden. It should always stay to h-full.