### PR TITLE
Adding 2 allowed Headers in CORS

### DIFF
--- a/play/src/pusher/app.ts
+++ b/play/src/pusher/app.ts
@@ -59,6 +59,8 @@ class App {
                     "Accept",
                     "Pragma",
                     "Cache-Control",
+                    "baggage",
+                    "sentry-trace",
                 ],
                 credentials: true,
             })


### PR DESCRIPTION
"baggage" and "sentry-trace" can be returned by Sentry and should be white-listed in CORS