### PR TITLE
Fixing the local video feedback in Busy status

### DIFF
--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -19,7 +19,7 @@ import {
     localStreamStore,
     localVoiceIndicatorStore,
     localVolumeStore,
-    requestedCameraState,
+    mediaStreamConstraintsStore,
     requestedMicrophoneState,
     silentStore,
 } from "./MediaStore";
@@ -169,7 +169,10 @@ export const myCameraPeerStore: Readable<Streamable> = derived([LL], ([$LL]) => 
         uniqueId: "-1",
         media,
         volumeStore: localVolumeStore,
-        hasVideo: requestedCameraState,
+        hasVideo: derived(
+            mediaStreamConstraintsStore,
+            ($mediaStreamConstraintsStore) => $mediaStreamConstraintsStore.video !== false
+        ),
         // hasAudio = true because the webcam has a microphone attached and could potentially play sound
         hasAudio: writable(true),
         isMuted: derived(requestedMicrophoneState, (micState) => !micState),


### PR DESCRIPTION
The "hasVideo" store in the local camera was returning true if the user requested to start a webcam, irrespective of the status. We now rely on mediaStreamConstraintsStore to know if a video stream is to be expected or not.