### PR TITLE
Add keyboard shortcut to cycle availability status

### DIFF
--- a/play/src/front/Components/ActionBar/AvailabilityStatus/AvailabilityStatusList.svelte
+++ b/play/src/front/Components/ActionBar/AvailabilityStatus/AvailabilityStatusList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { AvailabilityStatus } from "@workadventure/messages";
     import { resetAllStatusStoreExcept } from "../../../Rules/StatusRules/statusChangerFunctions";
-    import type { RequestedStatus } from "../../../Rules/StatusRules/statusRules";
+    import { requestedStatusChangeLockingStatuses, type RequestedStatus } from "../../../Rules/StatusRules/statusRules";
     import { availabilityStatusStore } from "../../../Stores/MediaStore";
     import { getColorHexOfStatus, getStatusLabel } from "../../../Utils/AvailabilityStatus";
     import LL from "../../../../i18n/i18n-svelte";
@@ -38,7 +38,7 @@
 
     <HeaderMenuItem label={$LL.actionbar.listStatusTitle.enable()} />
     <!-- Some status (silent, in a meeting...) are locking the status bar to only one option -->
-    {#if [AvailabilityStatus.LISTENER, AvailabilityStatus.SPEAKER, AvailabilityStatus.JITSI, AvailabilityStatus.LIVEKIT, AvailabilityStatus.BBB, AvailabilityStatus.DENY_PROXIMITY_MEETING, AvailabilityStatus.SILENT].includes($availabilityStatusStore)}
+    {#if requestedStatusChangeLockingStatuses.includes($availabilityStatusStore)}
         <button
             class="status-button group flex px-2 py-1 gap-2 items-center transition-all cursor-pointer text-sm text-neutral-100 w-full pointer-events-auto text-start rounded active:outline-none focus:outline-none"
         >

--- a/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
+++ b/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
@@ -17,7 +17,23 @@ import { isPopupJustClosed } from "../Game/Say/SayManager";
 import LL from "../../../i18n/i18n-svelte";
 import { followRoleStore, followStateStore, followUsersStore } from "../../Stores/FollowStore";
 import { localUserStore } from "../../Connection/LocalUserStore";
+import { cycleRequestedStatus } from "../../Rules/StatusRules/statusChangerFunctions";
 import type { Shortcut } from "./UserInputManager";
+
+const isTypingTarget = (target: EventTarget | null): boolean => {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+
+    return (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        target.getAttribute("role") === "textbox" ||
+        target.getAttribute("contenteditable") === "true" ||
+        target.isContentEditable
+    );
+};
 
 export class GameSceneUserInputHandler implements UserInputHandlerInterface {
     private gameScene: GameScene;
@@ -93,6 +109,12 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
             {
                 key: "F",
                 description: get(LL).menu.shortcuts.follow(),
+            },
+            // Shift + Y
+            {
+                key: "Y",
+                description: get(LL).menu.shortcuts.cycleStatus(),
+                shiftKey: true,
             },
         ];
     }
@@ -231,11 +253,7 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
                 // Handle Cmd (Mac) / Ctrl (Windows & Linux) + D for "walk my desk"
                 if (event.metaKey || event.ctrlKey) {
                     // Prevent the shortcut from being triggered when typing in input fields
-                    if (
-                        event.target instanceof HTMLInputElement ||
-                        event.target instanceof HTMLTextAreaElement ||
-                        event.target instanceof HTMLSelectElement
-                    ) {
+                    if (isTypingTarget(event.target)) {
                         return event;
                     }
                     event.preventDefault();
@@ -265,6 +283,18 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
             }
             case "KeyF": {
                 this.handleKeyF();
+                break;
+            }
+            case "KeyY": {
+                if (!event.shiftKey) break;
+                if (event.ctrlKey || event.metaKey || event.altKey) break;
+                // Don't trigger while the user is typing in a form field.
+                if (isTypingTarget(event.target)) {
+                    return event;
+                }
+                if (cycleRequestedStatus()) {
+                    event.preventDefault();
+                }
                 break;
             }
             default: {

--- a/play/src/front/Rules/StatusRules/requestedStatusCycle.ts
+++ b/play/src/front/Rules/StatusRules/requestedStatusCycle.ts
@@ -1,0 +1,18 @@
+import { AvailabilityStatus } from "@workadventure/messages";
+import type { RequestedStatus } from "./statusRules";
+
+// Cycle order matches the ProfileMenu status list (ONLINE -> BUSY -> BACK_IN_A_MOMENT -> DO_NOT_DISTURB).
+// Kept as a local copy to avoid touching the ProfileMenu component in this PR; unifying with
+// `statusToShow` can be done as a follow-up.
+export const requestedStatusCycle: ReadonlyArray<RequestedStatus | null> = [
+    null,
+    AvailabilityStatus.BUSY,
+    AvailabilityStatus.BACK_IN_A_MOMENT,
+    AvailabilityStatus.DO_NOT_DISTURB,
+];
+
+export const getNextRequestedStatus = (current: RequestedStatus | null): RequestedStatus | null => {
+    const currentIndex = requestedStatusCycle.findIndex((status) => status === current);
+    const nextIndex = (currentIndex + 1) % requestedStatusCycle.length;
+    return requestedStatusCycle[nextIndex];
+};

--- a/play/src/front/Rules/StatusRules/statusChangerFunctions.ts
+++ b/play/src/front/Rules/StatusRules/statusChangerFunctions.ts
@@ -1,9 +1,11 @@
-import { requestedStatusStore } from "../../Stores/MediaStore";
+import { get } from "svelte/store";
+import { availabilityStatusStore, requestedStatusStore } from "../../Stores/MediaStore";
 import { localUserStore } from "../../Connection/LocalUserStore";
 import { popupStore } from "../../Stores/PopupStore";
 import BubbleConfirmationModal from "../../Components/ActionBar/AvailabilityStatus/Modals/BubbleConfirmationModal.svelte";
 import ChangeStatusConfirmationModal from "../../Components/ActionBar/AvailabilityStatus/Modals/ChangeStatusConfirmationModal.svelte";
-import type { RequestedStatus } from "./statusRules";
+import { statusBlocksRequestedStatusChange, type RequestedStatus } from "./statusRules";
+import { getNextRequestedStatus } from "./requestedStatusCycle";
 
 export const askToChangeStatus = () => {
     popupStore.addPopup(ChangeStatusConfirmationModal, {}, "changeStatusConfirmationModal");
@@ -20,6 +22,15 @@ export const hideBubbleConfirmationModal = () => {
 export const resetAllStatusStoreExcept = (status: RequestedStatus | null = null) => {
     requestedStatusStore.set(status);
     localUserStore.setRequestedStatus(status);
+};
+
+export const cycleRequestedStatus = (): boolean => {
+    if (statusBlocksRequestedStatusChange(get(availabilityStatusStore))) {
+        return false;
+    }
+
+    resetAllStatusStoreExcept(getNextRequestedStatus(get(requestedStatusStore)));
+    return true;
 };
 
 export const passStatusToOnline = () => {

--- a/play/src/front/Rules/StatusRules/statusRules.ts
+++ b/play/src/front/Rules/StatusRules/statusRules.ts
@@ -29,6 +29,20 @@ export const setableStatus: Array<AvailabilityStatus> = [
     AvailabilityStatus.BACK_IN_A_MOMENT,
 ];
 
+export const requestedStatusChangeLockingStatuses: ReadonlyArray<AvailabilityStatus> = [
+    AvailabilityStatus.LISTENER,
+    AvailabilityStatus.SPEAKER,
+    AvailabilityStatus.JITSI,
+    AvailabilityStatus.LIVEKIT,
+    AvailabilityStatus.BBB,
+    AvailabilityStatus.DENY_PROXIMITY_MEETING,
+    AvailabilityStatus.SILENT,
+];
+
+export const statusBlocksRequestedStatusChange = (status: AvailabilityStatus): boolean => {
+    return requestedStatusChangeLockingStatuses.includes(status);
+};
+
 const invalidTransition: Map<AvailabilityStatus, Array<AvailabilityStatus>> = new Map([
     [AvailabilityStatus.UNCHANGED, [...setableStatus]],
     [AvailabilityStatus.ONLINE, []],

--- a/play/src/i18n/ar-SA/menu.ts
+++ b/play/src/i18n/ar-SA/menu.ts
@@ -193,6 +193,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "فتح نافذة قل",
         openThinkPopup: "فتح نافذة فكر",
         walkMyDesk: "الذهاب إلى مكتبي",
+        cycleStatus: "تبديل حالة التوفر",
     },
 };
 

--- a/play/src/i18n/ca-ES/menu.ts
+++ b/play/src/i18n/ca-ES/menu.ts
@@ -196,6 +196,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "Obrir la finestra emergent en mode dir",
         openThinkPopup: "Obrir la finestra emergent en mode pensar",
         walkMyDesk: "Caminar fins al meu escriptori",
+        cycleStatus: "Canviar l'estat de disponibilitat",
     },
 };
 

--- a/play/src/i18n/de-DE/menu.ts
+++ b/play/src/i18n/de-DE/menu.ts
@@ -196,6 +196,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "Sprech-Popup öffnen",
         openThinkPopup: "Denk-Popup öffnen",
         walkMyDesk: "Zu meinem Schreibtisch gehen",
+        cycleStatus: "Verfügbarkeitsstatus wechseln",
     },
 };
 

--- a/play/src/i18n/dsb-DE/menu.ts
+++ b/play/src/i18n/dsb-DE/menu.ts
@@ -194,6 +194,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: 'Popup „groniś" wótcyniś',
         openThinkPopup: 'Popup „mysliś" wótcyniś',
         walkMyDesk: "K mójomu blidkoju hyś",
+        cycleStatus: "Status pśipšawjeń pśešaltowaś",
     },
 };
 

--- a/play/src/i18n/en-US/menu.ts
+++ b/play/src/i18n/en-US/menu.ts
@@ -193,6 +193,7 @@ const menu: BaseTranslation = {
         openSayPopup: "Open Say Popup",
         openThinkPopup: "Open Think Popup",
         walkMyDesk: "Walk to My Desk",
+        cycleStatus: "Cycle Availability Status",
     },
 };
 

--- a/play/src/i18n/es-ES/menu.ts
+++ b/play/src/i18n/es-ES/menu.ts
@@ -196,6 +196,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "Abrir la ventana emergente en modo decir",
         openThinkPopup: "Abrir la ventana emergente en modo pensar",
         walkMyDesk: "Caminar hasta mi escritorio",
+        cycleStatus: "Cambiar estado de disponibilidad",
     },
 };
 

--- a/play/src/i18n/fr-FR/menu.ts
+++ b/play/src/i18n/fr-FR/menu.ts
@@ -174,6 +174,7 @@ const menu: DeepPartial<Translation["menu"]> = {
     },
     shortcuts: {
         walkMyDesk: "Aller à mon bureau",
+        cycleStatus: "Changer le statut de disponibilité",
         title: "Raccourcis clavier",
         keys: "Raccourci",
         actions: "Action",

--- a/play/src/i18n/hsb-DE/menu.ts
+++ b/play/src/i18n/hsb-DE/menu.ts
@@ -194,6 +194,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: 'popup „rěkać" wočinić',
         openThinkPopup: 'popup „myslić" wočinić',
         walkMyDesk: "k mojemu blidkej hić",
+        cycleStatus: "Status k disponowanju přepinać",
     },
 };
 

--- a/play/src/i18n/it-IT/menu.ts
+++ b/play/src/i18n/it-IT/menu.ts
@@ -196,6 +196,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "Apri popup di dire",
         openThinkPopup: "Apri popup di pensare",
         walkMyDesk: "Vai alla mia scrivania",
+        cycleStatus: "Cambia stato di disponibilità",
     },
 };
 

--- a/play/src/i18n/ja-JP/menu.ts
+++ b/play/src/i18n/ja-JP/menu.ts
@@ -194,6 +194,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "言うポップアップを開く",
         openThinkPopup: "考えるポップアップを開く",
         walkMyDesk: "私の机に移動",
+        cycleStatus: "ステータスを切り替える",
     },
 };
 

--- a/play/src/i18n/ko-KR/menu.ts
+++ b/play/src/i18n/ko-KR/menu.ts
@@ -192,6 +192,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "말하기 팝업 열기",
         openThinkPopup: "생각하기 팝업 열기",
         walkMyDesk: "내 책상으로 이동",
+        cycleStatus: "가용 상태 전환",
     },
 };
 

--- a/play/src/i18n/nl-NL/menu.ts
+++ b/play/src/i18n/nl-NL/menu.ts
@@ -195,6 +195,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "Zeg-popup openen",
         openThinkPopup: "Denk-popup openen",
         walkMyDesk: "Naar mijn bureau lopen",
+        cycleStatus: "Beschikbaarheidsstatus wisselen",
     },
 };
 

--- a/play/src/i18n/pt-BR/menu.ts
+++ b/play/src/i18n/pt-BR/menu.ts
@@ -195,6 +195,7 @@ const menu: BaseTranslation = {
         openSayPopup: "Abrir Popup de Fala",
         openThinkPopup: "Abrir Popup de Pensamento",
         walkMyDesk: "Ir para Minha Mesa",
+        cycleStatus: "Alternar status de disponibilidade",
     },
 };
 

--- a/play/src/i18n/zh-CN/menu.ts
+++ b/play/src/i18n/zh-CN/menu.ts
@@ -191,6 +191,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "打开说弹出窗口",
         openThinkPopup: "打开思考弹出窗口",
         walkMyDesk: "走到我的办公桌",
+        cycleStatus: "切换在线状态",
     },
 };
 

--- a/play/src/i18n/zh-TW/menu.ts
+++ b/play/src/i18n/zh-TW/menu.ts
@@ -191,6 +191,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         openSayPopup: "開啟「說」彈出視窗",
         openThinkPopup: "開啟「想」彈出視窗",
         walkMyDesk: "走到我的辦公桌",
+        cycleStatus: "切換在線狀態",
     },
 };
 

--- a/play/tests/front/Rules/StatusRules/requestedStatusCycle.test.ts
+++ b/play/tests/front/Rules/StatusRules/requestedStatusCycle.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { AvailabilityStatus } from "@workadventure/messages";
+import {
+    getNextRequestedStatus,
+    requestedStatusCycle,
+} from "../../../../src/front/Rules/StatusRules/requestedStatusCycle";
+import { statusBlocksRequestedStatusChange } from "../../../../src/front/Rules/StatusRules/statusRules";
+
+describe("requestedStatusCycle", () => {
+    it("walks through the documented order then loops back to ONLINE", () => {
+        let current = requestedStatusCycle[0];
+        const visited = [current];
+        for (let i = 0; i < requestedStatusCycle.length; i++) {
+            current = getNextRequestedStatus(current);
+            visited.push(current);
+        }
+        expect(visited).toEqual([
+            null,
+            AvailabilityStatus.BUSY,
+            AvailabilityStatus.BACK_IN_A_MOMENT,
+            AvailabilityStatus.DO_NOT_DISTURB,
+            null,
+        ]);
+    });
+
+    it("returns ONLINE when the current status is not in the cycle", () => {
+        // A system-assigned status (e.g. JITSI) should never be the user's requested status,
+        // but if it ever leaks in we want a safe fallback rather than throwing.
+        expect(getNextRequestedStatus(AvailabilityStatus.JITSI as never)).toBe(null);
+    });
+
+    it("identifies availability statuses that should lock requested status changes", () => {
+        expect(statusBlocksRequestedStatusChange(AvailabilityStatus.JITSI)).toBe(true);
+        expect(statusBlocksRequestedStatusChange(AvailabilityStatus.SILENT)).toBe(true);
+        expect(statusBlocksRequestedStatusChange(AvailabilityStatus.BUSY)).toBe(false);
+        expect(statusBlocksRequestedStatusChange(AvailabilityStatus.ONLINE)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

I often find myself wanting a quick way to change my availability status without opening the profile menu, so this PR proposes a small keyboard shortcut for it.

The new shortcut is `Shift + Y`.

The cycle order is:

`Online -> Busy -> Back in a moment -> Do not disturb -> Online`

The shortcut follows the same lock condition as the profile menu. For example, statuses such as Jitsi, BBB, LiveKit, Silent, and Speaker cannot be overridden by the shortcut.

This also adds the shortcut label to the i18n files.

## Motivation

I would eventually like to contribute more keyboard shortcuts for frequently used actions such as toggling the microphone, camera, or screen sharing.

Before going further in that direction, I wanted to start with a small availability-status shortcut and get feedback on whether this kind of shortcut would be welcome, and whether the chosen key / behavior feels right.

I’m happy to adjust the shortcut key, cycle order, or behavior based on maintainer feedback.

## Checks

- `cd play && npm run typesafe-i18n`
- `cd play && npm run i18n:check`
- `cd play && npm test -- --run tests/front/Rules/StatusRules/requestedStatusCycle.test.ts`
- `cd play && npm run svelte-check`
- `cd play && npm run typecheck`