### PR TITLE
Using Canvas to display Woka in Woka select screens

### DIFF
--- a/play/src/front/Components/Woka/WokaCustomizeScene.svelte
+++ b/play/src/front/Components/Woka/WokaCustomizeScene.svelte
@@ -380,7 +380,13 @@
                                             on:click={() => selectTexture(selectedBodyPart, texture.id)}
                                             id={`texture-${selectedBodyPart}-${texture.id}`}
                                         >
-                                            <WokaImage selectedTextures={{[selectedBodyPart]: texture.id}} {wokaData} {getTextureUrl} classList="p-2" direction={assetsDirection} />
+                                            <WokaImage
+                                                selectedTextures={{ [selectedBodyPart]: texture.id }}
+                                                {wokaData}
+                                                {getTextureUrl}
+                                                classList="p-2"
+                                                direction={assetsDirection}
+                                            />
                                         </button>
                                     {/each}
                                 </div>

--- a/play/src/front/Components/Woka/WokaCustomizeScene.svelte
+++ b/play/src/front/Components/Woka/WokaCustomizeScene.svelte
@@ -15,6 +15,7 @@
     import WokaPreview from "./WokaPreview.svelte";
     import type { WokaBodyPart, WokaData, WokaTexture } from "./WokaTypes";
     import { getItemsPerRow } from "./ItemsPerRow";
+    import WokaImage from "./WokaImage.svelte";
 
     export let back: () => void;
     export let saveAndContinue: (texturesId: string[]) => void;
@@ -379,34 +380,7 @@
                                             on:click={() => selectTexture(selectedBodyPart, texture.id)}
                                             id={`texture-${selectedBodyPart}-${texture.id}`}
                                         >
-                                            <div class="p-2 bg-white/10 rounded flex items-center justify-center">
-                                                {#if texture.url.includes("empty.png")}
-                                                    <div class="w-[64px] h-[64px] flex items-center justify-center">
-                                                        <svg
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                            width="32"
-                                                            height="32"
-                                                            viewBox="0 0 24 24"
-                                                            fill="none"
-                                                            stroke="currentColor"
-                                                            stroke-width="2"
-                                                            stroke-linecap="round"
-                                                            stroke-linejoin="round"
-                                                            class="icon icon-tabler icons-tabler-outline icon-tabler-forbid"
-                                                            ><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path
-                                                                d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"
-                                                            /><path d="M9 9l6 6" /></svg
-                                                        >
-                                                    </div>
-                                                {:else}
-                                                    <div
-                                                        class="w-[64px] h-[64px] bg-no-repeat"
-                                                        style="background-image: url('{getTextureUrl(
-                                                            texture.url
-                                                        )}'); background-size: calc(3 * 64px) calc(4 * 64px); background-position: 0px calc(-1 * {assetsDirection} * 64px); image-rendering: pixelated;"
-                                                    />
-                                                {/if}
-                                            </div>
+                                            <WokaImage selectedTextures={{[selectedBodyPart]: texture.id}} {wokaData} {getTextureUrl} classList="p-2" direction={assetsDirection} />
                                         </button>
                                     {/each}
                                 </div>

--- a/play/src/front/Components/Woka/WokaImage.svelte
+++ b/play/src/front/Components/Woka/WokaImage.svelte
@@ -20,7 +20,6 @@
     let frameCount: number = 0;
     const framesPerStep = 15;
 
-
     function findTextureUrl(bodyPart: string): string | null {
         const textureId = selectedTextures?.[bodyPart];
         if (!textureId || !wokaData?.[bodyPart]?.collections) return null;

--- a/play/src/front/Components/Woka/WokaImage.svelte
+++ b/play/src/front/Components/Woka/WokaImage.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+    import { onMount, onDestroy } from "svelte";
+    import { WokaData, WokaTexture } from "./WokaTypes";
+
+    export let selectedTextures: Record<string, string>;
+    export let wokaData: WokaData | null = null;
+    export let canvasSize = 64;
+    export let direction: number = 0;
+    export let getTextureUrl: (url: string) => string = (url) => url;
+    export let classList: string = "";
+
+    const bodyPartOrder = ["body", "eyes", "hair", "clothes", "hat", "accessory", "woka"];
+
+    let canvas: HTMLCanvasElement;
+    let ctx: CanvasRenderingContext2D;
+    let images: Record<string, HTMLImageElement> = {};
+    let frame: number = 0;
+
+    let raf: number;
+    let frameCount: number = 0;
+    const framesPerStep = 15;
+
+
+    function findTextureUrl(bodyPart: string): string | null {
+        const textureId = selectedTextures?.[bodyPart];
+        if (!textureId || !wokaData?.[bodyPart]?.collections) return null;
+        for (const collection of wokaData[bodyPart].collections) {
+            const texture = collection.textures.find((t: WokaTexture) => t.id === textureId);
+            if (texture) return getTextureUrl(texture.url);
+        }
+        return null;
+    }
+
+    function loadImages() {
+        images = {};
+        for (const part of bodyPartOrder) {
+            const url = findTextureUrl(part);
+            if (url) {
+                const img = new window.Image();
+                img.src = url;
+                // Load image with CORS headers to populate the cache with CORS headers
+                img.crossOrigin = "user-credentials";
+                images[part] = img;
+            }
+        }
+    }
+
+    function draw() {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        for (const part of bodyPartOrder) {
+            const img = images[part];
+            ctx.imageSmoothingEnabled = false;
+            if (img && img.complete) {
+                ctx.drawImage(img, frame * 32, direction * 32, 32, 32, 0, 0, canvasSize, canvasSize);
+            }
+        }
+    }
+
+    function animate() {
+        frameCount++;
+        if (frameCount >= framesPerStep) {
+            frame = (frame + 1) % 3;
+            frameCount = 0;
+        }
+        draw();
+        raf = requestAnimationFrame(animate);
+    }
+
+    $: if (selectedTextures) {
+        loadImages();
+    }
+
+    onMount(() => {
+        const context = canvas.getContext("2d");
+        if (!context) return;
+        ctx = context;
+        loadImages();
+        animate();
+    });
+    onDestroy(() => {
+        cancelAnimationFrame(raf);
+    });
+</script>
+
+<canvas
+    bind:this={canvas}
+    width={canvasSize}
+    height={canvasSize}
+    style="image-rendering: pixelated;"
+    class={classList}
+/>

--- a/play/src/front/Components/Woka/WokaPreview.svelte
+++ b/play/src/front/Components/Woka/WokaPreview.svelte
@@ -14,7 +14,6 @@
 
     let direction: number = 0;
     const canvasSize = 130;
-
 </script>
 
 <div class="woka-preview flex items-center justify-center relative">
@@ -42,6 +41,12 @@
                 /><path d="M20 4v5h-5" /></svg
             >
         </button>
-        <WokaImage {selectedTextures} {wokaData} {getTextureUrl} {canvasSize} direction={directionsMapping[direction]} />
+        <WokaImage
+            {selectedTextures}
+            {wokaData}
+            {getTextureUrl}
+            {canvasSize}
+            direction={directionsMapping[direction]}
+        />
     </div>
 </div>

--- a/play/src/front/Components/Woka/WokaSelectScene.svelte
+++ b/play/src/front/Components/Woka/WokaSelectScene.svelte
@@ -8,6 +8,7 @@
     import WokaPreview from "./WokaPreview.svelte";
     import type { WokaCollection, WokaData, WokaTexture } from "./WokaTypes";
     import { getItemsPerRow } from "./ItemsPerRow";
+    import WokaImage from "./WokaImage.svelte";
 
     export let customize: () => void;
     export let saveAndContinue: (texturesId: string[]) => void;
@@ -247,6 +248,7 @@
                                     class="w-full flex flex-row flex-wrap items-start justify-start gap-3"
                                 >
                                     {#each collection.textures || [] as texture (texture.id)}
+
                                         <button
                                             class="rounded border border-solid box-border p-0 h-fit {selectedWokaTextureId?.woka ===
                                             texture.id
@@ -255,14 +257,7 @@
                                             id="woka-{texture.id}"
                                             on:click={() => selectTexture(collectionIndex, texture.id)}
                                         >
-                                            <div class="p-2 bg-white/10 rounded flex items-center justify-center">
-                                                <div
-                                                    class="w-[64px] h-[64px] bg-no-repeat"
-                                                    style="background-image: url('{getTextureUrl(
-                                                        texture.url
-                                                    )}'); background-size: calc(3 * 64px) calc(4 * 64px); background-position: 0px calc(-1 * {assetsDirection} * 64px); image-rendering: pixelated;"
-                                                />
-                                            </div>
+                                            <WokaImage selectedTextures={{"woka": texture.id}} {wokaData} {getTextureUrl} classList="p-2" direction={assetsDirection} />
                                         </button>
                                     {/each}
                                 </div>

--- a/play/src/front/Components/Woka/WokaSelectScene.svelte
+++ b/play/src/front/Components/Woka/WokaSelectScene.svelte
@@ -248,7 +248,6 @@
                                     class="w-full flex flex-row flex-wrap items-start justify-start gap-3"
                                 >
                                     {#each collection.textures || [] as texture (texture.id)}
-
                                         <button
                                             class="rounded border border-solid box-border p-0 h-fit {selectedWokaTextureId?.woka ===
                                             texture.id
@@ -257,7 +256,13 @@
                                             id="woka-{texture.id}"
                                             on:click={() => selectTexture(collectionIndex, texture.id)}
                                         >
-                                            <WokaImage selectedTextures={{"woka": texture.id}} {wokaData} {getTextureUrl} classList="p-2" direction={assetsDirection} />
+                                            <WokaImage
+                                                selectedTextures={{ woka: texture.id }}
+                                                {wokaData}
+                                                {getTextureUrl}
+                                                classList="p-2"
+                                                direction={assetsDirection}
+                                            />
                                         </button>
                                     {/each}
                                 </div>

--- a/play/src/front/Stores/BroadcastTrackStore.ts
+++ b/play/src/front/Stores/BroadcastTrackStore.ts
@@ -1,0 +1,10 @@
+import { createNestedStore } from "@workadventure/store-utils";
+import { writable } from "svelte/store";
+import { GameScene } from "../Phaser/Game/GameScene";
+import { TrackWrapper } from "../Streaming/Common/TrackWrapper";
+import { gameSceneStore } from "./GameSceneStore";
+
+export const broadcastTracksStore = createNestedStore<GameScene | undefined, Map<string, TrackWrapper>>(
+    gameSceneStore,
+    (gameScene) => (gameScene ? gameScene.broadcastService.getTracks() : writable<Map<string, TrackWrapper>>(new Map()))
+);

--- a/play/src/front/Stores/GameSceneStore.ts
+++ b/play/src/front/Stores/GameSceneStore.ts
@@ -1,5 +1,5 @@
 import { writable } from "svelte/store";
-import { GameScene } from "../Phaser/Game/GameScene";
+import { type GameScene } from "../Phaser/Game/GameScene";
 import { ExtensionModule } from "../ExternalModule/ExtensionModule";
 import { waitForStoreValue } from "./Utils/waitForStoreValue";
 

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -20,6 +20,7 @@ import { privacyShutdownStore } from "./PrivacyShutdownStore";
 import { inExternalServiceStore, myCameraStore, myMicrophoneStore, proximityMeetingStore } from "./MyMediaStore";
 import { userMovingStore } from "./GameStore";
 import { hideHelpCameraSettings } from "./HelpSettingsStore";
+import { broadcastTracksStore } from "./BroadcastTrackStore";
 
 /**
  * A store that contains the camera state requested by the user (on or off).
@@ -270,6 +271,7 @@ export const cameraEnergySavingStore = derived(
         deviceChanged10SecondsAgoStore,
         userMoved5SecondsAgoStore,
         peerStore,
+        broadcastTracksStore,
         enabledWebCam10secondsAgoStore,
         mouseIsHoveringCameraButton,
         cameraNoEnergySavingStore,
@@ -280,6 +282,7 @@ export const cameraEnergySavingStore = derived(
         $deviceChanged10SecondsAgoStore,
         $userMoved5SecondsAgoStore,
         $peerStore,
+        $broadcastTracksStore,
         $enabledWebCam10secondsAgoStore,
         $mouseInBottomRight,
         $cameraNoEnergySavingStore,
@@ -291,6 +294,7 @@ export const cameraEnergySavingStore = derived(
             !$userMoved5SecondsAgoStore &&
             !$deviceChanged10SecondsAgoStore &&
             $peerStore.size === 0 &&
+            $broadcastTracksStore.size === 0 &&
             !$enabledWebCam10secondsAgoStore &&
             !$cameraNoEnergySavingStore &&
             !$devicesNotLoaded &&

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -1,9 +1,6 @@
 import { Readable, derived, get, writable } from "svelte/store";
-import { createNestedStore } from "@workadventure/store-utils";
-import { GameScene } from "../Phaser/Game/GameScene";
 import { JitsiTrackWrapper } from "../Streaming/Jitsi/JitsiTrackWrapper";
 import { JitsiTrackStreamWrapper } from "../Streaming/Jitsi/JitsiTrackStreamWrapper";
-import { TrackWrapper } from "../Streaming/Common/TrackWrapper";
 import { ScreenSharingPeer } from "../WebRtc/ScreenSharingPeer";
 import { LayoutMode } from "../WebRtc/LayoutManager";
 import { PeerStatus } from "../WebRtc/VideoPeer";
@@ -13,7 +10,6 @@ import LL from "../../i18n/i18n-svelte";
 import { screenSharingLocalMedia } from "./ScreenSharingStore";
 import { peerStore, screenSharingStreamStore } from "./PeerStore";
 import { highlightedEmbedScreen } from "./HighlightedEmbedScreenStore";
-import { gameSceneStore } from "./GameSceneStore";
 import { embedScreenLayoutStore } from "./EmbedScreensStore";
 import { highlightFullScreen } from "./ActionsCamStore";
 import { scriptingVideoStore } from "./ScriptingVideoStore";
@@ -28,6 +24,7 @@ import {
     silentStore,
 } from "./MediaStore";
 import { currentPlayerWokaStore } from "./CurrentPlayerWokaStore";
+import { broadcastTracksStore } from "./BroadcastTrackStore";
 
 //export type Streamable = RemotePeer | ScreenSharingLocalMedia | JitsiTrackStreamWrapper;
 
@@ -73,11 +70,6 @@ export interface Streamable {
     readonly displayMode: "fit" | "cover";
     readonly displayInPictureInPictureMode: boolean;
 }
-
-const broadcastTracksStore = createNestedStore<GameScene | undefined, Map<string, TrackWrapper>>(
-    gameSceneStore,
-    (gameScene) => (gameScene ? gameScene.broadcastService.getTracks() : writable<Map<string, TrackWrapper>>(new Map()))
-);
 
 const jitsiTracksStore = derived([broadcastTracksStore], ([$broadcastTracksStore]) => {
     const jitsiTracks = new Map<string, JitsiTrackWrapper>();


### PR DESCRIPTION
Using a div with a background color caused images to be loaded and put in cache without CORS headers. This is an issue with S3 bucket that store images even when CORS is configured. As a result, when entering the map, Phaser would load in AJAX the image that is in cache, without CORS. It would not work. By loading everything from scratch in AJAX, we avoid this problem.