### PR TITLE
Fixing PiP triggered when alone

### DIFF
--- a/play/src/front/Components/Video/PictureInPicture.svelte
+++ b/play/src/front/Components/Video/PictureInPicture.svelte
@@ -3,7 +3,7 @@
     import { Unsubscriber } from "svelte/store";
     import { z } from "zod";
     import Debug from "debug";
-    import { streamableCollectionStore } from "../../Stores/StreamableCollectionStore";
+    import { isInRemoteConversation, streamableCollectionStore } from "../../Stores/StreamableCollectionStore";
     import { activePictureInPictureStore } from "../../Stores/PeerStore";
     import { visibilityStore } from "../../Stores/VisibilityStore";
     import { localUserStore } from "../../Connection/LocalUserStore";
@@ -73,8 +73,8 @@
         activePictureInPictureStore.set(false);
     }
 
-    const unsubscribeStreamablePictureInPictureStore = streamableCollectionStore.subscribe((streamables) => {
-        if (streamables.size == 0) {
+    const unsubscribeIsInRemoteConversation = isInRemoteConversation.subscribe((isTalking) => {
+        if (!isTalking) {
             destroyPictureInPictureComponent();
         }
     });
@@ -84,8 +84,10 @@
     function requestPictureInPicture() {
         debug("Request Picture in Picture mode");
 
-        // We activate the picture in picture mode only if we have a streamable in the collection
-        if ($streamableCollectionStore.size == 1) return;
+        // We activate the picture in picture mode only if we are in a remote conversation
+        if (!$isInRemoteConversation) {
+            return;
+        }
 
         if (pipWindow !== undefined || pipRequested) return;
 
@@ -183,7 +185,7 @@
 
     onDestroy(() => {
         destroyPictureInPictureComponent();
-        unsubscribeStreamablePictureInPictureStore();
+        unsubscribeIsInRemoteConversation();
     });
 </script>
 


### PR DESCRIPTION
Following the streamableCollectionStore refactor, we now use the isInRemoteConversation store to decide if we should open the picture-in-picture mode or not.