### PR TITLE
Optimizing rendering of Woka pictures

### DIFF
--- a/play/src/front/Chat/Components/Avatar.svelte
+++ b/play/src/front/Chat/Components/Avatar.svelte
@@ -1,30 +1,13 @@
 <script lang="ts">
-    import WokaFromUserId from "../../Components/Woka/WokaFromUserId.svelte";
     import { getColorByString } from "../../Utils/ColorGenerator";
 
     export let avatarUrl: string | null = null;
-    export let userId: number | string | null = null;
     export let fallbackName = "A";
     export let color: string | null = null;
     export let isChatAvatar = false;
 </script>
 
-{#if userId && userId != -1}
-    <div
-        class="rounded-full"
-        style="width: 32px; height: 32px;"
-        style:background-color={`${color ? color : `${getColorByString(fallbackName)}`}`}
-    >
-        <WokaFromUserId {userId} placeholderSrc="" customWidth="32px" />
-    </div>
-{:else if userId === -1}
-    <div
-        class="rounded-full bg-amber-600 text-center uppercase text-white w-8 h-8"
-        style:background-color={`${color ? color : getColorByString(fallbackName)}`}
-    >
-        <WokaFromUserId {userId} placeholderSrc="" customWidth="32px" />
-    </div>
-{:else if avatarUrl}
+{#if avatarUrl}
     <img
         src={avatarUrl}
         alt="User avatar"

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -1,5 +1,5 @@
 import type OutlinePipelinePlugin from "phaser3-rex-plugins/plugins/outlinepipeline-plugin.js";
-import { Unsubscriber, Writable, get, writable } from "svelte/store";
+import { Unsubscriber, get, readable, Readable } from "svelte/store";
 import type CancelablePromise from "cancelable-promise";
 import { Deferred } from "ts-deferred";
 import {
@@ -9,7 +9,6 @@ import {
     PositionMessage_Direction,
 } from "@workadventure/messages";
 import { defaultWoka } from "@workadventure/shared-utils";
-import { asError } from "catch-unknown";
 import { currentPlayerWokaStore } from "../../Stores/CurrentPlayerWokaStore";
 import { PlayerStatusDot } from "../Components/PlayerStatusDot";
 import { TalkIcon } from "../Components/TalkIcon";
@@ -64,7 +63,8 @@ export abstract class Character extends Container implements OutlineableInterfac
     private texts: Map<string, Phaser.GameObjects.DOMElement> = new Map();
     private textsToBuild = new Map();
     scene: GameScene;
-    private readonly _pictureStore: Writable<string | undefined>;
+    private lastRenderedSprite: string | undefined;
+    private readonly _pictureStore: Readable<string | undefined>;
     protected readonly outlineColorStore = createColorStore();
     private outlineColorStoreUnsubscribe: Unsubscriber | undefined;
     private texturePromise: CancelablePromise<string[] | void> | undefined;
@@ -95,7 +95,32 @@ export abstract class Character extends Container implements OutlineableInterfac
         this.clickable = false;
 
         this.sprites = new Map<string, Sprite>();
-        this._pictureStore = writable(undefined);
+
+        // Note: the picture store is rarely used because most of the time, we display the character sent in the space
+        // by the remote player.
+        // The sole place where we need the picture store is when you click on a Woka on the map and want to display
+        // the Woka sprite in the popup that opens.
+        this._pictureStore = readable<string | undefined>(undefined, (set) => {
+            this.waitAndGetSnapshot()
+                .then((htmlImageElementSrc) => {
+                    set(htmlImageElementSrc);
+                })
+                .catch((e) => {
+                    console.warn(e);
+                    set(defaultWoka);
+                });
+        });
+
+        if (userId != undefined) {
+            this.waitAndGetSnapshot()
+                .then((htmlImageElementSrc) => {
+                    currentPlayerWokaStore.set(htmlImageElementSrc);
+                })
+                .catch((e) => {
+                    console.warn(e);
+                    currentPlayerWokaStore.set(defaultWoka);
+                });
+        }
 
         //textures are inside a Promise in case they need to be lazyloaded before use.
         this.texturePromise = texturesPromise
@@ -104,23 +129,6 @@ export abstract class Character extends Container implements OutlineableInterfac
                 this.invisible = false;
                 this.playAnimation(direction, moving);
                 this.textureLoadedDeferred.resolve();
-                // getSnapshot can be quite long (~16ms) so we delay it to avoid freezing the game.
-                // Since requestAnimationFrame has the priority over setTimeout, the game will keep running smoothly.
-                return new Promise<void>((resolve, reject) => {
-                    setTimeout(() => {
-                        this.getSnapshot()
-                            .then((htmlImageElementSrc) => {
-                                this._pictureStore.set(htmlImageElementSrc);
-                                if (userId != undefined) {
-                                    currentPlayerWokaStore.set(htmlImageElementSrc);
-                                }
-                                resolve();
-                            })
-                            .catch((e) => {
-                                reject(asError(e));
-                            });
-                    }, 0);
-                });
             })
             .catch(() => {
                 return lazyLoadPlayerCharacterTextures(scene.superLoad, [
@@ -138,17 +146,6 @@ export abstract class Character extends Container implements OutlineableInterfac
                         this.invisible = false;
                         this.playAnimation(direction, moving);
                         this.textureLoadedDeferred.resolve();
-
-                        return this.getSnapshot().then((htmlImageElementSrc) => {
-                            // When there is no renderer (for instance with bots), the htmlImageElementSrc is an empty string
-                            if (!htmlImageElementSrc) {
-                                htmlImageElementSrc = defaultWoka;
-                            }
-                            if (userId != undefined) {
-                                currentPlayerWokaStore.set(htmlImageElementSrc);
-                            }
-                            this._pictureStore.set(htmlImageElementSrc);
-                        });
                     })
                     .catch((e) => {
                         this.textureLoadedDeferred.reject(e);
@@ -232,6 +229,36 @@ export abstract class Character extends Container implements OutlineableInterfac
         this.getBody().setSize(CHARACTER_BODY_WIDTH, CHARACTER_BODY_HEIGHT); //edit the hitbox to better match the character model
         this.getBody().setOffset(CHARACTER_BODY_OFFSET_X, CHARACTER_BODY_OFFSET_Y);
         this.setDepth(0);
+    }
+
+    private waitAndGetSnapshot(): Promise<string> {
+        if (this.lastRenderedSprite) {
+            return Promise.resolve(this.lastRenderedSprite);
+        }
+        return new Promise((resolve) => {
+            // getSnapshot can be quite long (~16ms) so we delay it to avoid freezing the game.
+            // Since requestAnimationFrame has the priority over setTimeout, the game will keep running smoothly.
+            this.textureLoadedDeferred.promise
+                .then(() => {
+                    setTimeout(() => {
+                        this.getSnapshot()
+                            .then((htmlImageElementSrc) => {
+                                this.lastRenderedSprite = htmlImageElementSrc;
+                                resolve(htmlImageElementSrc);
+                            })
+                            .catch((e) => {
+                                console.warn(e);
+                                this.lastRenderedSprite = defaultWoka;
+                                resolve(defaultWoka);
+                            });
+                    }, 0);
+                })
+                .catch((e) => {
+                    console.warn(e);
+                    this.lastRenderedSprite = defaultWoka;
+                    resolve(defaultWoka);
+                });
+        });
     }
 
     public setClickable(clickable = true): void {


### PR DESCRIPTION
The Woka picture (in the Character.pictureStore) is in fact rarely used. It is only used when you click on a woka and want to display the woka in the popup.

Therefore, it makes no sense to compute the image for each woka entering. Especially since this is a long operation (15ms to 30 ms) that can be costly if there are a lot of Wokas out there.

We now use a readable to render the texture only when the store is subscribed (lazy instantiation of the texture).