### PR TITLE
Fix Jitsi Meet host with non-standard ports

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -372,6 +372,7 @@ jobs:
         env:
           RENDERER_MODE: ${{ matrix.renderer }}
           NO_FLAKY: ${{ steps.check-no-flaky.outputs.has_no_flaky_label }}
+          IS_FORK: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != 'workadventure') && (github.event_name == 'pull_request' || github.repository_owner != 'workadventure') }}
       - name: Display docker compose logs on failure
         run: docker compose -f docker-compose.yaml -f docker-compose.e2e.yml logs
         if: failure()

--- a/play/src/front/Components/Cowebsites/JistiCowebsiteComponent.svelte
+++ b/play/src/front/Components/Cowebsites/JistiCowebsiteComponent.svelte
@@ -136,7 +136,7 @@
                         resolve();
                     };
 
-                    jitsiApi = new window.JitsiMeetExternalAPI(new URL(domain).hostname, options);
+                    jitsiApi = new window.JitsiMeetExternalAPI(new URL(domain).host, options);
 
                     jitsiApi.addListener("videoConferenceJoined", onVideoConferenceJoined);
 

--- a/tests/tests/chat/matrixChat.spec.ts
+++ b/tests/tests/chat/matrixChat.spec.ts
@@ -143,6 +143,8 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     await page.context().close();
   });
   test("Send application messages and klaxoon link in public chat room", async ({ browser }) => {
+    test.skip(process.env.IS_FORK === "true", "Skip Klaxoon test on forked PR because the secret env variable is not set");
+
     await using page = await getPage(browser, 'Alice', Map.url("empty"));
     await oidcMatrixUserLogin(page);
     await ChatUtils.openChat(page);

--- a/tests/tests/map_editor.spec.ts
+++ b/tests/tests/map_editor.spec.ts
@@ -201,6 +201,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
     // Test to set Klaxoon application in the area with the map editor
     test("Successfully set Klaxoon's application in the area in the map editor", async ({ browser, request }) => {
+        test.skip(process.env.IS_FORK === "true", "Skip Klaxoon test on forked PR because the secret env variable is not set");
+
         await resetWamMaps(request);
         await using page = await getPage(browser, "Admin1", Map.url("empty"));
 


### PR DESCRIPTION
The `.hostname` property of an `URL` object does not expose the port. When setting the `JITSI_URL` environment variable to a value with a non-standard port, it was discarded when used as the `<iframe>` source.