### PR TITLE
Adding possiblity to disable generating source maps

### DIFF
--- a/play/vite.config.ts
+++ b/play/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(({ mode }) => {
             },
         },
         build: {
-            sourcemap: true,
+            sourcemap: env.GENERATE_SOURCEMAP !== "false",
             outDir: "./dist/public",
             rollupOptions: {
                 plugins: [NodeGlobalsPolyfillPlugin({ buffer: true })],


### PR DESCRIPTION
Source maps are really long to generate. In some CI setups (SAAS), it could be useful to be able to disable them.

Now, the `GENERATE_SOURCEMAP=false` env var will turn off sourcemap generation.