### PR TITLE
Fixing custom Woka lost

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1615,6 +1615,9 @@ export class GameScene extends DirtyScene {
             )
             .then(async (onConnect: OnConnectInterface) => {
                 this.connection = onConnect.connection;
+                gameManager.setCharacterTextureIds(onConnect.room.characterTextures.map((texture) => texture.id));
+                gameManager.setCompanionTextureId(onConnect.room?.companionTexture?.id ?? null);
+
                 this.mapEditorModeManager?.subscribeToRoomConnection(this.connection);
                 const commandsToApply = onConnect.room.commandsToApply;
                 if (commandsToApply) {


### PR DESCRIPTION
When using an AdminAPI and configuring a custom woka, if you click on customize your woka again, you were redirected to the default woka page instead of the custom woka page (and the custom woka settings were lost). This is now fixed.