### PR TITLE
fix button close on ios

### DIFF
--- a/play/src/front/Components/Input/ButtonClose.svelte
+++ b/play/src/front/Components/Input/ButtonClose.svelte
@@ -32,7 +32,7 @@
 <button
     type="button"
     {id}
-    class="{sizeClasses} flex items-center justify-center rounded backdrop-blur close-window transition-all aspect-square text-2xl {textColor} {bgColor} {hoverColor} close-btn"
+    class="{sizeClasses} p-0 flex items-center justify-center rounded backdrop-blur close-window transition-all aspect-square text-2xl {textColor} {bgColor} {hoverColor} close-btn"
     data-testid={dataTestId}
     on:click={handleClick}
 >


### PR DESCRIPTION
- Fix issue where icon of close button was not visible

<img width="424" height="874" alt="image" src="https://github.com/user-attachments/assets/fbeee3e5-7866-42e9-85a7-50523c9d55ee" />
