### PR TITLE
Add FAST_BUILD argument to control build mode for play image

### DIFF
--- a/.github/workflows/build-single-image.yml
+++ b/.github/workflows/build-single-image.yml
@@ -90,6 +90,11 @@ jobs:
             "SENTRY_ORG=${{ secrets.SENTRY_ORG }}"
             "SENTRY_ENVIRONMENT=${{ github.event_name == 'release' && 'production' || env.GITHUB_REF_NAME == 'master' && 'staging' || 'testing' }}"
             "SENTRY_RELEASE=${{ github.event_name == 'release' && env.GITHUB_REF_NAME || format('{0}@{1}', env.GITHUB_REF_NAME_SLUG, env.GITHUB_SHA) }}"
+          build-args: |
+            # Some images (the play image) can be built in two modes: normal mode and fast mode (without Legacy browser support)
+            # We use the FAST_BUILD build-arg to control this.
+            # We use fast build when the image is just tested in CI and not pushed to the registry.
+            FAST_BUILD=${{ inputs.push-to-registry != true && '' || 'true' }}
           outputs: ${{ inputs.push-to-registry != true && format('type=docker,dest=/tmp/{0}.tar', inputs.short_name) || '' }}
 
       - name: Zip image

--- a/play/Dockerfile
+++ b/play/Dockerfile
@@ -11,6 +11,7 @@ RUN npm run tag-version && npm run ts-proto
 # typescript build
 FROM --platform=$BUILDPLATFORM node:20.18-bullseye-slim AS builder
 ARG NODE_OPTIONS="--max-old-space-size=16384"
+ARG FAST_BUILD=""
 WORKDIR /usr/src
 RUN apt-get update && apt-get install -y git
 COPY package.json package-lock.json ./
@@ -41,6 +42,7 @@ RUN --mount=type=secret,id=SENTRY_RELEASE \
     export SENTRY_PROJECT=$(cat /run/secrets/SENTRY_PROJECT) && \
     export SENTRY_ENVIRONMENT=$(cat /run/secrets/SENTRY_ENVIRONMENT) && \
     export NODE_OPTIONS="$NODE_OPTIONS" && \
+    export DISABLE_LEGACY_BROWSERS="$FAST_BUILD" && \
     cd play && \
     npm run typesafe-i18n && \
     npm run build-iframe-api && \


### PR DESCRIPTION
In FAST_BUILD (triggered only when the image is not pushed to the registry), the Vite legacy browser plugin is skipped. This helps almost cut in half the build time.