### PR TITLE
fix: preserve custom port in Jitsi URL configuration Fixes #5064

### DIFF
--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -623,12 +623,18 @@ export class AreasPropertiesListener {
                 jitsiUrl = `https://${jitsiUrl}`;
             }
 
-            jitsiUrl = jitsiUrl.replace(/\/+/g, "/");
+            let parsedUrl: URL;
+            try {
+                parsedUrl = new URL(jitsiUrl);
+            } catch (error) {
+                console.error("Invalid Jitsi URL:", jitsiUrl, error);
+                throw new Error(`Invalid Jitsi URL: ${jitsiUrl}`, { cause: error });
+            }
 
             inJitsiStore.set(true);
 
             const coWebsite = new JitsiCoWebsite(
-                new URL(jitsiUrl),
+                parsedUrl,
                 property.width,
                 property.closable,
                 roomName,


### PR DESCRIPTION
## Description
Fixes #5064 - Jitsi rooms now correctly use custom ports specified in the configuration.

## Changes
- Modified `AreasPropertiesListener.ts` to parse `jitsiUrl` into a URL object before passing to `JitsiCoWebsite`

## Testing
 ✅ Code compiles
 ✅ Linting passes
 ✅ Type checking passes
 ❌ Unable to test with actual Jitsi instance on custom port locally.

However, tested by creating a node.js server. 😊  Would be good if @moufmouf take a look and test it with jitsi instance.
<img width="321" height="46" alt="Screenshot 2025-10-06 at 9 39 04 PM" src="https://github.com/user-attachments/assets/a5b087b8-dc50-49cd-90f3-668abd752bf2" />
