### PR TITLE
Fixing the flicker when coming back to a tab

### DIFF
--- a/back/src/Services/GaugeManager.ts
+++ b/back/src/Services/GaugeManager.ts
@@ -50,7 +50,6 @@ class GaugeManager {
         /* eslint rxjs/no-ignored-subscription: "off", svelte/no-ignored-unsubscribe: "off" */
 
         clientEventsEmitter.spaceUpdatedSubject.subscribe((space: Space) => {
-            console.log("GaugeManager: space updated", space.name);
             let spaceStats = this.worldStats.get(space.world);
             if (!spaceStats) {
                 spaceStats = { publishers: 0, watchers: 0 };
@@ -66,12 +65,10 @@ class GaugeManager {
         });
 
         clientEventsEmitter.newSpaceSubject.subscribe((space: Space) => {
-            console.log("GaugeManager: space created", space.name);
             this.nbSpacesGauge.inc();
         });
 
         clientEventsEmitter.deleteSpaceSubject.subscribe((space: Space) => {
-            console.log("GaugeManager: space deleted", space.name);
             this.nbSpacesGauge.dec();
             const spaceStats = this.worldStats.get(space.world);
             if (spaceStats) {

--- a/livekit-config.yaml
+++ b/livekit-config.yaml
@@ -16,5 +16,5 @@ keys:
     devkey: 12345678901234567890123456789012
 logging:
   json: false
-  level: debug
-
+  #level: debug
+  level: info

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3090,19 +3090,7 @@ ${escapedMessage}
         });
 
         iframeListener.registerAnswerer("teleportPlayerTo", (message) => {
-            this.CurrentPlayer.x = message.x;
-            this.CurrentPlayer.y = message.y;
-            this.CurrentPlayer.finishFollowingPath(true);
-            // clear properties in case we are moved on the same layer / area in order to trigger them
-            //this.gameMapFrontWrapper.clearCurrentProperties();
-
-            /*this.handleCurrentPlayerHasMovedEvent({
-                x: message.x,
-                y: message.y,
-                direction: this.CurrentPlayer.lastDirection,
-                moving: false,
-            });*/
-            this.markDirty();
+            this.CurrentPlayer.teleportTo(message.x, message.y);
         });
 
         iframeListener.registerAnswerer("getWoka", () => {

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -130,13 +130,19 @@ export class Player extends Character {
     }
 
     public finishFollowingPath(cancelled = false): void {
+        let wasFollowing = false;
+        if (this.pathToFollow || this.followingPathPromiseResolve) {
+            wasFollowing = true;
+        }
         this.pathToFollow = undefined;
         this.pathWalkingSpeed = undefined;
         this.currentPathSegmentDistanceFromStart = 0;
         this.stop();
         this.followingPathPromiseResolve?.call(this, { x: this.x, y: this.y, cancelled });
         this.getBody().setDirectControl(false);
-        this.emit(hasMovedEventName, { moving: false, direction: this._lastDirection, x: this.x, y: this.y });
+        if (wasFollowing) {
+            this.emit(hasMovedEventName, { moving: false, direction: this._lastDirection, x: this.x, y: this.y });
+        }
     }
 
     private deduceSpeed(speedUp: boolean, followMode: boolean): number {
@@ -338,6 +344,16 @@ export class Player extends Character {
             this.companion.setTarget(this.x, this.y, this._lastDirection);
         }
     }
+
+    public teleportTo(x: number, y: number): void {
+        this.x = x;
+        this.y = y;
+        this.setDepth(this.y + 16);
+        this.finishFollowingPath(true);
+        this.emit(hasMovedEventName, { moving: false, direction: this._lastDirection, x: this.x, y: this.y });
+        this.scene.markDirty();
+    }
+
     destroy(): void {
         this.unsubscribeVisibilityStore();
         //this.unsubscribeLayoutManagerActionStore();


### PR DESCRIPTION
When moving out of a tab, the movement was "stopped" (in case you were walking to some point), which waas triggering a movement, therefore a reset of the timer of the "oneLine" store. We don't do that anymore and switching tabs won't trigger video changes anymore.

Also: putting Livekit config to info, and removing logs for GaugeManager in the back.