### PR TITLE
Fix zoom on focusable area

### DIFF
--- a/play/src/front/Phaser/Game/CameraManager.ts
+++ b/play/src/front/Phaser/Game/CameraManager.ts
@@ -212,12 +212,20 @@ export class CameraManager extends Phaser.Events.EventEmitter {
         this.setCameraMode(CameraMode.Focus);
         this.waScaleManager.saveZoom();
         this.waScaleManager.setFocusTarget(focusOn);
-        this.cameraLocked = true;
 
-        this.unlockCameraWithDelay(duration);
+        this.cameraLocked = false;
+        this.zoomLocked = false;
+
         this.restoreZoomTween?.stop();
         this.startFollowTween?.stop();
-        this.camera.stopFollow();
+
+        //Set the camera to focus on the given point
+        const focusPoint = {
+            x: focusOn.x,
+            y: focusOn.y,
+        };
+
+        this.camera.startFollow(focusPoint, true);
         this.playerToFollow = undefined;
 
         const currentZoomModifier = this.waScaleManager.zoomModifier;


### PR DESCRIPTION
Fixed a bug when you are on a focusable area and zoom in, the zoom point becomes the top left corner of the screen. Now, on the focusable area, the camera remains centered.