### PR TITLE
Refactoring disconnect management

### DIFF
--- a/back/src/Controller/DebugController.ts
+++ b/back/src/Controller/DebugController.ts
@@ -32,26 +32,28 @@ export class DebugController {
 
     private getDump() {
         this.app.get("/dump", validateTokenMiddleware, (req: Request, res: Response): void => {
-            res.status(200).send(
-                dumpVariable(socketManager, (value: unknown) => {
-                    if (value && typeof value === "object" && value.constructor) {
-                        if (value.constructor.name === "uWS.WebSocket") {
-                            return "WebSocket";
-                        } else if (value.constructor.name === "ClientDuplexStreamImpl") {
-                            return "ClientDuplexStreamImpl";
-                        } else if (value.constructor.name === "ClientReadableStreamImpl") {
-                            return "ClientReadableStreamImpl";
-                        } else if (value.constructor.name === "ServerWritableStreamImpl") {
-                            return "ServerWritableStreamImpl";
-                        } else if (value.constructor.name === "ServerDuplexStreamImpl") {
-                            return "ServerDuplexStreamImpl";
-                        } else if (value.constructor.name === "Commander") {
-                            return "Commander";
+            res.status(200)
+                .contentType("text/plain")
+                .send(
+                    dumpVariable(socketManager, (value: unknown) => {
+                        if (value && typeof value === "object" && value.constructor) {
+                            if (value.constructor.name === "uWS.WebSocket") {
+                                return "WebSocket";
+                            } else if (value.constructor.name === "ClientDuplexStreamImpl") {
+                                return "ClientDuplexStreamImpl";
+                            } else if (value.constructor.name === "ClientReadableStreamImpl") {
+                                return "ClientReadableStreamImpl";
+                            } else if (value.constructor.name === "ServerWritableStreamImpl") {
+                                return "ServerWritableStreamImpl";
+                            } else if (value.constructor.name === "ServerDuplexStreamImpl") {
+                                return "ServerDuplexStreamImpl";
+                            } else if (value.constructor.name === "Commander") {
+                                return "Commander";
+                            }
                         }
-                    }
-                    return value;
-                })
-            );
+                        return value;
+                    })
+                );
         });
     }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -251,6 +251,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.back.rule=Host(`api.workadventure.localhost`)"
       - "traefik.http.routers.back.entryPoints=web"
+      - "traefik.http.routers.back.service=back"
       - "traefik.http.services.back.loadbalancer.server.port=8080"
 
   map-storage:

--- a/play/src/pusher/controllers/DebugController.ts
+++ b/play/src/pusher/controllers/DebugController.ts
@@ -19,7 +19,7 @@ export class DebugController extends BaseHttpController {
                 return;
             }
 
-            //res.header("Content-Type", "application/json");
+            res.contentType("text/plain");
 
             res.send(
                 dumpVariable(socketManager, (originalValue) => {

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -228,7 +228,6 @@ export class IoSocketController {
             maxPayloadLength: 16 * 1024 * 1024,
             maxBackpressure: 65536, // Maximum 64kB of data in the buffer.
             upgrade: (res, req, context) => {
-                console.log("upgrading websocket");
                 (async () => {
                     /* Keep track of abortions */
                     const upgradeAborted = { aborted: false };
@@ -1184,22 +1183,7 @@ export class IoSocketController {
                 }
 
                 const socket = ws as Socket;
-                try {
-                    socketData.disconnecting = true;
-                    socketManager.leaveRoom(socket);
-                    socketManager.leaveSpaces(socket).catch((error) => {
-                        console.error(error);
-                        Sentry.captureException(error);
-                    });
-                    socketManager.leaveChatRoomArea(socket).catch((error) => {
-                        console.error(error);
-                        Sentry.captureException(error);
-                    });
-                    socketData.currentChatRoomArea = [];
-                } catch (e) {
-                    Sentry.captureException(`An error occurred on "disconnect" ${e}`);
-                    console.error(e);
-                }
+                socketManager.cleanupSocket(socket);
             },
         });
     }

--- a/play/src/pusher/models/SpaceToBackForwarder.ts
+++ b/play/src/pusher/models/SpaceToBackForwarder.ts
@@ -178,12 +178,19 @@ export class SpaceToBackForwarder implements SpaceToBackForwarderInterface {
         if (!this._space.spaceStreamToBackPromise) {
             throw new Error("Space stream to back not found");
         }
-
         this._space.spaceStreamToBackPromise
             .then((spaceStreamToBack) => {
-                spaceStreamToBack.write({
-                    message: pusherToBackSpaceMessage,
-                });
+                spaceStreamToBack.write(
+                    {
+                        message: pusherToBackSpaceMessage,
+                    },
+                    (error: unknown) => {
+                        if (error) {
+                            console.log("Error while forwarding message to space back", error);
+                            Sentry.captureException(error);
+                        }
+                    }
+                );
 
                 if (pusherToBackSpaceMessage && pusherToBackSpaceMessage.$case) {
                     this._clientEventsEmitter.emitSpaceEvent(this._space.name, pusherToBackSpaceMessage.$case);

--- a/play/tests/pusher/SpaceToBackForwarder.test.ts
+++ b/play/tests/pusher/SpaceToBackForwarder.test.ts
@@ -287,12 +287,15 @@ describe("SpaceToBackForwarder", () => {
             spaceForwarder.updateUser(spaceUser, ["name"]);
             await flushPromises();
 
-            expect(mockWriteFunction).toHaveBeenCalledWith({
-                message: {
-                    $case: "updateSpaceUserMessage",
-                    updateSpaceUserMessage: { spaceName: "test", user: spaceUser, updateMask: ["name"] },
+            expect(mockWriteFunction).toHaveBeenCalledWith(
+                {
+                    message: {
+                        $case: "updateSpaceUserMessage",
+                        updateSpaceUserMessage: { spaceName: "test", user: spaceUser, updateMask: ["name"] },
+                    },
                 },
-            });
+                expect.any(Function)
+            );
             expect(mockWriteFunction).toHaveBeenCalledOnce();
         });
         it("should throw an error when the user is not found in pusher local connected user", () => {
@@ -583,17 +586,20 @@ describe("SpaceToBackForwarder", () => {
             });
             await flushPromises();
 
-            expect(mockWriteFunction).toHaveBeenCalledWith({
-                message: {
-                    $case: "updateSpaceMetadataMessage",
-                    updateSpaceMetadataMessage: {
-                        spaceName: "world.test",
-                        metadata: JSON.stringify({
-                            "metadata-1": "value-1",
-                        }),
+            expect(mockWriteFunction).toHaveBeenCalledWith(
+                {
+                    message: {
+                        $case: "updateSpaceMetadataMessage",
+                        updateSpaceMetadataMessage: {
+                            spaceName: "world.test",
+                            metadata: JSON.stringify({
+                                "metadata-1": "value-1",
+                            }),
+                        },
                     },
                 },
-            });
+                expect.any(Function)
+            );
             expect(mockWriteFunction).toHaveBeenCalledOnce();
         });
     });
@@ -634,17 +640,20 @@ describe("SpaceToBackForwarder", () => {
             });
             await flushPromises();
 
-            expect(mockWriteFunction).toHaveBeenCalledWith({
-                message: {
-                    $case: "updateSpaceMetadataMessage",
-                    updateSpaceMetadataMessage: {
-                        spaceName: "test",
-                        metadata: JSON.stringify({
-                            "metadata-1": "value-1",
-                        }),
+            expect(mockWriteFunction).toHaveBeenCalledWith(
+                {
+                    message: {
+                        $case: "updateSpaceMetadataMessage",
+                        updateSpaceMetadataMessage: {
+                            spaceName: "test",
+                            metadata: JSON.stringify({
+                                "metadata-1": "value-1",
+                            }),
+                        },
                     },
                 },
-            });
+                expect.any(Function)
+            );
             expect(mockWriteFunction).toHaveBeenCalledOnce();
         });
 
@@ -724,12 +733,15 @@ describe("SpaceToBackForwarder", () => {
             spaceForwarder.syncLocalUsersWithServer([spaceUser]);
             await flushPromises();
 
-            expect(mockWriteFunction).toHaveBeenCalledWith({
-                message: {
-                    $case: "syncSpaceUsersMessage",
-                    syncSpaceUsersMessage: { spaceName: "test", users: [spaceUser] },
+            expect(mockWriteFunction).toHaveBeenCalledWith(
+                {
+                    message: {
+                        $case: "syncSpaceUsersMessage",
+                        syncSpaceUsersMessage: { spaceName: "test", users: [spaceUser] },
+                    },
                 },
-            });
+                expect.any(Function)
+            );
             expect(mockWriteFunction).toHaveBeenCalledOnce();
         });
     });

--- a/tests/tests/spaces.spec.ts
+++ b/tests/tests/spaces.spec.ts
@@ -13,7 +13,7 @@ test.describe("Spaces @nomobile @nowebkit", () => {
             "Skip on mobile and WebKit, this is a mostly back test"
         );
     });
-    test("purges spaces if back restarts @slow",
+    test("purges spaces if back restarts @docker @slow",
         async ({ browser, request }) => {
             await using page = await getPage(browser, 'Alice', publicTestMapUrl("tests/E2E/empty.json", "spaces"));
 

--- a/tests/tests/spaces.spec.ts
+++ b/tests/tests/spaces.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import {publicTestMapUrl} from "./utils/urls";
+import { getPage } from "./utils/auth"
+import {isMobile} from "./utils/isMobile";
+import {getBackDump, getPusherDump} from "./utils/debug";
+import {rebootBack} from "./utils/containers";
+
+test.setTimeout(180_000);
+test.describe("Spaces @nomobile @nowebkit", () => {
+    test.beforeEach(async ({ page, browserName }) => {
+        test.skip(
+            isMobile(page) || browserName === "webkit",
+            "Skip on mobile and WebKit, this is a mostly back test"
+        );
+    });
+    test("purges spaces if back restarts @slow",
+        async ({ browser, request }) => {
+            await using page = await getPage(browser, 'Alice', publicTestMapUrl("tests/E2E/empty.json", "spaces"));
+
+
+            await expect.poll(() => getBackDump()).toContain("Alice");
+            await expect.poll(() => getPusherDump()).toContain("Alice");
+
+            await page.close();
+            await page.context().close();
+
+            // Wait for the user to be removed from the spaces
+            await expect.poll(() => getBackDump(), { timeout: 60_000 }).not.toContain("Alice");
+            await expect.poll(() => getPusherDump(), { timeout: 60_000 }).not.toContain("Alice");
+
+
+            // Let's reopen the page
+            await using page2 = await getPage(browser, 'Alice', publicTestMapUrl("tests/E2E/empty.json", "spaces"));
+
+            await expect.poll(() => getBackDump()).toContain("Alice");
+            await expect.poll(() => getPusherDump()).toContain("Alice");
+
+            // Now, restart the back
+            await rebootBack();
+
+            await expect(page2.getByText("Connecting")).toBeVisible();
+
+            // Wait for the user to be removed from the spaces
+            await expect.poll(() => getPusherDump(), { timeout: 10_000 }).not.toContain("Alice");
+            //await expect(getBackDump()).not.toContain("Alice");
+
+            await page2.context().close();
+        });
+});
+


### PR DESCRIPTION
Refactoring the way we handle disconnects in the watcher between pusher and back Adding a E2E test to check the spaces are correctly cleaned up in pusher when a disconnect happens.