### PR TITLE
Refactoring live streaming store

### DIFF
--- a/play/src/front/Components/ActionBar/MenuIcons/MapSubMenu.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/MapSubMenu.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
     import { clickOutside } from "svelte-outside";
     import { getContext, setContext } from "svelte";
-    import { streamingMegaphoneStore } from "../../../Stores/MediaStore";
     import { mapMenuVisibleStore, openedMenuStore } from "../../../Stores/MenuStore";
     import { LL } from "../../../../i18n/i18n-svelte";
     import AdminPanIcon from "../../Icons/AdminPanIcon.svelte";
     import ChevronDownIcon from "../../Icons/ChevronDownIcon.svelte";
-    import MegaphoneConfirm from "../MegaphoneConfirm.svelte";
     import { createFloatingUiActions } from "../../../Utils/svelte-floatingui";
     import MapSubMenuContent from "./MapSubMenuContent.svelte";
     import HeaderMenuItem from "./HeaderMenuItem.svelte";
@@ -92,9 +90,6 @@
                     <!--    </li>-->
                     <!--{/if}-->
                 </div>
-                {#if $streamingMegaphoneStore}
-                    <MegaphoneConfirm />
-                {/if}
             </div>
         {/if}
     {:else}

--- a/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
+++ b/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
@@ -167,17 +167,13 @@
         analyticsClient.startMegaphone();
         currentLiveStreamingSpaceStore.set($megaphoneSpaceStore);
         requestedMegaphoneStore.set(true);
-        $megaphoneSpaceStore?.emitUpdateUser({
-            megaphoneState: true,
-        });
+        $megaphoneSpaceStore?.startStreaming();
         //close();
     }
 
     function stopLive() {
         analyticsClient.stopMegaphone();
-        $megaphoneSpaceStore?.emitUpdateUser({
-            megaphoneState: false,
-        });
+        $megaphoneSpaceStore?.stopStreaming();
         currentLiveStreamingSpaceStore.set(undefined);
         requestedMegaphoneStore.set(false);
         close();

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -34,14 +34,7 @@ import { chatVisibilityStore, chatZoneLiveStore } from "../../../Stores/ChatStor
  * @DEPRECATED - This is the old way to show trigger message
  import { layoutManagerActionStore } from "../../../Stores/LayoutManagerStore";
  */
-import {
-    inJitsiStore,
-    inLivekitStore,
-    inOpenWebsite,
-    isSpeakerStore,
-    silentStore,
-    streamingMegaphoneStore,
-} from "../../../Stores/MediaStore";
+import { inJitsiStore, inLivekitStore, inOpenWebsite, isSpeakerStore, silentStore } from "../../../Stores/MediaStore";
 import { currentLiveStreamingSpaceStore } from "../../../Stores/MegaphoneStore";
 import { notificationPlayingStore } from "../../../Stores/NotificationStore";
 import type { CoWebsite } from "../../../WebRtc/CoWebsite/CoWebsite";
@@ -1067,11 +1060,9 @@ export class AreasPropertiesListener {
             const space = await this.scene.broadcastService.joinSpace(uniqRoomName);
             currentLiveStreamingSpaceStore.set(space);
             isSpeakerStore.set(true);
-            streamingMegaphoneStore.set(true);
+            //streamingMegaphoneStore.set(true);
 
-            space.emitUpdateUser({
-                megaphoneState: true,
-            });
+            space.startStreaming();
 
             bindMuteEventsToSpace(space);
 
@@ -1092,7 +1083,8 @@ export class AreasPropertiesListener {
                 Sentry.captureException(e);
             });
 
-            streamingMegaphoneStore.set(false);
+            //streamingMegaphoneStore.set(false);
+
             if (property.chatEnabled) {
                 //this.handleLeaveMucRoom(uniqRoomName);
             }

--- a/play/src/front/Space/SpaceInterface.ts
+++ b/play/src/front/Space/SpaceInterface.ts
@@ -77,6 +77,24 @@ export interface SpaceInterface {
     readonly usersStore: Readable<Map<string, SpaceUserExtended>>;
     //removeUser(userId: number): void;
     //updateUserData(userdata: Partial<SpaceUser>): void;
+    /**
+     * Start streaming the local camera and microphone to other users in the space.
+     * This will trigger an error if the filter type is ALL_USERS (because everyone is always streaming in a ALL_USERS space).
+     */
+    startStreaming(): void;
+
+    /**
+     * Stop streaming the local camera and microphone to other users in the space.
+     * This will trigger an error if the filter type is ALL_USERS (because everyone is always streaming in a ALL_USERS space).
+     */
+    stopStreaming(): void;
+
+    /**
+     * This store returns true if the local user is currently streaming their camera and microphone to other users in the space.
+     * In a ALL_USERS space, this store will always return true.
+     * In a LIVE_STREAMING_USERS, this store will return true when the startStreaming() method has been called, and false when the stopStreaming() method has been called.
+     */
+    readonly isStreamingStore: Readable<boolean>;
 
     /**
      * Use this observer to get a description of new users.

--- a/play/src/front/Space/SpaceRegistry/SpaceRegistry.ts
+++ b/play/src/front/Space/SpaceRegistry/SpaceRegistry.ts
@@ -109,6 +109,28 @@ export class SpaceRegistry implements SpaceRegistryInterface {
         return unsubscribe;
     });
 
+    public readonly isLiveStreamingStore: Readable<boolean> = derived(this.spaces, ($spaces, set) => {
+        if ($spaces.size === 0) {
+            set(false);
+            return () => {};
+        }
+
+        const stores = Array.from($spaces.values(), (space) => space.isStreamingStore);
+        return derived(stores, (list) => list.some(Boolean)).subscribe(set);
+
+        /*const spaceStores = Array.from($spaces.values()).map((space) => space.isStreamingStore);
+
+        const combinedStore = derived(spaceStores, (isStreamingList) => {
+            return isStreamingList.some((isStreaming) => isStreaming);
+        });
+
+        const unsubscribe = combinedStore.subscribe((result) => {
+            set(result);
+        });
+
+        return unsubscribe;*/
+    });
+
     constructor(
         private roomConnection: RoomConnectionForSpacesInterface,
         private connectStream = connectionManager.roomConnectionStream,

--- a/play/src/front/Space/SpaceRegistry/SpaceRegistryInterface.ts
+++ b/play/src/front/Space/SpaceRegistry/SpaceRegistryInterface.ts
@@ -17,4 +17,5 @@ export interface SpaceRegistryInterface {
     destroy(): Promise<void>;
     videoStreamStore: Readable<Map<string, VideoBox>>;
     screenShareStreamStore: Readable<Map<string, VideoBox>>;
+    readonly isLiveStreamingStore: Readable<boolean>;
 }

--- a/play/src/front/Space/Utils/SpaceScriptingBridge.ts
+++ b/play/src/front/Space/Utils/SpaceScriptingBridge.ts
@@ -2,7 +2,6 @@ import { Subscription } from "rxjs";
 import { get } from "svelte/store";
 import { SpaceInterface, SpaceUserExtended } from "../SpaceInterface";
 import { CheckedWorkAdventureMessagePort } from "../../Api/Iframe/CheckedWorkAdventureMessagePort";
-import { streamingMegaphoneStore } from "../../Stores/MediaStore";
 
 /**
  * Represents a bridge between one Space and the scripting API.
@@ -102,21 +101,14 @@ export class SpaceScriptingBridge {
                 case "leave": {
                     this.leave();
                     this.onSpaceLeft();
-                    streamingMegaphoneStore.set(false);
                     break;
                 }
                 case "startStreaming": {
-                    streamingMegaphoneStore.set(true);
-                    this.space.emitUpdateUser({
-                        megaphoneState: true,
-                    });
+                    this.space.startStreaming();
                     break;
                 }
                 case "stopStreaming": {
-                    this.space.emitUpdateUser({
-                        megaphoneState: false,
-                    });
-                    streamingMegaphoneStore.set(false);
+                    this.space.stopStreaming();
                     break;
                 }
                 case "setMetadata": {

--- a/play/src/front/Stores/IsStreamingStore.ts
+++ b/play/src/front/Stores/IsStreamingStore.ts
@@ -1,0 +1,15 @@
+import { derived, Readable } from "svelte/store";
+import { gameSceneStore } from "./GameSceneStore";
+
+/**
+ * This store is true if we are expected to speak (live stream, talk in a bubble, ...) in any space.
+ */
+export const isLiveStreamingStore: Readable<boolean> = derived(gameSceneStore, ($gameSceneStore, set) => {
+    if ($gameSceneStore == null) {
+        set(false);
+        return;
+    }
+    return $gameSceneStore.spaceRegistry.isLiveStreamingStore.subscribe((isLive) => {
+        set(isLive);
+    });
+});

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -19,7 +19,8 @@ import { privacyShutdownStore } from "./PrivacyShutdownStore";
 import { inExternalServiceStore, myCameraStore, myMicrophoneStore, proximityMeetingStore } from "./MyMediaStore";
 import { userMovingStore } from "./GameStore";
 import { hideHelpCameraSettings } from "./HelpSettingsStore";
-import { videoStreamElementsStore } from "./PeerStore";
+import { isLiveStreamingStore } from "./IsStreamingStore";
+
 /**
  * A store that contains the camera state requested by the user (on or off).
  */
@@ -268,32 +269,29 @@ export const cameraEnergySavingStore = derived(
     [
         deviceChanged10SecondsAgoStore,
         userMoved5SecondsAgoStore,
-        videoStreamElementsStore,
         enabledWebCam10secondsAgoStore,
         mouseIsHoveringCameraButton,
         cameraNoEnergySavingStore,
-        streamingMegaphoneStore,
         devicesNotLoaded,
+        isLiveStreamingStore,
     ],
     ([
         $deviceChanged10SecondsAgoStore,
         $userMoved5SecondsAgoStore,
-        $videoStreamElementsStore,
         $enabledWebCam10secondsAgoStore,
         $mouseInBottomRight,
         $cameraNoEnergySavingStore,
-        $streamingMegaphoneStore,
         $devicesNotLoaded,
+        $isLiveStreamingStore,
     ]) => {
         return (
             !$mouseInBottomRight &&
             !$userMoved5SecondsAgoStore &&
             !$deviceChanged10SecondsAgoStore &&
-            $videoStreamElementsStore.length === 0 &&
             !$enabledWebCam10secondsAgoStore &&
             !$cameraNoEnergySavingStore &&
             !$devicesNotLoaded &&
-            !$streamingMegaphoneStore
+            !$isLiveStreamingStore
         );
     }
 );

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -27,6 +27,7 @@ import {
 import { currentPlayerWokaStore } from "./CurrentPlayerWokaStore";
 import { screenShareStreamElementsStore, videoStreamElementsStore } from "./PeerStore";
 import { windowSize } from "./CoWebsiteStore";
+import { isLiveStreamingStore } from "./IsStreamingStore";
 
 //export type Streamable = RemotePeer | ScreenSharingLocalMedia | JitsiTrackStreamWrapper;
 
@@ -167,6 +168,7 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
             silentStore,
             requestedCameraState,
             windowSize,
+            isLiveStreamingStore,
         ],
         (
             [
@@ -180,6 +182,7 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
                 $silentStore,
                 $requestedCameraState,
                 $windowSize,
+                $isLiveStreamingStore,
             ] /*, set*/
         ) => {
             const peers = new Map<string, VideoBox>();
@@ -197,11 +200,7 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
                 let shouldAddMyCamera = true;
                 // Are we the only one to display video AND are we not publishing a video stream? If so, let's hide the video.
                 // Are we the only one to display video AND we are on a small screen? If so, let's hide the video (because the webcam takes space and makes iPhones laggy when it starts)
-                if (
-                    $screenShareStreamElementsStore.length === 0 &&
-                    $videoStreamElementsStore.length === 0 &&
-                    (!$requestedCameraState || $windowSize.width < 768)
-                ) {
+                if (!$isLiveStreamingStore && (!$requestedCameraState || $windowSize.width < 768)) {
                     shouldAddMyCamera = false;
                 }
 


### PR DESCRIPTION
We add a new liveStreamingStore (boolean) that tells whether we are streaming / talking in at least one space. This store comes from the spaceRegistry, which itself derives it from all spaces joined.

If we are in a space with "ALL_USERS" filter, we consider to be live-streaming. Otherwise, we are streaming in a space when the new space.startStreaming() method is called.