### PR TITLE
Fixing too fast reconnection loop

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -329,7 +329,10 @@ export class SocketManager {
                 (emoteEventMessage: EmoteEventMessage, listener: ZoneSocket) =>
                     this.onEmote(emoteEventMessage, listener),
                 (groupId: number, listener: ZoneSocket) => {
-                    void this.onLockGroup(groupId, listener, roomPromise);
+                    this.onLockGroup(groupId, listener, roomPromise).catch((e) => {
+                        console.error("An error happened while handling a lock group event:", e);
+                        Sentry.captureException(e);
+                    });
                 },
                 (playerDetailsUpdatedMessage: PlayerDetailsUpdatedMessage, listener: ZoneSocket) =>
                     this.onPlayerDetailsUpdated(playerDetailsUpdatedMessage, listener),

--- a/play/src/pusher/models/SpaceConnection.ts
+++ b/play/src/pusher/models/SpaceConnection.ts
@@ -166,19 +166,24 @@ export class SpaceConnection {
     ) {
         return (err: Error) => {
             if (spaceStreamToBack.pingTimeout) clearTimeout(spaceStreamToBack.pingTimeout);
-            console.error("Error in connection to back server '" + apiSpaceClient.getChannel().getTarget(), err);
+            console.error(
+                "Error in connection to back server for watchSpace '" + apiSpaceClient.getChannel().getTarget(),
+                err
+            );
             Sentry.captureException(err);
-            try {
-                this.removeListeners(spaceStreamToBack, backId);
-                this.retryConnection(backId);
-            } catch (e) {
-                console.error("Error while retrying connection ...", e);
-                Sentry.captureException(e);
-                this.cleanUpSpacePerBackId(backId).catch((e) => {
-                    console.error("Error while cleaning up space per back id", e);
+            this.removeListeners(spaceStreamToBack, backId);
+            setTimeout(() => {
+                try {
+                    this.retryConnection(backId);
+                } catch (e) {
+                    console.error("Error while retrying connection ...", e);
                     Sentry.captureException(e);
-                });
-            }
+                    this.cleanUpSpacePerBackId(backId).catch((e) => {
+                        console.error("Error while cleaning up space per back id", e);
+                        Sentry.captureException(e);
+                    });
+                }
+            }, 1000);
         };
     }
 

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -606,12 +606,13 @@ export class SocketManager implements ZoneEventListener {
 
             if (space) {
                 try {
+                    socketData.joinSpacesPromise.delete(spaceName);
+
                     await space.forwarder.unregisterUser(socket);
                     if (space.isEmpty()) {
                         space.cleanup();
                     }
 
-                    socketData.joinSpacesPromise.delete(spaceName);
                     return { space, spaceName, success: true };
                 } catch (error) {
                     console.error(`Error unregistering user from space ${spaceName}:`, error);

--- a/play/tests/pusher/Space.test.ts
+++ b/play/tests/pusher/Space.test.ts
@@ -537,6 +537,11 @@ describe("SpaceConnection", () => {
 
             await flushPromises();
 
+            // Wait 1 second to let the reconnection happen
+            await new Promise((resolve) => {
+                setTimeout(resolve, 1000);
+            });
+
             expect(mockGetSpaceClient).toHaveBeenCalledTimes(2);
             expect(mockWatchSpace).toHaveBeenCalledTimes(2);
             expect(mockSendLocalUsersToBack).toHaveBeenCalledOnce();


### PR DESCRIPTION
When a space was shut, it was trying to reconnect in a loop as fast as possible. We add a setTimeout to slow down retries.
This will help fix issues when redeploying in Kube where connTracks are saturated.