### PR TITLE
Fixing Space cleanup issues

### DIFF
--- a/play/src/front/Components/Cowebsites/JistiCowebsiteComponent.svelte
+++ b/play/src/front/Components/Cowebsites/JistiCowebsiteComponent.svelte
@@ -29,7 +29,7 @@
     let jwt: string | undefined = actualCowebsite.jwt;
     let jitsiApi: JitsiApi;
     let screenWakeRelease: (() => Promise<void>) | undefined;
-    let jistiMeetLoadedPromise: CancelablePromise<void>;
+    let jitsiMeetLoadedPromise: CancelablePromise<void> | undefined;
 
     // Event handlers as named functions to enable proper cleanup
     const onVideoConferenceJoined = () => {
@@ -131,7 +131,7 @@
                     },
                 };
 
-                jistiMeetLoadedPromise = new CancelablePromise<void>((resolve) => {
+                jitsiMeetLoadedPromise = new CancelablePromise<void>((resolve) => {
                     options.onload = () => {
                         resolve();
                     };
@@ -148,7 +148,7 @@
                     jitsiApi.addListener("participantKickedOut", onParticipantsCountChange);
                 });
 
-                jistiMeetLoadedPromise
+                jitsiMeetLoadedPromise
                     .then(() => {
                         if (cancelled) {
                             debug("CLOSING BECAUSE CANCELLED AFTER LOAD");
@@ -173,7 +173,7 @@
     });
 
     onDestroy(() => {
-        jistiMeetLoadedPromise.cancel();
+        jitsiMeetLoadedPromise?.cancel();
 
         if (jitsiApi) {
             jitsiApi.removeListener("videoConferenceJoined", onVideoConferenceJoined);

--- a/play/src/front/Connection/ConnectionClosedError.ts
+++ b/play/src/front/Connection/ConnectionClosedError.ts
@@ -1,0 +1,8 @@
+export class ConnectionClosedError extends Error {
+    constructor(message?: string) {
+        super(message);
+        this.name = "ConnectionClosedError";
+        // Set the prototype explicitly to maintain the correct prototype chain
+        Object.setPrototypeOf(this, ConnectionClosedError.prototype);
+    }
+}

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2329,7 +2329,9 @@ export class GameScene extends DirtyScene {
                 //this.reposition();
             } else {
                 this.CurrentPlayer.toggleTalk(false, true);
-                this.connection?.emitPlayerShowVoiceIndicator(false);
+                if (!this.connection?.closed) {
+                    this.connection?.emitPlayerShowVoiceIndicator(false);
+                }
                 this.showVoiceIndicatorChangeMessageSent = false;
                 //this.MapPlayersByKey.forEach((remotePlayer) => remotePlayer.toggleTalk(false, true));
                 if (this.localVolumeStoreUnsubscriber) {

--- a/play/src/front/Space/SpaceRegistry/SpaceRegistry.ts
+++ b/play/src/front/Space/SpaceRegistry/SpaceRegistry.ts
@@ -17,6 +17,7 @@ import { SpaceRegistryInterface } from "./SpaceRegistryInterface";
  */
 export type RoomConnectionForSpacesInterface = Pick<
     RoomConnection,
+    | "closed"
     | "addSpaceUserMessageStream"
     | "updateSpaceUserMessageStream"
     | "removeSpaceUserMessageStream"
@@ -217,9 +218,11 @@ export class SpaceRegistry implements SpaceRegistryInterface {
         // If a space is not destroyed, it means that there is a bug in the code.
         await Promise.all(
             Array.from(this.spaces.values()).map(async (space) => {
-                await space.destroy();
-                console.warn(`Space "${space.getName()}" was not destroyed properly.`);
-                Sentry.captureException(new Error(`Space "${space.getName()}" was not destroyed properly.`));
+                if (!this.leavingSpacesPromises.has(space.getName())) {
+                    await space.destroy();
+                    console.warn(`Space "${space.getName()}" was not destroyed properly.`);
+                    Sentry.captureException(new Error(`Space "${space.getName()}" was not destroyed properly.`));
+                }
             })
         );
 

--- a/play/src/front/Space/tests/MockRoomConnectionForSpaces.ts
+++ b/play/src/front/Space/tests/MockRoomConnectionForSpaces.ts
@@ -13,6 +13,7 @@ import { Subject } from "rxjs";
 import { RoomConnectionForSpacesInterface } from "../SpaceRegistry/SpaceRegistry";
 
 export class MockRoomConnectionForSpaces implements RoomConnectionForSpacesInterface {
+    public closed = false;
     public addSpaceUserMessageStream = new Subject<AddSpaceUserPusherToFrontMessage>();
     public updateSpaceUserMessageStream = new Subject<UpdateSpaceUserPusherToFrontMessage>();
     public removeSpaceUserMessageStream = new Subject<RemoveSpaceUserPusherToFrontMessage>();

--- a/play/src/front/Space/tests/SpaceIntegration.test.ts
+++ b/play/src/front/Space/tests/SpaceIntegration.test.ts
@@ -25,6 +25,7 @@ import { SpaceUserExtended } from "../SpaceInterface";
 /* eslint @typescript-eslint/unbound-method: 0 */
 
 class MockRoomConnection implements RoomConnectionForSpacesInterface {
+    public closed = false;
     public addSpaceUserMessageStream = new Subject<AddSpaceUserPusherToFrontMessage>();
     public updateSpaceUserMessageStream = new Subject<UpdateSpaceUserPusherToFrontMessage>();
     public removeSpaceUserMessageStream = new Subject<RemoveSpaceUserPusherToFrontMessage>();

--- a/play/src/i18n/ar-SA/actionbar.ts
+++ b/play/src/i18n/ar-SA/actionbar.ts
@@ -48,7 +48,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ONLINE: "متصل",
         AWAY: "بعيد",
         BACK_IN_A_MOMENT: "سأعود بعد قليل",
-        DO_NOT_DISTURB: "لا تزعج",
+        DO_NOT_DISTURB: "عدم الإزعاج",
         BUSY: "مشغول",
         OFFLINE: "غير متصل",
         SILENT: "صامت",

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -1137,6 +1137,9 @@ export class IoSocketController {
     }
 
     private sendAnswerMessage(socket: WebSocket<SocketData>, answerMessage: AnswerMessage) {
+        if (socket.getUserData().disconnecting) {
+            return;
+        }
         socket.send(
             ServerToClientMessage.encode({
                 message: {


### PR DESCRIPTION
- Fixing an issue where Jitsi would be disabled without being enabled first
- Fixing an issue where an answer is sent by the pusher too late (the room connection is closed)
- Fixing an issue where setTimeout is not correctly disabled when leaving a room
- Fixing an issue where leaving a space after a socket disconnect displays console warnings