### PR TITLE
Smoother transitions between Livekit and WebRTC

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -758,6 +758,7 @@ jobs:
             GOOGLE_SHEETS_ENABLED: true
             GOOGLE_SLIDES_ENABLED: true
             DEBUG: \"*\"
+            MAX_USERS_FOR_WEBRTC: \"3\"
           commonSecretEnv:
             ADMIN_API_TOKEN: \"${ADMIN_API_TOKEN}\"
             ADMIN_SOCKETS_TOKEN: \"${ADMIN_SOCKETS_TOKEN}\"

--- a/back/src/Model/CommunicationManager.ts
+++ b/back/src/Model/CommunicationManager.ts
@@ -23,7 +23,6 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserAdded(user);
         if (nextState) {
             this.setState(nextState);
-            //await nextState.handleUserAdded(user);
         }
     }
 
@@ -32,7 +31,6 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserDeleted(user);
         if (nextState) {
             this.setState(nextState);
-            //await nextState.handleUserDeleted(user);
         }
     }
 
@@ -40,7 +38,6 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserUpdated(user);
         if (nextState) {
             this.setState(nextState);
-            //await nextState.handleUserUpdated(user);
         }
     }
 
@@ -49,7 +46,6 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserToNotifyAdded(user);
         if (nextState) {
             this.setState(nextState);
-            //await nextState.handleUserToNotifyAdded(user);
         }
     }
 
@@ -58,7 +54,6 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserToNotifyDeleted(user);
         if (nextState) {
             this.setState(nextState);
-            //await nextState.handleUserToNotifyDeleted(user);
         }
     }
 

--- a/back/src/Model/CommunicationManager.ts
+++ b/back/src/Model/CommunicationManager.ts
@@ -23,7 +23,7 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserAdded(user);
         if (nextState) {
             this.setState(nextState);
-            await nextState.handleUserAdded(user);
+            //await nextState.handleUserAdded(user);
         }
     }
 
@@ -32,7 +32,7 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserDeleted(user);
         if (nextState) {
             this.setState(nextState);
-            await nextState.handleUserDeleted(user);
+            //await nextState.handleUserDeleted(user);
         }
     }
 
@@ -40,7 +40,7 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserUpdated(user);
         if (nextState) {
             this.setState(nextState);
-            await nextState.handleUserUpdated(user);
+            //await nextState.handleUserUpdated(user);
         }
     }
 
@@ -49,7 +49,7 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserToNotifyAdded(user);
         if (nextState) {
             this.setState(nextState);
-            await nextState.handleUserToNotifyAdded(user);
+            //await nextState.handleUserToNotifyAdded(user);
         }
     }
 
@@ -58,7 +58,7 @@ export class CommunicationManager implements ICommunicationManager {
         const nextState = await this._currentState.handleUserToNotifyDeleted(user);
         if (nextState) {
             this.setState(nextState);
-            await nextState.handleUserToNotifyDeleted(user);
+            //await nextState.handleUserToNotifyDeleted(user);
         }
     }
 

--- a/back/src/Model/CommunicationManager.ts
+++ b/back/src/Model/CommunicationManager.ts
@@ -5,67 +5,115 @@ import { ICommunicationSpace } from "./Interfaces/ICommunicationSpace";
 import { WebRTCState } from "./States/WebRTCState";
 import { ICommunicationManager } from "./Interfaces/ICommunicationManager";
 import { ICommunicationState } from "./Interfaces/ICommunicationState";
-import { DefaultState } from "./States/DefaultState";
+import { VoidState } from "./States/VoidState";
 
 export class CommunicationManager implements ICommunicationManager {
     private _currentState: ICommunicationState;
+    private _toFinalizeState: ICommunicationState | undefined;
+    private _finalizeStateTimeout: ReturnType<typeof setTimeout> | undefined;
+    private users: Map<string, SpaceUser> = new Map<string, SpaceUser>();
+    private usersToNotify: Map<string, SpaceUser> = new Map<string, SpaceUser>();
 
     constructor(private readonly space: ICommunicationSpace) {
         this._currentState = this.getInitialState();
     }
 
-    public handleUserAdded(user: SpaceUser): void {
-        this._currentState.handleUserAdded(user).catch((e) => {
-            Sentry.captureException(e);
-            console.error(e);
-        });
+    public async handleUserAdded(user: SpaceUser): Promise<void> {
+        this.users.set(user.spaceUserId, user);
+        const nextState = await this._currentState.handleUserAdded(user);
+        if (nextState) {
+            this.setState(nextState);
+            await nextState.handleUserAdded(user);
+        }
     }
 
-    public handleUserDeleted(user: SpaceUser): void {
-        this._currentState.handleUserDeleted(user).catch((e) => {
-            Sentry.captureException(e);
-            console.error(e);
-        });
+    public async handleUserDeleted(user: SpaceUser): Promise<void> {
+        this.users.delete(user.spaceUserId);
+        const nextState = await this._currentState.handleUserDeleted(user);
+        if (nextState) {
+            this.setState(nextState);
+            await nextState.handleUserDeleted(user);
+        }
     }
 
-    public handleUserUpdated(user: SpaceUser): void {
-        this._currentState.handleUserUpdated(user).catch((e) => {
-            Sentry.captureException(e);
-            console.error(e);
-        });
+    public async handleUserUpdated(user: SpaceUser): Promise<void> {
+        const nextState = await this._currentState.handleUserUpdated(user);
+        if (nextState) {
+            this.setState(nextState);
+            await nextState.handleUserUpdated(user);
+        }
     }
 
-    public handleUserReadyForSwitch(userId: string): void {
-        this._currentState.handleUserReadyForSwitch(userId).catch((e) => {
-            Sentry.captureException(e);
-            console.error(e);
-        });
+    public async handleUserToNotifyAdded(user: SpaceUser): Promise<void> {
+        this.usersToNotify.set(user.spaceUserId, user);
+        const nextState = await this._currentState.handleUserToNotifyAdded(user);
+        if (nextState) {
+            this.setState(nextState);
+            await nextState.handleUserToNotifyAdded(user);
+        }
     }
 
-    public handleUserToNotifyAdded(user: SpaceUser): void {
-        this._currentState.handleUserToNotifyAdded(user).catch((e) => {
-            Sentry.captureException(e);
-            console.error(e);
-        });
+    public async handleUserToNotifyDeleted(user: SpaceUser): Promise<void> {
+        this.usersToNotify.delete(user.spaceUserId);
+        const nextState = await this._currentState.handleUserToNotifyDeleted(user);
+        if (nextState) {
+            this.setState(nextState);
+            await nextState.handleUserToNotifyDeleted(user);
+        }
     }
 
-    public handleUserToNotifyDeleted(user: SpaceUser): void {
-        this._currentState.handleUserToNotifyDeleted(user).catch((e) => {
-            Sentry.captureException(e);
-            console.error(e);
-        });
-    }
-    public setState(state: ICommunicationState): void {
+    /**
+     * Sets the current communication state.
+     * After 5 seconds, the previous state will be finalized.
+     * If a new state is set before the timeout, the previous state will be finalized immediately.
+     */
+    private setState(state: ICommunicationState): void {
+        if (this._toFinalizeState) {
+            this.finalizeState(this._toFinalizeState);
+            if (this._finalizeStateTimeout) {
+                clearTimeout(this._finalizeStateTimeout);
+                this._finalizeStateTimeout = undefined;
+            }
+        }
+        this._toFinalizeState = this._currentState;
         this._currentState = state;
+
+        // Dispatch the new state to all users
+        this._toFinalizeState.switchState(state.communicationType);
+
+        // We initialize the new state after having dispatched the switch event so that the objects listening
+        // to the state change event are ready on the front side.
+        state.init();
+
+        this._finalizeStateTimeout = setTimeout(() => {
+            if (this._toFinalizeState) {
+                try {
+                    this.finalizeState(this._toFinalizeState);
+                } catch (e) {
+                    console.error("Error while finalizing state:", e);
+                    Sentry.captureException(e);
+                }
+            }
+            this._finalizeStateTimeout = undefined;
+            this._toFinalizeState = undefined;
+        }, 5000);
     }
 
     private getInitialState(): ICommunicationState {
         const propertiesToSync = this.space.getPropertiesToSync();
-        return this.hasMediaProperties(propertiesToSync) ? new WebRTCState(this.space, this) : new DefaultState();
+        const state = this.hasMediaProperties(propertiesToSync)
+            ? new WebRTCState(this.space, this.users, this.usersToNotify)
+            : new VoidState();
+        state.init();
+        return state;
     }
 
     private hasMediaProperties(properties: string[]): boolean {
         return properties.some((prop) => ["cameraState", "microphoneState", "screenSharingState"].includes(prop));
+    }
+
+    private finalizeState(toFinalizeState: ICommunicationState) {
+        toFinalizeState.finalize();
     }
 }
 

--- a/back/src/Model/Interfaces/ICommunicationManager.ts
+++ b/back/src/Model/Interfaces/ICommunicationManager.ts
@@ -1,12 +1,9 @@
 import { SpaceUser } from "@workadventure/messages";
-import { ICommunicationState } from "./ICommunicationState";
 
 export interface ICommunicationManager {
-    handleUserAdded(user: SpaceUser): void;
-    handleUserDeleted(user: SpaceUser): void;
-    handleUserUpdated(user: SpaceUser): void;
-    handleUserReadyForSwitch(userId: string): void;
-    handleUserToNotifyAdded(user: SpaceUser): void;
-    handleUserToNotifyDeleted(user: SpaceUser): void;
-    setState(state: ICommunicationState): void;
+    handleUserAdded(user: SpaceUser): Promise<void>;
+    handleUserDeleted(user: SpaceUser): Promise<void>;
+    handleUserUpdated(user: SpaceUser): Promise<void>;
+    handleUserToNotifyAdded(user: SpaceUser): Promise<void>;
+    handleUserToNotifyDeleted(user: SpaceUser): Promise<void>;
 }

--- a/back/src/Model/Interfaces/ICommunicationState.ts
+++ b/back/src/Model/Interfaces/ICommunicationState.ts
@@ -1,10 +1,13 @@
 import { SpaceUser } from "@workadventure/messages";
 
 export interface ICommunicationState {
-    handleUserAdded(user: SpaceUser): Promise<void>;
-    handleUserDeleted(user: SpaceUser): Promise<void>;
-    handleUserUpdated(user: SpaceUser): Promise<void>;
-    handleUserReadyForSwitch(userId: string): Promise<void>;
-    handleUserToNotifyAdded(user: SpaceUser): Promise<void>;
-    handleUserToNotifyDeleted(user: SpaceUser): Promise<void>;
+    get communicationType(): string;
+    init(): void;
+    handleUserAdded(user: SpaceUser): Promise<ICommunicationState | void>;
+    handleUserDeleted(user: SpaceUser): Promise<ICommunicationState | void>;
+    handleUserUpdated(user: SpaceUser): Promise<ICommunicationState | void>;
+    handleUserToNotifyAdded(user: SpaceUser): Promise<ICommunicationState | void>;
+    handleUserToNotifyDeleted(user: SpaceUser): Promise<ICommunicationState | void>;
+    switchState(targetCommunicationType: string): void;
+    finalize(): void;
 }

--- a/back/src/Model/Interfaces/ICommunicationStrategy.ts
+++ b/back/src/Model/Interfaces/ICommunicationStrategy.ts
@@ -6,7 +6,7 @@ export interface ICommunicationStrategy {
     updateUser(user: SpaceUser): void;
     addUserToNotify(user: SpaceUser): Promise<void>;
     deleteUserFromNotify(user: SpaceUser): void;
-    initialize(): void;
+    initialize(users: ReadonlyMap<string, SpaceUser>, usersToNotify: ReadonlyMap<string, SpaceUser>): void;
     addUserReady(userId: string): void;
     canSwitch(): boolean;
     cleanup(): void;

--- a/back/src/Model/Interfaces/ICommunicationStrategy.ts
+++ b/back/src/Model/Interfaces/ICommunicationStrategy.ts
@@ -1,12 +1,12 @@
 import { SpaceUser } from "@workadventure/messages";
 
 export interface ICommunicationStrategy {
-    addUser(user: SpaceUser, switchInProgress?: boolean): Promise<void>;
+    addUser(user: SpaceUser): Promise<void>;
     deleteUser(user: SpaceUser): void;
     updateUser(user: SpaceUser): void;
     addUserToNotify(user: SpaceUser): Promise<void>;
     deleteUserFromNotify(user: SpaceUser): void;
-    initialize(readyUsers: Set<string>): void;
+    initialize(): void;
     addUserReady(userId: string): void;
     canSwitch(): boolean;
     cleanup(): void;

--- a/back/src/Model/States/AbstractCommunicationState.ts
+++ b/back/src/Model/States/AbstractCommunicationState.ts
@@ -3,132 +3,51 @@ import { SpaceUser, PrivateEvent } from "@workadventure/messages";
 import { CommunicationType } from "../Types/CommunicationTypes";
 import { ICommunicationState } from "../Interfaces/ICommunicationState";
 import { ICommunicationStrategy } from "../Interfaces/ICommunicationStrategy";
-import { ICommunicationManager } from "../Interfaces/ICommunicationManager";
 import { CommunicationConfig } from "../CommunicationManager";
 import { ICommunicationSpace } from "../Interfaces/ICommunicationSpace";
 export abstract class CommunicationState implements ICommunicationState {
     protected _switchTimeout: NodeJS.Timeout | null = null;
-    protected SWITCH_TIMEOUT_MS = 0;
-    protected _nextStatePromise: Promise<CommunicationState> | null = null;
-    protected abstract _currentCommunicationType: CommunicationType;
-    protected abstract _nextCommunicationType: CommunicationType;
-    protected _waitingList: Set<string> = new Set<string>();
+    protected abstract _communicationType: CommunicationType;
     protected _switchInitiatorUserId: string | null = null;
 
     constructor(
         protected readonly _space: ICommunicationSpace,
-        protected readonly _communicationManager: ICommunicationManager,
         protected readonly _currentStrategy: ICommunicationStrategy,
-        protected readonly _readyUsers: Set<string> = new Set(),
+        protected users: ReadonlyMap<string, SpaceUser>,
+        protected usersToNotify: ReadonlyMap<string, SpaceUser>,
         protected readonly MAX_USERS_FOR_WEBRTC: number = Number(CommunicationConfig.MAX_USERS_FOR_WEBRTC)
-    ) {
-        this.preparedSwitchAction(this._readyUsers);
+    ) {}
+
+    public init(): void {
+        this._currentStrategy.initialize();
     }
+
     dispatchSwitchEvent(
         userId: string,
-        eventType:
-            | "communicationStrategyMessage"
-            | "prepareSwitchMessage"
-            | "executeSwitchMessage"
-            | "cancelSwitchMessage",
-        payload: unknown
+        event: Extract<
+            NonNullable<PrivateEvent["spaceEvent"]>["event"],
+            {
+                $case: "switchMessage" | "finalizeSwitchMessage";
+            }
+        >
     ): void {
-        const event: PrivateEvent = {
+        const privateEvent: PrivateEvent = {
             spaceName: this._space.getSpaceName(),
             receiverUserId: userId,
             senderUserId: userId,
             spaceEvent: {
-                event: {
-                    $case: eventType,
-                    [eventType]: payload,
-                },
+                event,
             },
         } as PrivateEvent;
-        this._space.dispatchPrivateEvent(event);
+        this._space.dispatchPrivateEvent(privateEvent);
     }
 
-    protected cancelSwitch() {
-        if (this._switchTimeout) {
-            clearTimeout(this._switchTimeout);
-            this._switchTimeout = null;
-        }
-        this._nextStatePromise = null;
-        this._readyUsers.clear();
-        const spaceUsers = this._space.getAllUsers();
-
-        spaceUsers.forEach((user) => {
-            if (this._waitingList.has(user.spaceUserId)) {
-                this.handleUserAdded(user).catch((e) => {
-                    Sentry.captureException(e);
-                    console.error(e);
-                });
-            } else {
-                this.dispatchSwitchEvent(user.spaceUserId, "cancelSwitchMessage", {
-                    strategy: this._nextCommunicationType,
-                });
-            }
-        });
-
-        this._waitingList.clear();
-    }
-
-    protected setupSwitchTimeout(): void {
-        if (this._switchTimeout) {
-            console.warn("Switch timeout already set");
-            clearTimeout(this._switchTimeout);
-            this._switchTimeout = null;
-        }
-
-        this._switchTimeout = setTimeout(() => {
-            this.executeFinalSwitch().catch((e) => {
-                Sentry.captureException(e);
-                console.error(e);
-            });
-        }, this.SWITCH_TIMEOUT_MS);
-    }
-
-    protected async executeFinalSwitch(): Promise<void> {
-        if (this._switchTimeout) {
-            clearTimeout(this._switchTimeout);
-            this._switchTimeout = null;
-        }
-
-        if (!this.isSwitching()) {
-            return;
-        }
-
-        if (!this._nextStatePromise) {
-            return;
-        }
-
+    handleUserAdded(user: SpaceUser): Promise<ICommunicationState | void> {
         try {
-            const users = new Set<string>([
-                ...this._space.getUsersInFilter().map((user) => user.spaceUserId),
-                ...this._space.getUsersToNotify().map((user) => user.spaceUserId),
-            ]);
-            if (this._switchInitiatorUserId) {
-                users.delete(this._switchInitiatorUserId);
+            if (!this.usersToNotify.has(user.spaceUserId)) {
+                this.notifyUserOfCurrentStrategy(user, this._communicationType);
             }
-
-            users.forEach((spaceUserId) => {
-                this.dispatchSwitchEvent(spaceUserId, "executeSwitchMessage", {
-                    strategy: this._nextCommunicationType,
-                });
-            });
-        } finally {
-            const nextState = await this._nextStatePromise;
-            this._communicationManager.setState(nextState);
-            nextState.afterSwitchAction();
-            this._readyUsers.clear();
-            this._switchInitiatorUserId = null;
-        }
-    }
-
-    handleUserAdded(user: SpaceUser): Promise<void> {
-        try {
-            this.notifyUserOfCurrentStrategy(user, this._currentCommunicationType);
-            const switchInProgress = this.isSwitching();
-            this._currentStrategy.addUser(user, switchInProgress).catch((e) => {
+            this._currentStrategy.addUser(user).catch((e) => {
                 Sentry.captureException(e);
                 console.error(e);
             });
@@ -138,17 +57,19 @@ export abstract class CommunicationState implements ICommunicationState {
             return Promise.resolve();
         }
     }
-    handleUserDeleted(user: SpaceUser): Promise<void> {
+    handleUserDeleted(user: SpaceUser): Promise<ICommunicationState | void> {
         this._currentStrategy.deleteUser(user);
         return Promise.resolve();
     }
-    handleUserUpdated(user: SpaceUser): Promise<void> {
+    handleUserUpdated(user: SpaceUser): Promise<ICommunicationState | void> {
         this._currentStrategy.updateUser(user);
         return Promise.resolve();
     }
-    handleUserToNotifyAdded(user: SpaceUser): Promise<void> {
+    handleUserToNotifyAdded(user: SpaceUser): Promise<ICommunicationState | void> {
         try {
-            this.notifyUserOfCurrentStrategy(user, this._currentCommunicationType);
+            if (!this.users.has(user.spaceUserId)) {
+                this.notifyUserOfCurrentStrategy(user, this._communicationType);
+            }
             this._currentStrategy.addUserToNotify(user).catch((e) => {
                 Sentry.captureException(e);
                 console.error(e);
@@ -159,53 +80,45 @@ export abstract class CommunicationState implements ICommunicationState {
         }
         return Promise.resolve();
     }
-    handleUserToNotifyDeleted(user: SpaceUser): Promise<void> {
+    handleUserToNotifyDeleted(user: SpaceUser): Promise<ICommunicationState | void> {
         this._currentStrategy.deleteUserFromNotify(user);
         return Promise.resolve();
     }
-    handleUserReadyForSwitch(userId: string): Promise<void> {
-        if (!this.isSwitching()) {
-            return Promise.resolve();
-        }
 
-        this._readyUsers.add(userId);
-
-        if (this.areAllUsersReady()) {
-            this.completeSwitchEarly().catch((e) => {
-                Sentry.captureException(e);
-                console.error(e);
+    public switchState(targetCommunicationType: string): void {
+        // Let's merge this.users and this.usersToNotify to get all users
+        const allUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
+        for (const user of allUsers.values()) {
+            this.dispatchSwitchEvent(user.spaceUserId, {
+                $case: "switchMessage",
+                switchMessage: {
+                    strategy: targetCommunicationType,
+                },
             });
         }
-        return Promise.resolve();
-    }
-
-    protected notifyAllUsersToPrepareSwitchToNextState(): void {
-        const users = this._space.getAllUsers();
-        const usersToNotify = users.filter((user) => !this._readyUsers.has(user.spaceUserId));
-        usersToNotify.forEach((user) => {
-            this.dispatchSwitchEvent(user.spaceUserId, "prepareSwitchMessage", {
-                strategy: this._nextCommunicationType,
-            });
-        });
     }
 
     protected notifyUserOfCurrentStrategy(user: SpaceUser, strategy: CommunicationType): void {
-        this.dispatchSwitchEvent(user.spaceUserId, "communicationStrategyMessage", { strategy });
+        this.dispatchSwitchEvent(user.spaceUserId, {
+            $case: "switchMessage",
+            switchMessage: { strategy },
+        });
     }
-    protected abstract shouldSwitchBackToCurrentState(): boolean;
-    protected abstract shouldSwitchToNextState(): boolean;
-    protected abstract areAllUsersReady(): boolean;
 
-    protected afterSwitchAction(): void {}
-    protected preparedSwitchAction(readyUsers: Set<string>): void {}
-    private async completeSwitchEarly(): Promise<void> {
-        if (this._switchTimeout) {
-            clearTimeout(this._switchTimeout);
-            this._switchTimeout = null;
+    public finalize(): void {
+        // Let's merge this.users and this.usersToNotify to get all users
+        const allUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
+        for (const user of allUsers.values()) {
+            this.dispatchSwitchEvent(user.spaceUserId, {
+                $case: "finalizeSwitchMessage",
+                finalizeSwitchMessage: {
+                    strategy: this._communicationType,
+                },
+            });
         }
-        await this.executeFinalSwitch();
     }
-    protected isSwitching(): boolean {
-        return !!this._nextStatePromise;
+
+    get communicationType(): string {
+        return this._communicationType;
     }
 }

--- a/back/src/Model/States/AbstractCommunicationState.ts
+++ b/back/src/Model/States/AbstractCommunicationState.ts
@@ -88,6 +88,14 @@ export abstract class CommunicationState implements ICommunicationState {
     public switchState(targetCommunicationType: string): void {
         // Let's merge this.users and this.usersToNotify to get all users
         const allUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
+        console.log(
+            "Sending switch event " +
+                targetCommunicationType +
+                " to " +
+                Array.from(allUsers.values())
+                    .map((user) => user.name)
+                    .join(", ")
+        );
         for (const user of allUsers.values()) {
             this.dispatchSwitchEvent(user.spaceUserId, {
                 $case: "switchMessage",
@@ -108,6 +116,14 @@ export abstract class CommunicationState implements ICommunicationState {
     public finalize(): void {
         // Let's merge this.users and this.usersToNotify to get all users
         const allUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
+        console.log(
+            "Sending finalize event " +
+                this._communicationType +
+                " to " +
+                Array.from(allUsers.values())
+                    .map((user) => user.name)
+                    .join(", ")
+        );
         for (const user of allUsers.values()) {
             this.dispatchSwitchEvent(user.spaceUserId, {
                 $case: "finalizeSwitchMessage",

--- a/back/src/Model/States/AbstractCommunicationState.ts
+++ b/back/src/Model/States/AbstractCommunicationState.ts
@@ -19,7 +19,7 @@ export abstract class CommunicationState implements ICommunicationState {
     ) {}
 
     public init(): void {
-        this._currentStrategy.initialize();
+        this._currentStrategy.initialize(this.users, this.usersToNotify);
     }
 
     dispatchSwitchEvent(

--- a/back/src/Model/States/AbstractCommunicationState.ts
+++ b/back/src/Model/States/AbstractCommunicationState.ts
@@ -89,6 +89,12 @@ export abstract class CommunicationState implements ICommunicationState {
         // Let's merge this.users and this.usersToNotify to get all users
         const allUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
         for (const user of allUsers.values()) {
+            console.trace(
+                "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC Switching user",
+                user.name,
+                "to",
+                targetCommunicationType
+            );
             this.dispatchSwitchEvent(user.spaceUserId, {
                 $case: "switchMessage",
                 switchMessage: {
@@ -99,6 +105,12 @@ export abstract class CommunicationState implements ICommunicationState {
     }
 
     protected notifyUserOfCurrentStrategy(user: SpaceUser, strategy: CommunicationType): void {
+        console.trace(
+            "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC Notify user of current Strategy",
+            user.name,
+            ":",
+            strategy
+        );
         this.dispatchSwitchEvent(user.spaceUserId, {
             $case: "switchMessage",
             switchMessage: { strategy },

--- a/back/src/Model/States/AbstractCommunicationState.ts
+++ b/back/src/Model/States/AbstractCommunicationState.ts
@@ -89,12 +89,6 @@ export abstract class CommunicationState implements ICommunicationState {
         // Let's merge this.users and this.usersToNotify to get all users
         const allUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
         for (const user of allUsers.values()) {
-            console.trace(
-                "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC Switching user",
-                user.name,
-                "to",
-                targetCommunicationType
-            );
             this.dispatchSwitchEvent(user.spaceUserId, {
                 $case: "switchMessage",
                 switchMessage: {
@@ -105,12 +99,6 @@ export abstract class CommunicationState implements ICommunicationState {
     }
 
     protected notifyUserOfCurrentStrategy(user: SpaceUser, strategy: CommunicationType): void {
-        console.trace(
-            "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC Notify user of current Strategy",
-            user.name,
-            ":",
-            strategy
-        );
         this.dispatchSwitchEvent(user.spaceUserId, {
             $case: "switchMessage",
             switchMessage: { strategy },

--- a/back/src/Model/States/AbstractCommunicationState.ts
+++ b/back/src/Model/States/AbstractCommunicationState.ts
@@ -88,14 +88,6 @@ export abstract class CommunicationState implements ICommunicationState {
     public switchState(targetCommunicationType: string): void {
         // Let's merge this.users and this.usersToNotify to get all users
         const allUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
-        console.log(
-            "Sending switch event " +
-                targetCommunicationType +
-                " to " +
-                Array.from(allUsers.values())
-                    .map((user) => user.name)
-                    .join(", ")
-        );
         for (const user of allUsers.values()) {
             this.dispatchSwitchEvent(user.spaceUserId, {
                 $case: "switchMessage",
@@ -116,14 +108,6 @@ export abstract class CommunicationState implements ICommunicationState {
     public finalize(): void {
         // Let's merge this.users and this.usersToNotify to get all users
         const allUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
-        console.log(
-            "Sending finalize event " +
-                this._communicationType +
-                " to " +
-                Array.from(allUsers.values())
-                    .map((user) => user.name)
-                    .join(", ")
-        );
         for (const user of allUsers.values()) {
             this.dispatchSwitchEvent(user.spaceUserId, {
                 $case: "finalizeSwitchMessage",

--- a/back/src/Model/States/LivekitState.ts
+++ b/back/src/Model/States/LivekitState.ts
@@ -1,31 +1,31 @@
 import { SpaceUser } from "@workadventure/messages";
 import { CommunicationType } from "../Types/CommunicationTypes";
 import { LivekitCommunicationStrategy } from "../Strategies/LivekitCommunicationStrategy";
-import { ICommunicationManager } from "../Interfaces/ICommunicationManager";
 import { ICommunicationSpace } from "../Interfaces/ICommunicationSpace";
 import { LivekitCredentialsResponse } from "../../Services/Repository/LivekitCredentialsResponse";
 import { LIVEKIT_API_KEY, LIVEKIT_API_SECRET, LIVEKIT_HOST } from "../../Enum/EnvironmentVariable";
 import { LiveKitService } from "../Services/LivekitService";
+import { ICommunicationState } from "../Interfaces/ICommunicationState";
 import { CommunicationState } from "./AbstractCommunicationState";
 import { WebRTCState } from "./WebRTCState";
 
 export class LivekitState extends CommunicationState {
-    protected _currentCommunicationType: CommunicationType = CommunicationType.LIVEKIT;
+    protected _communicationType: CommunicationType = CommunicationType.LIVEKIT;
     protected _nextCommunicationType: CommunicationType = CommunicationType.WEBRTC;
 
     constructor(
         protected readonly _space: ICommunicationSpace,
-        protected readonly _communicationManager: ICommunicationManager,
         protected readonly _livekitServerCredentials: LivekitCredentialsResponse = {
             livekitApiKey: LIVEKIT_API_KEY ?? "",
             livekitApiSecret: LIVEKIT_API_SECRET ?? "",
             livekitHost: LIVEKIT_HOST ?? "",
         },
+        users: ReadonlyMap<string, SpaceUser>,
+        usersToNotify: ReadonlyMap<string, SpaceUser>,
         protected readonly _readyUsers: Set<string> = new Set()
     ) {
         super(
             _space,
-            _communicationManager,
             new LivekitCommunicationStrategy(
                 _space,
                 new LiveKitService(
@@ -35,91 +35,27 @@ export class LivekitState extends CommunicationState {
                     _livekitServerCredentials.livekitHost.replace("http", "ws")
                 )
             ),
-            _readyUsers
+            users,
+            usersToNotify
         );
-        this.SWITCH_TIMEOUT_MS = 5000;
     }
-    async handleUserAdded(user: SpaceUser): Promise<void> {
-        if (this.shouldSwitchBackToCurrentState()) {
-            this.cancelSwitch();
-        }
-
-        if (this._nextStatePromise) {
-            this._waitingList.delete(user.spaceUserId);
-            const nextState = await this._nextStatePromise;
-            await nextState.handleUserAdded(user);
-            // Don't call super.handleUserAdded if the user is already handled by the next state
-            return;
-        }
-
-        return super.handleUserAdded(user);
-    }
-    async handleUserDeleted(user: SpaceUser): Promise<void> {
+    async handleUserDeleted(user: SpaceUser): Promise<ICommunicationState | void> {
         if (this.shouldSwitchToNextState()) {
-            this.switchToNextState();
-        }
-
-        if (this._nextStatePromise) {
-            this._waitingList.add(user.spaceUserId);
-            const nextState = await this._nextStatePromise;
-            await nextState.handleUserAdded(user);
+            return new WebRTCState(this._space, this.users, this.usersToNotify);
         }
 
         return super.handleUserDeleted(user);
     }
-    async handleUserUpdated(user: SpaceUser): Promise<void> {
-        return super.handleUserUpdated(user);
-    }
-    async handleUserReadyForSwitch(userId: string): Promise<void> {
-        return super.handleUserReadyForSwitch(userId);
-    }
 
-    handleUserToNotifyAdded(user: SpaceUser): Promise<void> {
-        if (this.shouldSwitchBackToCurrentState()) {
-            this.cancelSwitch();
-        }
-        return super.handleUserToNotifyAdded(user);
-    }
-
-    async handleUserToNotifyDeleted(user: SpaceUser): Promise<void> {
-        if (this.shouldSwitchBackToCurrentState()) {
-            this.cancelSwitch();
-        }
-
-        if (this.isSwitching()) {
-            if (this._nextStatePromise) {
-                this._waitingList.delete(user.spaceUserId);
-                const nextState = await this._nextStatePromise;
-                await nextState.handleUserAdded(user);
-                // Don't call super.handleUserAdded if the user is already handled by the next state
-                return;
-            }
+    async handleUserToNotifyDeleted(user: SpaceUser): Promise<ICommunicationState | void> {
+        if (this.shouldSwitchToNextState()) {
+            return new WebRTCState(this._space, this.users, this.usersToNotify);
         }
 
         await super.handleUserToNotifyDeleted(user);
     }
 
-    private switchToNextState(): void {
-        this._nextStatePromise = Promise.resolve(new WebRTCState(this._space, this._communicationManager));
-        this.notifyAllUsersToPrepareSwitchToNextState();
-        this.setupSwitchTimeout();
-    }
-
     protected shouldSwitchToNextState(): boolean {
-        const isMaxUsersReached = this._space.getAllUsers().length <= this.MAX_USERS_FOR_WEBRTC;
-        return !this.isSwitching() && isMaxUsersReached;
-    }
-
-    protected shouldSwitchBackToCurrentState(): boolean {
-        const isMaxUsersReached = this._space.getAllUsers().length > this.MAX_USERS_FOR_WEBRTC;
-        return this.isSwitching() && isMaxUsersReached;
-    }
-
-    protected areAllUsersReady(): boolean {
-        return this._readyUsers.size === this._space.getAllUsers().length;
-    }
-
-    protected preparedSwitchAction(readyUsers: Set<string>): void {
-        this._currentStrategy.initialize(readyUsers);
+        return this._space.getAllUsers().length <= this.MAX_USERS_FOR_WEBRTC;
     }
 }

--- a/back/src/Model/States/StateFactory.ts
+++ b/back/src/Model/States/StateFactory.ts
@@ -1,0 +1,32 @@
+import { SpaceUser } from "@workadventure/messages";
+import { getCapability } from "../../Services/Capabilities";
+import { adminApi } from "../../Services/AdminApi";
+import { LIVEKIT_API_KEY, LIVEKIT_API_SECRET, LIVEKIT_HOST } from "../../Enum/EnvironmentVariable";
+import { ICommunicationSpace } from "../Interfaces/ICommunicationSpace";
+import { LivekitState } from "./LivekitState";
+
+export async function createLivekitState(
+    space: ICommunicationSpace,
+    playUri: string,
+    users: ReadonlyMap<string, SpaceUser>,
+    usersToNotify: ReadonlyMap<string, SpaceUser>
+): Promise<LivekitState> {
+    if (getCapability("api/livekit/credentials") === "v1") {
+        const credentials = await adminApi.fetchLivekitCredentials(space.getSpaceName(), playUri);
+        return new LivekitState(space, credentials, users, usersToNotify);
+    } else {
+        if (!LIVEKIT_HOST || !LIVEKIT_API_KEY || !LIVEKIT_API_SECRET) {
+            throw new Error("Livekit credentials are not set in environment variables");
+        }
+        return new LivekitState(
+            space,
+            {
+                livekitHost: LIVEKIT_HOST,
+                livekitApiKey: LIVEKIT_API_KEY,
+                livekitApiSecret: LIVEKIT_API_SECRET,
+            },
+            users,
+            usersToNotify
+        ); //fallback to default credentials
+    }
+}

--- a/back/src/Model/States/VoidState.ts
+++ b/back/src/Model/States/VoidState.ts
@@ -1,7 +1,14 @@
 import { SpaceUser } from "@workadventure/messages";
 import { ICommunicationState } from "../Interfaces/ICommunicationState";
+import { CommunicationType } from "../Types/CommunicationTypes";
 
-export class DefaultState implements ICommunicationState {
+export class VoidState implements ICommunicationState {
+    init(): void {
+        return;
+    }
+    get communicationType(): string {
+        return CommunicationType.NONE;
+    }
     handleUserAdded(user: SpaceUser): Promise<void> {
         return Promise.resolve();
     }
@@ -21,5 +28,15 @@ export class DefaultState implements ICommunicationState {
     handleUserToNotifyDeleted(user: SpaceUser): Promise<void> {
         console.info("DefaultState handleUserToNotifyDeleted", user);
         return Promise.resolve();
+    }
+    switchState(): void {
+        return;
+    }
+    finalize(): void {
+        return;
+    }
+
+    public getCommunicationType(): string {
+        return CommunicationType.NONE;
     }
 }

--- a/back/src/Model/States/VoidState.ts
+++ b/back/src/Model/States/VoidState.ts
@@ -22,11 +22,11 @@ export class VoidState implements ICommunicationState {
         return Promise.resolve();
     }
     handleUserToNotifyAdded(user: SpaceUser): Promise<void> {
-        console.info("DefaultState handleUserToNotifyAdded", user);
+        //console.info("DefaultState handleUserToNotifyAdded", user);
         return Promise.resolve();
     }
     handleUserToNotifyDeleted(user: SpaceUser): Promise<void> {
-        console.info("DefaultState handleUserToNotifyDeleted", user);
+        //console.info("DefaultState handleUserToNotifyDeleted", user);
         return Promise.resolve();
     }
     switchState(): void {

--- a/back/src/Model/States/WebRTCState.ts
+++ b/back/src/Model/States/WebRTCState.ts
@@ -1,162 +1,46 @@
-import * as Sentry from "@sentry/node";
 import { SpaceUser } from "@workadventure/messages";
-import { ICommunicationManager } from "../Interfaces/ICommunicationManager";
 import { WebRTCCommunicationStrategy } from "../Strategies/WebRTCCommunicationStrategy";
 import { CommunicationType } from "../Types/CommunicationTypes";
 import { ICommunicationSpace } from "../Interfaces/ICommunicationSpace";
-import { adminApi } from "../../Services/AdminApi";
 import { getCapability } from "../../Services/Capabilities";
 import { LIVEKIT_HOST, LIVEKIT_API_KEY, LIVEKIT_API_SECRET } from "../../Enum/EnvironmentVariable";
+import { ICommunicationState } from "../Interfaces/ICommunicationState";
 import { CommunicationState } from "./AbstractCommunicationState";
-import { LivekitState } from "./LivekitState";
+import { createLivekitState } from "./StateFactory";
 
 export class WebRTCState extends CommunicationState {
-    protected _currentCommunicationType: CommunicationType = CommunicationType.WEBRTC;
+    protected _communicationType: CommunicationType = CommunicationType.WEBRTC;
     protected _nextCommunicationType: CommunicationType = CommunicationType.LIVEKIT;
     protected livekitAvailable: boolean;
 
     constructor(
         protected readonly _space: ICommunicationSpace,
-        protected readonly _communicationManager: ICommunicationManager
+        users: ReadonlyMap<string, SpaceUser>,
+        usersToNotify: ReadonlyMap<string, SpaceUser>
     ) {
-        super(_space, _communicationManager, new WebRTCCommunicationStrategy(_space));
-        this.SWITCH_TIMEOUT_MS = 5000;
+        super(_space, new WebRTCCommunicationStrategy(_space), users, usersToNotify);
         this.livekitAvailable =
             getCapability("api/livekit/credentials") === "v1" ||
             (!!LIVEKIT_HOST && !!LIVEKIT_API_KEY && !!LIVEKIT_API_SECRET);
     }
-    async handleUserAdded(user: SpaceUser): Promise<void> {
+    async handleUserAdded(user: SpaceUser): Promise<ICommunicationState | void> {
         if (this.shouldSwitchToNextState()) {
-            this.switchToNextState(user, "user");
-            return;
-        }
-
-        if (this._nextStatePromise) {
-            this._waitingList.add(user.spaceUserId);
-            const nextState = await this._nextStatePromise;
-            await nextState.handleUserAdded(user);
-            return;
+            return createLivekitState(this._space, user.playUri, this.users, this.usersToNotify);
         }
 
         return super.handleUserAdded(user);
     }
 
-    async handleUserDeleted(user: SpaceUser): Promise<void> {
-        this._waitingList.delete(user.spaceUserId);
-        if (this.shouldSwitchBackToCurrentState()) {
-            this.cancelSwitch();
-        }
-
-        if (this._nextStatePromise) {
-            const nextState = await this._nextStatePromise;
-            await nextState.handleUserDeleted(user);
-        }
-
-        return super.handleUserDeleted(user);
-    }
-
-    async handleUserUpdated(user: SpaceUser): Promise<void> {
-        if (this._nextStatePromise) {
-            const nextState = await this._nextStatePromise;
-            await nextState.handleUserUpdated(user);
-            return;
-        }
-
-        return super.handleUserUpdated(user);
-    }
-
-    async handleUserToNotifyAdded(user: SpaceUser): Promise<void> {
+    async handleUserToNotifyAdded(user: SpaceUser): Promise<ICommunicationState | void> {
         if (this.shouldSwitchToNextState()) {
-            this.switchToNextState(user, "userToNotify");
-            return;
+            return createLivekitState(this._space, user.playUri, this.users, this.usersToNotify);
         }
 
-        if (this._nextStatePromise) {
-            this._waitingList.add(user.spaceUserId);
-            const nextState = await this._nextStatePromise;
-            await nextState.handleUserToNotifyAdded(user);
-            return;
-        }
-
-        await super.handleUserToNotifyAdded(user);
-    }
-
-    async handleUserToNotifyDeleted(user: SpaceUser): Promise<void> {
-        if (this.shouldSwitchBackToCurrentState()) {
-            this.cancelSwitch();
-        }
-
-        if (this.isSwitching()) {
-            if (this._nextStatePromise) {
-                this._waitingList.delete(user.spaceUserId);
-                const nextState = await this._nextStatePromise;
-                await nextState.handleUserToNotifyDeleted(user);
-            }
-        }
-
-        await super.handleUserToNotifyDeleted(user);
-    }
-
-    private switchToNextState(user: SpaceUser, typeOfSwitch: "user" | "userToNotify"): void {
-        this._nextStatePromise = (async () => {
-            let nextState: LivekitState | undefined;
-            if (getCapability("api/livekit/credentials") === "v1") {
-                const credentials = await adminApi.fetchLivekitCredentials(this._space.getSpaceName(), user.playUri);
-                nextState = new LivekitState(this._space, this._communicationManager, credentials, this._readyUsers);
-            } else {
-                if (!LIVEKIT_HOST || !LIVEKIT_API_KEY || !LIVEKIT_API_SECRET) {
-                    throw new Error("Livekit credentials are not set in environment variables");
-                }
-                nextState = new LivekitState(
-                    this._space,
-                    this._communicationManager,
-                    {
-                        livekitHost: LIVEKIT_HOST,
-                        livekitApiKey: LIVEKIT_API_KEY,
-                        livekitApiSecret: LIVEKIT_API_SECRET,
-                    },
-                    this._readyUsers
-                ); //fallback to default credentials
-            }
-            this._readyUsers.add(user.spaceUserId);
-            this._switchInitiatorUserId = user.spaceUserId;
-            try {
-                if (
-                    typeOfSwitch === "user" &&
-                    this._space.getUsersInFilter().find((user) => user.spaceUserId === user.spaceUserId)
-                ) {
-                    await nextState.handleUserAdded(user);
-                }
-
-                if (
-                    typeOfSwitch === "userToNotify" &&
-                    this._space.getUsersToNotify().find((user) => user.spaceUserId === user.spaceUserId)
-                ) {
-                    await nextState.handleUserToNotifyAdded(user);
-                }
-            } catch (e) {
-                console.error(
-                    `WebRTCState.switchToNextState: Error adding user ${user.name} (${user.spaceUserId}) to Livekit state:`,
-                    e
-                );
-                Sentry.captureException(e);
-            }
-
-            this.notifyAllUsersToPrepareSwitchToNextState();
-            this.setupSwitchTimeout();
-            return nextState;
-        })();
-    }
-
-    areAllUsersReady(): boolean {
-        return this._readyUsers.size === this._space.getAllUsers().length;
+        return super.handleUserToNotifyAdded(user);
     }
 
     protected shouldSwitchToNextState(): boolean {
-        const shouldSwitchToNextState =
-            this._space.getAllUsers().length > this.MAX_USERS_FOR_WEBRTC &&
-            !this.isSwitching() &&
-            !this._nextStatePromise;
+        const shouldSwitchToNextState = this._space.getAllUsers().length > this.MAX_USERS_FOR_WEBRTC;
         if (shouldSwitchToNextState && !this.livekitAvailable) {
             console.warn(
                 "Livekit is not configured in environment variables (or in AdminAPI), cannot switch to conversation to Livekit"
@@ -164,14 +48,5 @@ export class WebRTCState extends CommunicationState {
             return false;
         }
         return shouldSwitchToNextState;
-    }
-
-    protected shouldSwitchBackToCurrentState(): boolean {
-        const isMaxUsersReached = this._space.getAllUsers().length <= this.MAX_USERS_FOR_WEBRTC;
-        return this.isSwitching() && isMaxUsersReached;
-    }
-
-    protected afterSwitchAction(): void {
-        this._currentStrategy.initialize(this._readyUsers);
     }
 }

--- a/back/src/Model/States/WebRTCState.ts
+++ b/back/src/Model/States/WebRTCState.ts
@@ -18,7 +18,7 @@ export class WebRTCState extends CommunicationState {
         users: ReadonlyMap<string, SpaceUser>,
         usersToNotify: ReadonlyMap<string, SpaceUser>
     ) {
-        super(_space, new WebRTCCommunicationStrategy(_space), users, usersToNotify);
+        super(_space, new WebRTCCommunicationStrategy(_space, users, usersToNotify), users, usersToNotify);
         this.livekitAvailable =
             getCapability("api/livekit/credentials") === "v1" ||
             (!!LIVEKIT_HOST && !!LIVEKIT_API_KEY && !!LIVEKIT_API_SECRET);

--- a/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
@@ -31,7 +31,6 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
         // Send invitation to all receiving users if this is the first room creation
         if (this.receivingUsers.size > 0 && this.streamingUsers.size === 0) {
             for (const receivingUser of this.receivingUsers.values()) {
-                console.log("AAAAAAAAAAAAAAAAAAAA Sending invitation to receiving user", receivingUser.name);
                 this.sendLivekitInvitationMessage(receivingUser).catch((error) => {
                     console.error(`Error generating token for user ${receivingUser.spaceUserId} in Livekit:`, error);
                     Sentry.captureException(error);
@@ -43,7 +42,6 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
 
         // Send invitation to the new user if not already receiving
         if (!this.receivingUsers.has(user.spaceUserId)) {
-            console.log("AAAAAAAAAAAAAAAAAAAA Sending invitation to streaming user", user.name);
             this.sendLivekitInvitationMessage(user).catch((error) => {
                 console.error(`Error generating token for user ${user.spaceUserId} in Livekit:`, error);
                 Sentry.captureException(error);
@@ -60,7 +58,6 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
         }
 
         try {
-            console.log("AAAAAAAAAAAAAAAAAAAAAA Sending disconnect to user", user.name);
             this.space.dispatchPrivateEvent({
                 spaceName: this.space.getSpaceName(),
                 receiverUserId: user.spaceUserId,
@@ -112,7 +109,6 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
     updateUser(user: SpaceUser): void {}
 
     initialize(users: ReadonlyMap<string, SpaceUser>, usersToNotify: ReadonlyMap<string, SpaceUser>): void {
-        console.log("AAAAAAAAAAAAAAAAAAAA Initializing LivekitCommunicationStrategy with users");
         (async () => {
             for (const user of users.values()) {
                 // We want to add users sequentially
@@ -165,7 +161,6 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
 
         // Let's only send the invitation if the user is not already streaming in the room
         if (!this.streamingUsers.has(user.spaceUserId)) {
-            console.log("AAAAAAAAAAAAAAAAAAAA Sending invitation to receiving user in addUserNotify", user.name);
             this.sendLivekitInvitationMessage(user).catch((error) => {
                 console.error(`Error generating token for user ${user.spaceUserId} in Livekit:`, error);
                 Sentry.captureException(error);

--- a/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
@@ -11,14 +11,9 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
     private streamingUsers: Map<string, SpaceUser> = new Map<string, SpaceUser>();
     private receivingUsers: Map<string, SpaceUser> = new Map<string, SpaceUser>();
 
-    constructor(private space: ICommunicationSpace, private livekitService: LiveKitService) {
-        // this.livekitService.createRoom(this.space.getSpaceName()).catch((error) => {
-        //     console.error(`Error creating room ${this.space.getSpaceName()} on Livekit:`, error);
-        //     Sentry.captureException(error);
-        // });
-    }
+    constructor(private space: ICommunicationSpace, private livekitService: LiveKitService) {}
 
-    async addUser(user: SpaceUser, switchInProgress = false): Promise<void> {
+    async addUser(user: SpaceUser): Promise<void> {
         // Check if the user is already streaming
         if (this.streamingUsers.has(user.spaceUserId)) {
             console.warn("User already streaming in the room", user.spaceUserId);
@@ -36,7 +31,7 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
         // Send invitation to all receiving users if this is the first room creation
         if (this.receivingUsers.size > 0 && this.streamingUsers.size === 0) {
             for (const receivingUser of this.receivingUsers.values()) {
-                this.sendLivekitInvitationMessage(receivingUser, switchInProgress).catch((error) => {
+                this.sendLivekitInvitationMessage(receivingUser).catch((error) => {
                     console.error(`Error generating token for user ${receivingUser.spaceUserId} in Livekit:`, error);
                     Sentry.captureException(error);
                 });
@@ -47,7 +42,7 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
 
         // Send invitation to the new user if not already receiving
         if (!this.receivingUsers.has(user.spaceUserId)) {
-            this.sendLivekitInvitationMessage(user, switchInProgress).catch((error) => {
+            this.sendLivekitInvitationMessage(user).catch((error) => {
                 console.error(`Error generating token for user ${user.spaceUserId} in Livekit:`, error);
                 Sentry.captureException(error);
             });
@@ -113,18 +108,18 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
 
     updateUser(user: SpaceUser): void {}
 
-    initialize(readyUsers: Set<string>): void {
-        const users = this.space.getUsersInFilter().filter((user) => !readyUsers.has(user.spaceUserId));
-        users.forEach((user) => {
-            this.addUser(user, false).catch((error) => {
+    initialize(): void {
+        // FIXME: we should take users from the state instead?
+        this.space.getUsersInFilter().forEach((user) => {
+            this.addUser(user).catch((error) => {
                 console.error(`Error adding user ${user.spaceUserId} to Livekit:`, error);
                 Sentry.captureException(error);
             });
         });
 
-        const usersToNotify = this.space.getUsersToNotify().filter((user) => !readyUsers.has(user.spaceUserId));
-        usersToNotify.forEach((user) => {
-            this.addUserToNotify(user, false).catch((error) => {
+        // FIXME: we should take users from the state instead?
+        this.space.getUsersToNotify().forEach((user) => {
+            this.addUserToNotify(user).catch((error) => {
                 console.error(`Error adding user ${user.spaceUserId} to Livekit:`, error);
                 Sentry.captureException(error);
             });
@@ -139,7 +134,7 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
         return this.usersReady.length === this.space.getAllUsers().length;
     }
 
-    async addUserToNotify(user: SpaceUser, switchInProgress = false): Promise<void> {
+    async addUserToNotify(user: SpaceUser): Promise<void> {
         if (this.receivingUsers.has(user.spaceUserId)) {
             console.warn("User already receiving in the room", user.spaceUserId);
             Sentry.captureMessage(`User already receiving in the room ${user.spaceUserId}`);
@@ -155,7 +150,7 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
 
         // Let's only send the invitation if the user is not already streaming in the room
         if (!this.streamingUsers.has(user.spaceUserId)) {
-            this.sendLivekitInvitationMessage(user, switchInProgress).catch((error) => {
+            this.sendLivekitInvitationMessage(user).catch((error) => {
                 console.error(`Error generating token for user ${user.spaceUserId} in Livekit:`, error);
                 Sentry.captureException(error);
             });
@@ -179,7 +174,7 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
         }
     }
 
-    private async sendLivekitInvitationMessage(user: SpaceUser, switchInProgress = false): Promise<void> {
+    private async sendLivekitInvitationMessage(user: SpaceUser): Promise<void> {
         const token = await this.livekitService.generateToken(this.space.getSpaceName(), user);
 
         this.space.dispatchPrivateEvent({
@@ -192,7 +187,6 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
                     livekitInvitationMessage: {
                         token: token,
                         serverUrl: this.livekitService.getLivekitFrontendUrl(),
-                        shouldJoinRoomImmediately: !switchInProgress,
                     },
                 },
             },

--- a/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
@@ -31,6 +31,7 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
         // Send invitation to all receiving users if this is the first room creation
         if (this.receivingUsers.size > 0 && this.streamingUsers.size === 0) {
             for (const receivingUser of this.receivingUsers.values()) {
+                console.log("AAAAAAAAAAAAAAAAAAAA Sending invitation to receiving user", receivingUser.name);
                 this.sendLivekitInvitationMessage(receivingUser).catch((error) => {
                     console.error(`Error generating token for user ${receivingUser.spaceUserId} in Livekit:`, error);
                     Sentry.captureException(error);
@@ -42,6 +43,7 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
 
         // Send invitation to the new user if not already receiving
         if (!this.receivingUsers.has(user.spaceUserId)) {
+            console.log("AAAAAAAAAAAAAAAAAAAA Sending invitation to streaming user", user.name);
             this.sendLivekitInvitationMessage(user).catch((error) => {
                 console.error(`Error generating token for user ${user.spaceUserId} in Livekit:`, error);
                 Sentry.captureException(error);
@@ -58,6 +60,7 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
         }
 
         try {
+            console.log("AAAAAAAAAAAAAAAAAAAAAA Sending disconnect to user", user.name);
             this.space.dispatchPrivateEvent({
                 spaceName: this.space.getSpaceName(),
                 receiverUserId: user.spaceUserId,
@@ -108,21 +111,33 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
 
     updateUser(user: SpaceUser): void {}
 
-    initialize(): void {
-        // FIXME: we should take users from the state instead?
-        this.space.getUsersInFilter().forEach((user) => {
-            this.addUser(user).catch((error) => {
-                console.error(`Error adding user ${user.spaceUserId} to Livekit:`, error);
-                Sentry.captureException(error);
-            });
-        });
+    initialize(users: ReadonlyMap<string, SpaceUser>, usersToNotify: ReadonlyMap<string, SpaceUser>): void {
+        console.log("AAAAAAAAAAAAAAAAAAAA Initializing LivekitCommunicationStrategy with users");
+        (async () => {
+            for (const user of users.values()) {
+                // We want to add users sequentially
+                // The first user will trigger the room creation (which is async) but for other users, the
+                // room will already be created, and the execution will not wait at all.
+                // eslint-disable-next-line no-await-in-loop
+                await this.addUser(user).catch((error) => {
+                    console.error(`Error adding user ${user.spaceUserId} to Livekit:`, error);
+                    Sentry.captureException(error);
+                });
+            }
 
-        // FIXME: we should take users from the state instead?
-        this.space.getUsersToNotify().forEach((user) => {
-            this.addUserToNotify(user).catch((error) => {
-                console.error(`Error adding user ${user.spaceUserId} to Livekit:`, error);
-                Sentry.captureException(error);
-            });
+            for (const user of usersToNotify.values()) {
+                // We want to add users sequentially
+                // The first user will trigger the room creation (which is async) but for other users, the
+                // room will already be created, and the execution will not wait at all.
+                // eslint-disable-next-line no-await-in-loop
+                await this.addUserToNotify(user).catch((error) => {
+                    console.error(`Error adding user ${user.spaceUserId} to Livekit:`, error);
+                    Sentry.captureException(error);
+                });
+            }
+        })().catch((error) => {
+            console.error("Error initializing LivekitCommunicationStrategy:", error);
+            Sentry.captureException(error);
         });
     }
 
@@ -150,6 +165,7 @@ export class LivekitCommunicationStrategy implements ICommunicationStrategy {
 
         // Let's only send the invitation if the user is not already streaming in the room
         if (!this.streamingUsers.has(user.spaceUserId)) {
+            console.log("AAAAAAAAAAAAAAAAAAAA Sending invitation to receiving user in addUserNotify", user.name);
             this.sendLivekitInvitationMessage(user).catch((error) => {
                 console.error(`Error generating token for user ${user.spaceUserId} in Livekit:`, error);
                 Sentry.captureException(error);

--- a/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
@@ -61,6 +61,8 @@ class ConnectionManager {
 export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     constructor(
         private readonly _space: ICommunicationSpace,
+        private users: ReadonlyMap<string, SpaceUser>,
+        private usersToNotify: ReadonlyMap<string, SpaceUser>,
         private readonly _credentialsService: WebRTCCredentialsService = webRTCCredentialsService,
         private readonly _connections: ConnectionManager = new ConnectionManager()
     ) {
@@ -75,46 +77,32 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
         // When someone enters the space, we don't need to try establishing the connection. We must wait for the user to watch
         // the space for that.
 
-        // FIXME: we should take users from the state instead?
-        if (!this._space.getUsersToNotify().find((user) => user.spaceUserId === newUser.spaceUserId)) {
+        if (!this.usersToNotify.has(newUser.spaceUserId)) {
             return Promise.resolve();
         }
 
-        const existingUsers = this._space.getUsersToNotify().filter((user) => user.spaceUserId !== newUser.spaceUserId);
-
-        existingUsers.forEach((existingUser) => {
+        for (const existingUser of this.usersToNotify.values()) {
+            if (existingUser.spaceUserId === newUser.spaceUserId) {
+                continue;
+            }
             if (this.shouldEstablishConnection(newUser, existingUser)) {
                 this.establishConnection(newUser, existingUser);
-                return;
             }
-        });
+        }
 
         return Promise.resolve();
     }
 
     public deleteUser(user: SpaceUser): void {
-        // FIXME: we should take users from the state instead?
-        if (!this._space.getUsersToNotify().find((user) => user.spaceUserId === user.spaceUserId)) {
-            return;
-        }
-
-        // FIXME: we should take users from the state instead?
-        const watchers = this._space.getUsersToNotify().map((user) => user.spaceUserId);
-
-        if (!watchers.includes(user.spaceUserId)) {
+        if (!this.usersToNotify.has(user.spaceUserId)) {
             this.shutdownAllConnections(user);
-            //this.cleanupUserMessages(user.spaceUserId);
-            //return;
         }
 
-        // FIXME: we should take users from the state instead?
-        const streamer = this._space.getUsersInFilter().map((user) => user.spaceUserId);
-
-        watchers.forEach((watcher) => {
-            if (!streamer.includes(watcher)) {
-                this.shutdownConnection(user.spaceUserId, watcher);
+        for (const userToNotify of this.usersToNotify.values()) {
+            if (!this.users.has(userToNotify.spaceUserId)) {
+                this.shutdownConnection(user.spaceUserId, userToNotify.spaceUserId);
             }
-        });
+        }
 
         this.cleanupUserMessages(user.spaceUserId);
     }
@@ -129,24 +117,24 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     public async addUserToNotify(user: SpaceUser): Promise<void> {
-        const usersInFilter = this._space.getUsersInFilter();
-        usersInFilter.forEach((existingUser) => {
-            if (this.shouldEstablishConnection(existingUser, user) && existingUser.spaceUserId !== user.spaceUserId) {
-                this.establishConnection(existingUser, user);
-                return;
+        for (const userInFilter of this.users.values()) {
+            if (userInFilter.spaceUserId === user.spaceUserId) {
+                continue;
             }
-        });
+            if (this.shouldEstablishConnection(user, userInFilter)) {
+                this.establishConnection(user, userInFilter);
+            }
+        }
 
         return Promise.resolve();
     }
     public deleteUserFromNotify(user: SpaceUser): void {
-        const usersInFilter = this._space.getUsersInFilter();
-        usersInFilter.forEach((existingUser) => {
-            if (existingUser.spaceUserId !== user.spaceUserId) {
-                this.shutdownConnection(existingUser.spaceUserId, user.spaceUserId);
-                return;
+        for (const userInFilter of this.users.values()) {
+            if (userInFilter.spaceUserId === user.spaceUserId) {
+                continue;
             }
-        });
+            this.shutdownConnection(user.spaceUserId, userInFilter.spaceUserId);
+        }
 
         this.cleanupUserToNotifyMessages(user.spaceUserId);
     }

--- a/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
@@ -71,10 +71,11 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
         return true;
     }
 
-    public addUser(newUser: SpaceUser, switchInProgress?: boolean): Promise<void> {
+    public addUser(newUser: SpaceUser): Promise<void> {
         // When someone enters the space, we don't need to try establishing the connection. We must wait for the user to watch
         // the space for that.
 
+        // FIXME: we should take users from the state instead?
         if (!this._space.getUsersToNotify().find((user) => user.spaceUserId === newUser.spaceUserId)) {
             return Promise.resolve();
         }
@@ -92,10 +93,12 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     public deleteUser(user: SpaceUser): void {
+        // FIXME: we should take users from the state instead?
         if (!this._space.getUsersToNotify().find((user) => user.spaceUserId === user.spaceUserId)) {
             return;
         }
 
+        // FIXME: we should take users from the state instead?
         const watchers = this._space.getUsersToNotify().map((user) => user.spaceUserId);
 
         if (!watchers.includes(user.spaceUserId)) {
@@ -103,6 +106,8 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
             //this.cleanupUserMessages(user.spaceUserId);
             //return;
         }
+
+        // FIXME: we should take users from the state instead?
         const streamer = this._space.getUsersInFilter().map((user) => user.spaceUserId);
 
         watchers.forEach((watcher) => {

--- a/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
@@ -239,11 +239,9 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
         });
     }
 
-    initialize(): void {
-        const users = this._space.getUsersInFilter();
-        const watchers = this._space.getUsersToNotify();
+    initialize(users: ReadonlyMap<string, SpaceUser>, usersToNotify: ReadonlyMap<string, SpaceUser>): void {
         users.forEach((user1) => {
-            watchers.forEach((user2) => {
+            usersToNotify.forEach((user2) => {
                 if (user1.spaceUserId === user2.spaceUserId) {
                     return;
                 }

--- a/back/src/Model/Types/CommunicationTypes.ts
+++ b/back/src/Model/Types/CommunicationTypes.ts
@@ -8,20 +8,3 @@ export interface IWebRTCCredentials {
     webRtcUserName: string;
     webRtcPassword: string;
 }
-
-export interface ISwitchConfig {
-    MAX_USERS_FOR_WEBRTC: number;
-    SWITCH_TO_LIVEKIT_TIMEOUT_MS: number;
-    SWITCH_TO_WEBRTC_TIMEOUT_MS: number;
-    WEBRTC_RECONNECTION_WINDOW_MS: number;
-}
-
-export interface ICommunicationEvent {
-    spaceName: string;
-    receiverUserId: string;
-    senderUserId: string;
-    event: {
-        $case: "prepareSwitchMessage" | "communicationStrategyMessage" | "executeSwitchMessage" | "webRtcStartMessage";
-        [key: string]: unknown;
-    };
-}

--- a/docker-compose.livekit.yaml
+++ b/docker-compose.livekit.yaml
@@ -21,7 +21,7 @@ services:
 
   egress:
     image: livekit/egress:v1.9.0
-    restart: unless-stopped
+    #restart: unless-stopped
     ports:
       - "8080:8080" # Egress API
       - "8081:8081" # Egress Health

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -205,7 +205,7 @@ services:
     command: npm run dev
     working_dir: /usr/src/app/back
     environment:
-      DEBUG: "*"
+      #DEBUG: "*"
       PLAY_URL: http://play.workadventure.localhost
       # On startup, we ask the messages container to regenerate the files.
       # Note: we need to use this "messages" container because of ARM64 processors that are not supported with protoc (used in "messages" container)

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -945,15 +945,13 @@ message PrivateSpaceEvent {
     WebRtcSignalToServerMessage webRtcScreenSharingSignalToServerMessage = 8;
     WebRtcDisconnectMessage webRtcDisconnectMessage = 9;
     CommunicationStrategyMessage communicationStrategyMessage = 10;
-    PrepareSwitchMessage prepareSwitchMessage = 11;
-    ExecuteSwitchMessage executeSwitchMessage = 12;
+    SwitchMessage switchMessage = 11;
+    FinalizeSwitchMessage finalizeSwitchMessage = 12;
     LivekitInvitationMessage livekitInvitationMessage = 13;
     LivekitDisconnectMessage livekitDisconnectMessage = 14;
-    UserReadyForSwitchEvent userReadyForSwitchEvent = 15;
     AddSpaceUserMessage addSpaceUserMessage = 16;
     UpdateSpaceUserMessage updateSpaceUserMessage = 17;
     RemoveSpaceUserMessage removeSpaceUserMessage = 18;
-    CancelSwitchMessage cancelSwitchMessage = 19;
     BlockUserMessage blockUserMessage = 20;
     UnblockUserMessage unblockUserMessage = 21;
   }
@@ -963,15 +961,11 @@ message CommunicationStrategyMessage {
   string strategy = 1;
 }
 
-message PrepareSwitchMessage {
+message SwitchMessage {
   string strategy = 1;
 }
 
-message ExecuteSwitchMessage {
-  string strategy = 1;
-}
-
-message CancelSwitchMessage {
+message FinalizeSwitchMessage {
   string strategy = 1;
 }
 
@@ -984,14 +978,9 @@ message UnblockUserMessage {
 message LivekitInvitationMessage {
   string token = 1;
   string serverUrl = 2;
-  bool shouldJoinRoomImmediately = 3;
 }
 
 message LivekitDisconnectMessage {
-}
-
-message UserReadyForSwitchEvent {
-  string strategy = 1;
 }
 
 message SpaceMessage {

--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -510,10 +510,12 @@ export class ProximityChatRoom implements ChatRoom {
             this.usersUnsubscriber?.();
             this.spaceMessageSubscription?.unsubscribe();
             this.spaceIsTypingSubscription?.unsubscribe();
-            this.spaceRegistry.leaveSpace(this._space).catch((error) => {
-                console.error("Error leaving space: ", error);
-                Sentry.captureException(error);
-            });
+            if (this._space) {
+                this.spaceRegistry.leaveSpace(this._space).catch((error) => {
+                    console.error("Error leaving space: ", error);
+                    Sentry.captureException(error);
+                });
+            }
             this._space = undefined;
             throw e;
         }

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -423,6 +423,10 @@ export class LiveKitRoom implements LiveKitRoomInterface {
         }
 
         for (const speaker of speakers) {
+            // The current user is always displayed first, so we skip it
+            if (this.space.mySpaceUserId === speaker.identity) {
+                continue;
+            }
             const extendedVideoStream = this.space.getVideoPeerVideoBox(speaker.identity);
 
             // If this is a video and not a screen share, we add 2000 to the priority

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -72,7 +72,6 @@ export class LiveKitRoom implements LiveKitRoomInterface {
         }
     ) {
         this._livekitRoomCounter.increment();
-        console.trace("LiveKitRoom created", space.getName());
     }
 
     public async prepareConnection(): Promise<Room> {

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -72,6 +72,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
         }
     ) {
         this._livekitRoomCounter.increment();
+        console.trace("LiveKitRoom created", space.getName());
     }
 
     public async prepareConnection(): Promise<Room> {

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -475,20 +475,23 @@ export class LiveKitRoom implements LiveKitRoomInterface {
     }
 
     public destroy() {
-        this.unsubscribers.forEach((unsubscriber) => unsubscriber());
-        this.participants.forEach((participant) => participant.destroy());
-        this.room?.off(RoomEvent.ParticipantConnected, this.handleParticipantConnected.bind(this));
-        this.room?.off(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected.bind(this));
-        this.room?.off(RoomEvent.ActiveSpeakersChanged, this.handleActiveSpeakersChanged.bind(this));
-        this.leaveRoom();
-        this.localParticipant?.setMicrophoneEnabled(false).catch((err) => {
-            console.error("An error occurred while disabling microphone", err);
-            Sentry.captureException(err);
-        });
-        this.localParticipant?.setCameraEnabled(false).catch((err) => {
-            console.error("An error occurred while disabling camera", err);
-            Sentry.captureException(err);
-        });
-        this._livekitRoomCounter.decrement();
+        try {
+            this.unsubscribers.forEach((unsubscriber) => unsubscriber());
+            this.participants.forEach((participant) => participant.destroy());
+            this.room?.off(RoomEvent.ParticipantConnected, this.handleParticipantConnected.bind(this));
+            this.room?.off(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected.bind(this));
+            this.room?.off(RoomEvent.ActiveSpeakersChanged, this.handleActiveSpeakersChanged.bind(this));
+            this.leaveRoom();
+            this.localParticipant?.setMicrophoneEnabled(false).catch((err) => {
+                console.error("An error occurred while disabling microphone", err);
+                Sentry.captureException(err);
+            });
+            this.localParticipant?.setCameraEnabled(false).catch((err) => {
+                console.error("An error occurred while disabling camera", err);
+                Sentry.captureException(err);
+            });
+        } finally {
+            this._livekitRoomCounter.decrement();
+        }
     }
 }

--- a/play/src/front/Livekit/LivekitConnection.ts
+++ b/play/src/front/Livekit/LivekitConnection.ts
@@ -89,7 +89,6 @@ export class LivekitConnection {
                     Sentry.captureException(new Error("LivekitRoom not found"));
                     return;
                 }
-                this.livekitRoom?.leaveRoom();
                 this.shutdownAbortController.abort();
                 this.shutdownAbortController = new AbortController();
                 this.livekitRoom?.destroy();

--- a/play/src/front/Livekit/LivekitConnection.ts
+++ b/play/src/front/Livekit/LivekitConnection.ts
@@ -49,22 +49,10 @@ export class LivekitConnection {
 
                 room.prepareConnection()
                     .then(() => {
-                        if (message.livekitInvitationMessage.shouldJoinRoomImmediately) {
-                            room.joinRoom().catch((err) => {
-                                console.error("An error occurred in executeSwitchMessage", err);
-                                Sentry.captureException(err);
-                            });
-                        } else {
-                            this.space.emitPrivateMessage(
-                                {
-                                    $case: "userReadyForSwitchEvent",
-                                    userReadyForSwitchEvent: {
-                                        strategy: CommunicationType.LIVEKIT,
-                                    },
-                                },
-                                "0"
-                            );
-                        }
+                        room.joinRoom().catch((err) => {
+                            console.error("An error occurred in executeSwitchMessage", err);
+                            Sentry.captureException(err);
+                        });
                     })
                     .catch((err) => {
                         console.error("An error occurred in LivekitConnection initialize", err);

--- a/play/src/front/Livekit/LivekitConnection.ts
+++ b/play/src/front/Livekit/LivekitConnection.ts
@@ -53,7 +53,9 @@ export class LivekitConnection {
                 if (inviteTriggered) {
                     console.error("Livekit invitation already triggered for this LivekitState");
                     Sentry.captureException(new Error("Livekit invitation already triggered for this LivekitState"));
+                    this.shutdownAbortController.abort();
                 }
+                this.shutdownAbortController = new AbortController();
                 inviteTriggered = true;
                 const serverUrl = message.livekitInvitationMessage.serverUrl;
                 const token = message.livekitInvitationMessage.token;
@@ -89,6 +91,7 @@ export class LivekitConnection {
                 }
                 this.livekitRoom?.leaveRoom();
                 this.shutdownAbortController.abort();
+                this.shutdownAbortController = new AbortController();
                 this.livekitRoom?.destroy();
                 this.livekitRoom = undefined;
             })

--- a/play/src/front/Livekit/LivekitConnection.ts
+++ b/play/src/front/Livekit/LivekitConnection.ts
@@ -18,6 +18,7 @@ export enum CommunicationType {
 export class LivekitConnection {
     private readonly unsubscribers: Subscription[] = [];
     private livekitRoom: LiveKitRoom | undefined;
+    private shutdownAbortController: AbortController = new AbortController();
     constructor(
         private space: SpaceInterface,
         private _streamableSubjects: StreamableSubjects,
@@ -33,7 +34,8 @@ export class LivekitConnection {
             token,
             this.space,
             this._streamableSubjects,
-            this._blockedUsersStore
+            this._blockedUsersStore,
+            this.shutdownAbortController.signal
         );
         this._streamingMegaphoneStore.set(true);
         return this.livekitRoom;
@@ -111,5 +113,13 @@ export class LivekitConnection {
         for (const subscription of this.unsubscribers) {
             subscription.unsubscribe();
         }
+    }
+
+    /**
+     * Starts the shutdown process of the communication state. It does not remove all video peers immediately,
+     * but any asynchronous operation receiving a new stream should be ignored after this call.
+     */
+    shutdown() {
+        this.shutdownAbortController.abort();
     }
 }

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -238,6 +238,7 @@ export class LiveKitParticipant {
             once(event, callback) {
                 callback();
             },
+            closeStreamable: () => {},
         };
     }
 
@@ -270,6 +271,7 @@ export class LiveKitParticipant {
             once(event, callback) {
                 callback();
             },
+            closeStreamable: () => {},
         };
     }
 

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -13,7 +13,6 @@ import { SpaceInterface, SpaceUserExtended } from "../Space/SpaceInterface";
 import { LivekitStreamable, Streamable } from "../Stores/StreamableCollectionStore";
 import { StreamableSubjects } from "../Space/SpacePeerManager/SpacePeerManager";
 import { decrementLivekitConnectionsCount, incrementLivekitConnectionsCount } from "../Utils/E2EHooks";
-import { localUserStore } from "../Connection/LocalUserStore";
 
 export class LiveKitParticipant {
     private _isSpeakingStore: Writable<boolean>;
@@ -198,12 +197,6 @@ export class LiveKitParticipant {
 
         // New Stream
         this._actualVideo = this.getVideoStream();
-        console.warn(
-            "AAAAAAAAAAAAAAAAAAAA Adding Livekit for user ",
-            localUserStore.getName(),
-            " remote user: ",
-            get(this._actualVideo.name)
-        );
         this._streamableSubjects.videoPeerAdded.next(this._actualVideo);
     }
 

--- a/play/src/front/Space/Space.ts
+++ b/play/src/front/Space/Space.ts
@@ -266,6 +266,9 @@ export class Space implements SpaceInterface {
                 return;
             }
 
+            const previousStreamable = get(videoBox.streamable);
+            previousStreamable?.closeStreamable();
+
             videoBox.streamable.set(peer);
         });
 

--- a/play/src/front/Space/Space.ts
+++ b/play/src/front/Space/Space.ts
@@ -266,8 +266,13 @@ export class Space implements SpaceInterface {
                 return;
             }
 
-            const previousStreamable = get(videoBox.streamable);
-            previousStreamable?.closeStreamable();
+            try {
+                const previousStreamable = get(videoBox.streamable);
+                previousStreamable?.closeStreamable();
+            } catch (e) {
+                console.error("Error while closing previous streamable", e);
+                Sentry.captureException(e);
+            }
 
             videoBox.streamable.set(peer);
         });

--- a/play/src/front/Space/SpacePeerManager/CommunicationMessageType.ts
+++ b/play/src/front/Space/SpacePeerManager/CommunicationMessageType.ts
@@ -1,8 +1,6 @@
 export enum CommunicationMessageType {
-    PREPARE_SWITCH_MESSAGE = "prepareSwitchMessage",
-    EXECUTE_SWITCH_MESSAGE = "executeSwitchMessage",
-    COMMUNICATION_STRATEGY_MESSAGE = "communicationStrategyMessage",
+    SWITCH_MESSAGE = "switchMessage",
+    FINALIZE_SWITCH_MESSAGE = "finalizeSwitchMessage",
     LIVEKIT_INVITATION_MESSAGE = "livekitInvitationMessage",
     LIVEKIT_DISCONNECT_MESSAGE = "livekitDisconnectMessage",
-    CANCEL_SWITCH_MESSAGE = "cancelSwitchMessage",
 }

--- a/play/src/front/Space/SpacePeerManager/DefaultCommunicationState.ts
+++ b/play/src/front/Space/SpacePeerManager/DefaultCommunicationState.ts
@@ -25,4 +25,8 @@ export class DefaultCommunicationState implements ICommunicationState {
     getScreenSharingForUser(spaceUserId: string): Streamable | undefined {
         return undefined;
     }
+
+    shutdown(): void {
+        return;
+    }
 }

--- a/play/src/front/Space/SpacePeerManager/DefaultCommunicationState.ts
+++ b/play/src/front/Space/SpacePeerManager/DefaultCommunicationState.ts
@@ -1,36 +1,9 @@
 import { Subscription } from "rxjs";
-import { Readable } from "svelte/store";
-import { SpaceInterface } from "../SpaceInterface";
-import { CommunicationType } from "../../Livekit/LivekitConnection";
 import { Streamable } from "../../Stores/StreamableCollectionStore";
-import { SimplePeerConnectionInterface, ICommunicationState, StreamableSubjects } from "./SpacePeerManager";
-import { LivekitState } from "./LivekitState";
-import { WebRTCState } from "./WebRTCState";
-import { CommunicationMessageType } from "./CommunicationMessageType";
+import { SimplePeerConnectionInterface, ICommunicationState } from "./SpacePeerManager";
 
 export class DefaultCommunicationState implements ICommunicationState {
     private _rxJsUnsubscribers: Subscription[] = [];
-    constructor(
-        private _space: SpaceInterface,
-        private _streamableSubjects: StreamableSubjects,
-        blockedUsersStore: Readable<Set<string>>
-    ) {
-        this._rxJsUnsubscribers.push(
-            this._space
-                .observePrivateEvent(CommunicationMessageType.COMMUNICATION_STRATEGY_MESSAGE)
-                .subscribe((message) => {
-                    if (message.communicationStrategyMessage.strategy === CommunicationType.WEBRTC) {
-                        const nextState = new WebRTCState(this._space, this._streamableSubjects, blockedUsersStore);
-                        this._space.spacePeerManager.setState(nextState);
-                    }
-                    if (message.communicationStrategyMessage.strategy === CommunicationType.LIVEKIT) {
-                        const nextState = new LivekitState(this._space, this._streamableSubjects, blockedUsersStore);
-                        this._space.spacePeerManager.setState(nextState);
-                    }
-                })
-        );
-    }
-
     destroy() {
         this._rxJsUnsubscribers.forEach((unsubscriber) => unsubscriber.unsubscribe());
     }

--- a/play/src/front/Space/SpacePeerManager/LivekitState.ts
+++ b/play/src/front/Space/SpacePeerManager/LivekitState.ts
@@ -41,4 +41,12 @@ export class LivekitState implements ICommunicationState {
     getScreenSharingForUser(spaceUserId: string): Streamable | undefined {
         return this.livekitConnection.getScreenSharingForUser(spaceUserId);
     }
+
+    /**
+     * Starts the shutdown process of the communication state. It does not remove all video peers immediately,
+     * but any asynchronous operation receiving a new stream should be ignored after this call.
+     */
+    shutdown(): void {
+        this.livekitConnection.shutdown();
+    }
 }

--- a/play/src/front/Space/SpacePeerManager/LivekitState.ts
+++ b/play/src/front/Space/SpacePeerManager/LivekitState.ts
@@ -1,76 +1,22 @@
-import { Subscription } from "rxjs";
 import * as Sentry from "@sentry/svelte";
 import { Readable } from "svelte/store";
-import { CommunicationType, LivekitConnection } from "../../Livekit/LivekitConnection";
+import { LivekitConnection } from "../../Livekit/LivekitConnection";
 import { SpaceInterface } from "../SpaceInterface";
 import { Streamable } from "../../Stores/StreamableCollectionStore";
 import { SimplePeerConnectionInterface, ICommunicationState, StreamableSubjects } from "./SpacePeerManager";
-import { WebRTCState } from "./WebRTCState";
-import { CommunicationMessageType } from "./CommunicationMessageType";
 
 export class LivekitState implements ICommunicationState {
     private livekitConnection: LivekitConnection;
-    private rxJsUnsubscribers: Subscription[] = [];
-    private _nextState: WebRTCState | null = null;
     constructor(
         private _space: SpaceInterface,
         private _streamableSubjects: StreamableSubjects,
         private _blockedUsersStore: Readable<Set<string>>
     ) {
         this.livekitConnection = new LivekitConnection(this._space, this._streamableSubjects, this._blockedUsersStore);
-
-        this.rxJsUnsubscribers.push(
-            this._space.observePrivateEvent(CommunicationMessageType.PREPARE_SWITCH_MESSAGE).subscribe((message) => {
-                if (message.prepareSwitchMessage.strategy === CommunicationType.WEBRTC) {
-                    this._nextState = new WebRTCState(this._space, this._streamableSubjects, this._blockedUsersStore);
-                }
-            })
-        );
-
-        this.rxJsUnsubscribers.push(
-            this._space.observePrivateEvent(CommunicationMessageType.EXECUTE_SWITCH_MESSAGE).subscribe((message) => {
-                if (message.executeSwitchMessage.strategy === CommunicationType.WEBRTC) {
-                    if (!this._nextState) {
-                        console.error("Next state is null");
-                        return;
-                    }
-
-                    this._space.spacePeerManager.setState(this._nextState);
-                    this._nextState = null;
-                }
-            })
-        );
-
-        this.rxJsUnsubscribers.push(
-            this._space
-                .observePrivateEvent(CommunicationMessageType.COMMUNICATION_STRATEGY_MESSAGE)
-                .subscribe((message) => {
-                    if (message.communicationStrategyMessage.strategy === CommunicationType.WEBRTC) {
-                        const nextState = new WebRTCState(
-                            this._space,
-                            this._streamableSubjects,
-                            this._blockedUsersStore
-                        );
-                        this._space.spacePeerManager.setState(nextState);
-                    }
-                })
-        );
-
-        this.rxJsUnsubscribers.push(
-            this._space.observePrivateEvent(CommunicationMessageType.CANCEL_SWITCH_MESSAGE).subscribe((message) => {
-                if (message.cancelSwitchMessage.strategy === CommunicationType.WEBRTC && this._nextState) {
-                    this._nextState.destroy();
-                    this._nextState = null;
-                }
-            })
-        );
     }
 
     destroy() {
         this.livekitConnection.destroy();
-        for (const subscription of this.rxJsUnsubscribers) {
-            subscription.unsubscribe();
-        }
     }
 
     getPeer(): SimplePeerConnectionInterface | undefined {

--- a/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
+++ b/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
@@ -195,6 +195,10 @@ export class SpacePeerManager {
     }
 
     destroy(): void {
+        if (this._toFinalizeState) {
+            this._toFinalizeState.destroy();
+        }
+
         if (this._communicationState) {
             this._communicationState.destroy();
         }

--- a/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
+++ b/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
@@ -101,6 +101,7 @@ export class SpacePeerManager {
         this.rxJsUnsubscribers.push(
             this.space.observePrivateEvent(CommunicationMessageType.SWITCH_MESSAGE).subscribe((message) => {
                 debug("Switching communication strategy to " + message.switchMessage.strategy);
+                console.warn("Switching communication strategy to " + message.switchMessage.strategy);
                 if (this._toFinalizeState && !(this._toFinalizeState instanceof DefaultCommunicationState)) {
                     console.error(
                         "A state is already pending finalization. The back should have send us a finalize message before."

--- a/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
+++ b/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
@@ -1,6 +1,8 @@
 // -------------------- Default Implementations --------------------x
 
-import { Subject } from "rxjs";
+import Debug from "debug";
+import { Subject, Subscription } from "rxjs";
+import * as Sentry from "@sentry/svelte";
 import { Readable, Unsubscriber } from "svelte/store";
 import { SpaceInterface } from "../SpaceInterface";
 import { LocalStreamStoreValue, requestedCameraState, requestedMicrophoneState } from "../../Stores/MediaStore";
@@ -8,7 +10,13 @@ import { screenSharingLocalStreamStore } from "../../Stores/ScreenSharingStore";
 import { Streamable } from "../../Stores/StreamableCollectionStore";
 import { nbSoundPlayedInBubbleStore } from "../../Stores/ApparentMediaContraintStore";
 import { bindMuteEventsToSpace } from "../Utils/BindMuteEvents";
+import { CommunicationType } from "../../Livekit/LivekitConnection";
 import { DefaultCommunicationState } from "./DefaultCommunicationState";
+import { CommunicationMessageType } from "./CommunicationMessageType";
+import { WebRTCState } from "./WebRTCState";
+import { LivekitState } from "./LivekitState";
+
+export const debug = Debug("SpacePeerManager");
 
 export interface ICommunicationState {
     getPeer(): SimplePeerConnectionInterface | undefined;
@@ -46,6 +54,7 @@ export class SpacePeerManager {
     private unsubscribes: Unsubscriber[] = [];
 
     private _communicationState: ICommunicationState;
+    private _toFinalizeState: ICommunicationState | undefined;
 
     private readonly _videoPeerAdded = new Subject<Streamable>();
     public readonly videoPeerAdded = this._videoPeerAdded.asObservable();
@@ -58,6 +67,7 @@ export class SpacePeerManager {
 
     private readonly _screenSharingPeerRemoved = new Subject<Streamable>();
     public readonly screenSharingPeerRemoved = this._screenSharingPeerRemoved.asObservable();
+    private rxJsUnsubscribers: Subscription[] = [];
 
     private readonly _streamableSubjects = {
         videoPeerAdded: this._videoPeerAdded,
@@ -74,10 +84,53 @@ export class SpacePeerManager {
         private screenSharingStateStore: Readable<LocalStreamStoreValue> = screenSharingLocalStreamStore,
         _bindMuteEventsToSpace: (space: SpaceInterface) => void = bindMuteEventsToSpace
     ) {
-        this._communicationState = new DefaultCommunicationState(
-            this.space,
-            this._streamableSubjects,
-            blockedUsersStore
+        this._communicationState = new DefaultCommunicationState();
+
+        this.rxJsUnsubscribers.push(
+            this.space.observePrivateEvent(CommunicationMessageType.SWITCH_MESSAGE).subscribe((message) => {
+                debug("Switching communication strategy to " + message.switchMessage.strategy);
+                if (this._toFinalizeState && !(this._toFinalizeState instanceof DefaultCommunicationState)) {
+                    console.error(
+                        "A state is already pending finalization. The back should have send us a finalize message before."
+                    );
+                    Sentry.captureMessage(
+                        "A state is already pending finalization. The back should have send us a finalize message before."
+                    );
+                }
+                this._toFinalizeState = this._communicationState;
+                if (message.switchMessage.strategy === CommunicationType.WEBRTC) {
+                    this._communicationState = new WebRTCState(this.space, this._streamableSubjects, blockedUsersStore);
+                } else if (message.switchMessage.strategy === CommunicationType.LIVEKIT) {
+                    this._communicationState = new LivekitState(
+                        this.space,
+                        this._streamableSubjects,
+                        blockedUsersStore
+                    );
+                } else {
+                    console.error("Unknown communication strategy: " + message.switchMessage.strategy);
+                    Sentry.captureMessage("Unknown communication strategy: " + message.switchMessage.strategy);
+                }
+
+                this.setState(this._communicationState);
+            })
+        );
+
+        this.rxJsUnsubscribers.push(
+            this.space.observePrivateEvent(CommunicationMessageType.FINALIZE_SWITCH_MESSAGE).subscribe((message) => {
+                debug("Finalizing previous communication strategy " + message.finalizeSwitchMessage.strategy);
+                if (!this._toFinalizeState) {
+                    console.error(
+                        "No state is pending finalization. The back should have send us a switch message before."
+                    );
+                    Sentry.captureMessage(
+                        "No state is pending finalization. The back should have send us a switch message before."
+                    );
+                    return;
+                }
+
+                this._toFinalizeState.destroy();
+                this._toFinalizeState = undefined;
+            })
         );
 
         _bindMuteEventsToSpace(this.space);
@@ -136,17 +189,16 @@ export class SpacePeerManager {
         for (const unsubscribe of this.unsubscribes) {
             unsubscribe();
         }
+        for (const subscription of this.rxJsUnsubscribers) {
+            subscription.unsubscribe();
+        }
     }
 
     getPeer(): SimplePeerConnectionInterface | undefined {
         return this._communicationState.getPeer();
     }
 
-    setState(state: ICommunicationState): void {
-        if (this._communicationState) {
-            this._communicationState.destroy();
-        }
-
+    private setState(state: ICommunicationState): void {
         if (state.shouldSynchronizeMediaState()) {
             this.synchronizeMediaState();
         } else {

--- a/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
+++ b/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
@@ -11,7 +11,6 @@ import { Streamable } from "../../Stores/StreamableCollectionStore";
 import { nbSoundPlayedInBubbleStore } from "../../Stores/ApparentMediaContraintStore";
 import { bindMuteEventsToSpace } from "../Utils/BindMuteEvents";
 import { CommunicationType } from "../../Livekit/LivekitConnection";
-import { localUserStore } from "../../Connection/LocalUserStore";
 import { DefaultCommunicationState } from "./DefaultCommunicationState";
 import { CommunicationMessageType } from "./CommunicationMessageType";
 import { WebRTCState } from "./WebRTCState";
@@ -101,12 +100,6 @@ export class SpacePeerManager {
 
         this.rxJsUnsubscribers.push(
             this.space.observePrivateEvent(CommunicationMessageType.SWITCH_MESSAGE).subscribe((message) => {
-                console.warn(
-                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa Switching communication strategy to " +
-                        message.switchMessage.strategy +
-                        " for " +
-                        localUserStore.getName()
-                );
                 debug("Switching communication strategy to " + message.switchMessage.strategy);
                 if (this._toFinalizeState && !(this._toFinalizeState instanceof DefaultCommunicationState)) {
                     console.error(
@@ -137,12 +130,6 @@ export class SpacePeerManager {
 
         this.rxJsUnsubscribers.push(
             this.space.observePrivateEvent(CommunicationMessageType.FINALIZE_SWITCH_MESSAGE).subscribe((message) => {
-                console.warn(
-                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa Finalizing previous communication strategy " +
-                        message.finalizeSwitchMessage.strategy +
-                        " for " +
-                        localUserStore.getName()
-                );
                 debug("Finalizing previous communication strategy " + message.finalizeSwitchMessage.strategy);
                 if (!this._toFinalizeState) {
                     console.error(

--- a/play/src/front/Space/SpacePeerManager/WebRTCState.ts
+++ b/play/src/front/Space/SpacePeerManager/WebRTCState.ts
@@ -59,4 +59,12 @@ export class WebRTCState implements ICommunicationState {
     getScreenSharingForUser(spaceUserId: string): Streamable | undefined {
         return this._peer.getScreenSharingForUser(spaceUserId);
     }
+
+    /**
+     * Starts the shutdown process of the communication state. It does not remove all video peers immediately,
+     * but any asynchronous operation receiving a new stream should be ignored after this call.
+     */
+    shutdown(): void {
+        this._peer.shutdown();
+    }
 }

--- a/play/src/front/Space/SpacePeerManager/WebRTCState.ts
+++ b/play/src/front/Space/SpacePeerManager/WebRTCState.ts
@@ -1,17 +1,13 @@
-import { Subscription } from "rxjs";
 import { Readable } from "svelte/store";
-import { CommunicationType } from "../../Livekit/LivekitConnection";
 import { SimplePeer } from "../../WebRtc/SimplePeer";
 import { SpaceInterface } from "../SpaceInterface";
 import { Streamable } from "../../Stores/StreamableCollectionStore";
-import { LivekitState } from "./LivekitState";
 import {
     SimplePeerConnectionInterface,
     PeerFactoryInterface,
     ICommunicationState,
     StreamableSubjects,
 } from "./SpacePeerManager";
-import { CommunicationMessageType } from "./CommunicationMessageType";
 
 export const defaultPeerFactory: PeerFactoryInterface = {
     create: (
@@ -25,9 +21,7 @@ export const defaultPeerFactory: PeerFactoryInterface = {
 };
 
 export class WebRTCState implements ICommunicationState {
-    private _peer: SimplePeerConnectionInterface;
-    private _nextState: LivekitState | null = null;
-    private _rxJsUnsubscribers: Subscription[] = [];
+    private readonly _peer: SimplePeerConnectionInterface;
 
     constructor(
         private _space: SpaceInterface,
@@ -36,42 +30,10 @@ export class WebRTCState implements ICommunicationState {
         private _peerFactory: PeerFactoryInterface = defaultPeerFactory
     ) {
         this._peer = this._peerFactory.create(this._space, this._streamableSubjects, _blockedUsersStore);
-
-        this._rxJsUnsubscribers.push(
-            this._space.observePrivateEvent(CommunicationMessageType.PREPARE_SWITCH_MESSAGE).subscribe((message) => {
-                if (message.prepareSwitchMessage.strategy === CommunicationType.LIVEKIT && this._nextState === null) {
-                    this._nextState = new LivekitState(this._space, this._streamableSubjects, _blockedUsersStore);
-                }
-            })
-        );
-
-        this._rxJsUnsubscribers.push(
-            this._space.observePrivateEvent(CommunicationMessageType.EXECUTE_SWITCH_MESSAGE).subscribe((message) => {
-                if (message.executeSwitchMessage.strategy === CommunicationType.LIVEKIT) {
-                    if (!this._nextState) {
-                        //throw new Error("Next state is null");
-                        console.error("Next state is null");
-                        return;
-                    }
-                    this._space.spacePeerManager.setState(this._nextState);
-                    this._nextState = null;
-                }
-            })
-        );
-
-        this._rxJsUnsubscribers.push(
-            this._space.observePrivateEvent(CommunicationMessageType.CANCEL_SWITCH_MESSAGE).subscribe((message) => {
-                if (message.cancelSwitchMessage.strategy === CommunicationType.LIVEKIT && this._nextState) {
-                    this._nextState.destroy();
-                    this._nextState = null;
-                }
-            })
-        );
     }
 
     destroy() {
         this._peer.destroy();
-        this._rxJsUnsubscribers.forEach((unsubscriber) => unsubscriber.unsubscribe());
     }
 
     getPeer(): SimplePeerConnectionInterface | undefined {

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -278,6 +278,7 @@ export const screenSharingLocalMedia = readable<Streamable | undefined>(undefine
         once: (event: string, callback: (...args: unknown[]) => void) => {
             callback();
         },
+        closeStreamable: () => {},
     } satisfies Streamable;
 
     const unsubscribe = screenSharingLocalStreamStore.subscribe((screenSharingLocalStream) => {

--- a/play/src/front/Stores/ScriptingVideoStore.ts
+++ b/play/src/front/Stores/ScriptingVideoStore.ts
@@ -29,6 +29,7 @@ function createStreamableFromVideo(url: string, config: VideoConfig): Streamable
         once: (event: string, callback: (...args: unknown[]) => void) => {
             callback();
         },
+        closeStreamable: () => {},
     };
 }
 

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -74,6 +74,7 @@ export interface Streamable {
     readonly usePresentationMode: boolean;
     readonly once: (event: string, callback: (...args: unknown[]) => void) => void;
     readonly spaceUserId: string | undefined;
+    readonly closeStreamable: () => void;
 }
 
 export const SCREEN_SHARE_STARTING_PRIORITY = 1000; // Priority for screen sharing streams
@@ -122,6 +123,7 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL]) => {
         },
         priority: -2,
         spaceUserId: undefined,
+        closeStreamable: () => {},
     };
     return streamableToVideoBox(streamable, -2);
 });

--- a/play/src/front/WebRtc/P2PMessages/P2PMessage.ts
+++ b/play/src/front/WebRtc/P2PMessages/P2PMessage.ts
@@ -4,17 +4,11 @@ import { BlockMessage } from "./BlockMessage";
 import { UnblockMessage } from "./UnblockMessage";
 
 export const STREAM_STOPPED_MESSAGE_TYPE = "stream_stopped";
-export const STREAM_ENDED_MESSAGE_TYPE = "stream_ended";
 
 export const StreamStoppedMessage = z.object({
     type: z.literal(STREAM_STOPPED_MESSAGE_TYPE),
 });
 export type StreamStoppedMessage = z.infer<typeof StreamStoppedMessage>;
-
-export const StreamEndedMessage = z.object({
-    type: z.literal(STREAM_ENDED_MESSAGE_TYPE),
-});
-export type StreamEndedMessage = z.infer<typeof StreamEndedMessage>;
 
 export const KickOffMessage = z.object({
     type: z.literal("kickoff"),
@@ -27,7 +21,6 @@ export const P2PMessage = z.union([
     BlockMessage,
     UnblockMessage,
     KickOffMessage,
-    StreamEndedMessage,
     StreamStoppedMessage,
 ]);
 

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -217,7 +217,7 @@ export class RemotePeer extends Peer implements Streamable {
         private type: "video" | "screenSharing",
         private _spaceUserId: string,
         private _blockedUsersStore: Readable<Set<string>>,
-        private onDestroy: () => void,
+        private onDestroy: () => void
     ) {
         incrementWebRtcConnectionsCount();
         const bandwidth = get(videoBandwidthStore);

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -598,20 +598,22 @@ export class RemotePeer extends Peer implements Streamable {
      * This function is called when the RemotePeer video is replaced by a Livekit video.
      * We don't close the remote peer immediately, because we are sending data to the peer and the peer might
      * still need to receive the data while it is switching to Livekit.
-     * Instead we put the RemotePeer in a "preparing to close" state, and wait for the peer to send us a message
+     * Instead, we put the RemotePeer in a "preparing to close" state, and wait for the peer to send us a message
      * on the data channel to inform us that it has stopped sending its own stream.
      * When this message is received, the connection is closed automatically.
      * If after 5 seconds, the peer hasn't sent us the message, we close the connection anyway.
      */
     closeStreamable(): void {
         this.preparingClose = true;
-        this.write(
-            new Buffer(
-                JSON.stringify({
-                    type: STREAM_STOPPED_MESSAGE_TYPE,
-                } as StreamStoppedMessage)
-            )
-        );
+        if (!this._connected) {
+            this.write(
+                Buffer.from(
+                    JSON.stringify({
+                        type: STREAM_STOPPED_MESSAGE_TYPE,
+                    } as StreamStoppedMessage)
+                )
+            );
+        }
         this.closeStreamableTimeout = setTimeout(() => {
             this.destroy();
         }, 5000);

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -605,7 +605,7 @@ export class RemotePeer extends Peer implements Streamable {
      */
     closeStreamable(): void {
         this.preparingClose = true;
-        if (!this._connected) {
+        if (this._connected) {
             this.write(
                 Buffer.from(
                     JSON.stringify({

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -331,7 +331,7 @@ export class RemotePeer extends Peer implements Streamable {
         this.once("finish", this.finishHandler);
 
         this.localStreamStoreSubscribe = this.localStreamStore.subscribe((streamValue) => {
-            if (streamValue.type === "success" && streamValue.stream) {
+            if (streamValue.type === "success") {
                 if (streamValue.stream) {
                     this.addStream(streamValue.stream);
                     this.localStream = streamValue.stream;

--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -11,6 +11,7 @@ import { SimplePeerConnectionInterface, StreamableSubjects } from "../Space/Spac
 import { SpaceInterface, SpaceUserExtended } from "../Space/SpaceInterface";
 import { Streamable } from "../Stores/StreamableCollectionStore";
 import { localStreamStore } from "../Stores/MediaStore";
+import { localUserStore } from "../Connection/LocalUserStore";
 import { RemotePeer } from "./RemotePeer";
 import { customWebRTCLogger } from "./CustomWebRTCLogger";
 
@@ -119,6 +120,12 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         //receive message start
         this._rxJsUnsubscribers.push(
             this._space.observePrivateEvent("webRtcStartMessage").subscribe((message) => {
+                console.warn(
+                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa webRtcStartMessage received for " +
+                        localUserStore.getName() +
+                        " from " +
+                        message.sender.name
+                );
                 const webRtcStartMessage = message.webRtcStartMessage;
 
                 const user: UserSimplePeerInterface = {
@@ -221,9 +228,18 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         this._analyticsClient.addNewParticipant(peer.uniqueId, user.userId, uuid);
 
         this.videoPeers.set(user.userId, peer);
-        peer.once("stream", (stream) => {
+        //peer.once("stream", (stream) => {
+        console.warn(
+            "AAAAAAAAAAAAAAAAAAAA Adding WebRTC for user ",
+            localUserStore.getName(),
+            " remote user: ",
+            spaceUser.name
+        );
+
+        if (!this.abortController.signal.aborted) {
             this._streamableSubjects.videoPeerAdded.next(peer);
-        });
+        }
+        //});
         return peer;
     }
 
@@ -296,7 +312,10 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         });
 
         this.screenSharePeers.set(user.userId, peer);
-        this._streamableSubjects.screenSharingPeerAdded.next(peer);
+
+        if (!this.abortController.signal.aborted) {
+            this._streamableSubjects.screenSharingPeerAdded.next(peer);
+        }
 
         return peer;
     }
@@ -374,7 +393,6 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         for (const subscription of this._rxJsUnsubscribers) {
             subscription.unsubscribe();
         }
-        this.abortController.abort();
     }
 
     private receiveWebrtcSignal(data: WebRtcSignalReceivedMessageInterface, spaceUser: SpaceUserExtended) {
@@ -494,5 +512,13 @@ export class SimplePeer implements SimplePeerConnectionInterface {
 
     public getScreenSharingForUser(spaceUserId: string): Streamable | undefined {
         return this.screenSharePeers.get(spaceUserId);
+    }
+
+    /**
+     * Starts the shutdown process of the communication state. It does not remove all video peers immediately,
+     * but any asynchronous operation receiving a new stream should be ignored after this call.
+     */
+    public shutdown(): void {
+        this.abortController.abort();
     }
 }

--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -11,7 +11,6 @@ import { SimplePeerConnectionInterface, StreamableSubjects } from "../Space/Spac
 import { SpaceInterface, SpaceUserExtended } from "../Space/SpaceInterface";
 import { Streamable } from "../Stores/StreamableCollectionStore";
 import { localStreamStore } from "../Stores/MediaStore";
-import { localUserStore } from "../Connection/LocalUserStore";
 import { RemotePeer } from "./RemotePeer";
 import { customWebRTCLogger } from "./CustomWebRTCLogger";
 
@@ -120,12 +119,6 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         //receive message start
         this._rxJsUnsubscribers.push(
             this._space.observePrivateEvent("webRtcStartMessage").subscribe((message) => {
-                console.warn(
-                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa webRtcStartMessage received for " +
-                        localUserStore.getName() +
-                        " from " +
-                        message.sender.name
-                );
                 const webRtcStartMessage = message.webRtcStartMessage;
 
                 const user: UserSimplePeerInterface = {
@@ -228,18 +221,10 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         this._analyticsClient.addNewParticipant(peer.uniqueId, user.userId, uuid);
 
         this.videoPeers.set(user.userId, peer);
-        //peer.once("stream", (stream) => {
-        console.warn(
-            "AAAAAAAAAAAAAAAAAAAA Adding WebRTC for user ",
-            localUserStore.getName(),
-            " remote user: ",
-            spaceUser.name
-        );
 
         if (!this.abortController.signal.aborted) {
             this._streamableSubjects.videoPeerAdded.next(peer);
         }
-        //});
         return peer;
     }
 

--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -221,7 +221,9 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         this._analyticsClient.addNewParticipant(peer.uniqueId, user.userId, uuid);
 
         this.videoPeers.set(user.userId, peer);
-        this._streamableSubjects.videoPeerAdded.next(peer);
+        peer.once("stream", (stream) => {
+            this._streamableSubjects.videoPeerAdded.next(peer);
+        });
         return peer;
     }
 

--- a/play/src/i18n/fr-FR/actionbar.ts
+++ b/play/src/i18n/fr-FR/actionbar.ts
@@ -91,7 +91,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
             desc: "Vous pouvez demander à un utilisateur de vous suivre, et si cette demande est acceptée, son Woka vous suivra automatiquement, établissant ainsi une connexion fluide.",
         },
         lock: {
-            title: "Vérouiller la bulle",
+            title: "Verrouiller la bulle",
             desc: "En activant cette fonctionnalité, vous garantissez que personne ne pourra rejoindre la discussion. Vous êtes maître de votre espace, et seules les personnes déjà présentes peuvent interagir.",
         },
         mic: {

--- a/tests/tests/livekit.spec.ts
+++ b/tests/tests/livekit.spec.ts
@@ -269,8 +269,6 @@ test.describe('Meeting actions test', () => {
 
         await Menu.toggleMegaphoneButton(page);
 
-        page
-        .locator(".menu-container #content-liveMessage")
     await expect(page.getByRole('button', { name: 'Start live message' })).toBeVisible();
     await page.getByRole('button', { name: 'Start live message' }).click({ timeout: 10_000 });
 


### PR DESCRIPTION
- [x] adding a closeStreamable function in Streamables only implemented in RemotePeer. This function will close the connection as soon as the remote party has finished listening to our own stream.
- [x] Changing `PrepareSwitchMessage` and `SwitchMessage` and `ExecuteSwitchMessage` into `FinalizeSwitchMessage`, remove `CancelSwitch` notion
- [x] Switch happens on the `SwitchMessage`. `FinalizeSwitchMessage` is used to close connections (to Livekit OR to WebRtc peers)
- [x] Cancel becomes a direct call to `FinalizeSwitchMessage` (rather than waiting 5 seconds) followed by another call to `SwitchMessage` to run the new switch immediately.