### PR TITLE
Move Tasks Vision background processing to a Web Worker

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -174,7 +174,7 @@ UPLOAD_MAX_FILESIZE=10485760
 # Virtual background transformer engine
 # Values: "tasks-vision" (new, with GPU acceleration) or "selfie-segmentation" (legacy, CPU-based)
 # Defaults to "selfie-segmentation"
-BACKGROUND_TRANSFORMER_ENGINE=selfie-segmentation
+BACKGROUND_TRANSFORMER_ENGINE=tasks-vision
 
 # JWT secret key
 SECRET_KEY=yourSecretKey2020

--- a/.env.template
+++ b/.env.template
@@ -174,7 +174,7 @@ UPLOAD_MAX_FILESIZE=10485760
 # Virtual background transformer engine
 # Values: "tasks-vision" (new, with GPU acceleration) or "selfie-segmentation" (legacy, CPU-based)
 # Defaults to "selfie-segmentation"
-BACKGROUND_TRANSFORMER_ENGINE=tasks-vision
+BACKGROUND_TRANSFORMER_ENGINE=selfie-segmentation
 
 # JWT secret key
 SECRET_KEY=yourSecretKey2020

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -692,6 +692,7 @@ jobs:
             replicaCount: 2
             env:
               PROMETHEUS_PORT: "9090"
+              BACKGROUND_TRANSFORMER_ENGINE: "tasks-vision"
             secretEnv:
               ROOM_API_SECRET_KEY: "password"
             podAnnotations:

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker.ts
@@ -1,8 +1,7 @@
 import type { MPMask } from "@mediapipe/tasks-vision";
 import { DrawingUtils, ImageSegmenter } from "@mediapipe/tasks-vision";
-// This worker is emitted as a classic script, and MediaPipe loads this file with importScripts().
-import wasmBinaryPath from "@mediapipe/tasks-vision/vision_wasm_internal.wasm?url";
-import wasmLoaderPath from "@mediapipe/tasks-vision/vision_wasm_internal.js?url";
+import wasmBinaryPath from "@mediapipe/tasks-vision/vision_wasm_module_internal.wasm?url";
+import wasmLoaderPath from "@mediapipe/tasks-vision/vision_wasm_module_internal.js?url";
 import { TasksVisionBlurCompositor } from "./TasksVisionBlurCompositor";
 import type {
     SerializedWorkerError,

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker.ts
@@ -1,7 +1,8 @@
 import type { MPMask } from "@mediapipe/tasks-vision";
 import { DrawingUtils, ImageSegmenter } from "@mediapipe/tasks-vision";
-import wasmBinaryPath from "@mediapipe/tasks-vision/vision_wasm_module_internal.wasm?url";
-import wasmLoaderPath from "@mediapipe/tasks-vision/vision_wasm_module_internal.js?url";
+// This worker is emitted as a classic script, and MediaPipe loads this file with importScripts().
+import wasmBinaryPath from "@mediapipe/tasks-vision/vision_wasm_internal.wasm?url";
+import wasmLoaderPath from "@mediapipe/tasks-vision/vision_wasm_internal.js?url";
 import { TasksVisionBlurCompositor } from "./TasksVisionBlurCompositor";
 import type {
     SerializedWorkerError,

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker.ts
@@ -268,14 +268,25 @@ function getBackgroundCanvas(width: number, height: number): OffscreenCanvas | n
     return backgroundCanvas;
 }
 
+function closeResource(name: string, resource: { close(): void } | null): void {
+    if (!resource) {
+        return;
+    }
+    try {
+        resource.close();
+    } catch (error) {
+        console.warn(`[MediaPipe Tasks Vision Worker] Error closing ${name}:`, error);
+    }
+}
+
 function dispose(): void {
-    blurCompositor?.close();
+    closeResource("blur compositor", blurCompositor);
     blurCompositor = null;
-    drawingUtils?.close();
+    closeResource("DrawingUtils", drawingUtils);
     drawingUtils = null;
-    imageSegmenter?.close();
+    closeResource("ImageSegmenter", imageSegmenter);
     imageSegmenter = null;
-    backgroundImage?.close();
+    closeResource("background image", backgroundImage);
     backgroundImage = null;
     gl?.getExtension("WEBGL_lose_context")?.loseContext();
     gl = null;

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker.ts
@@ -1,0 +1,301 @@
+import type { MPMask } from "@mediapipe/tasks-vision";
+import { DrawingUtils, ImageSegmenter } from "@mediapipe/tasks-vision";
+import wasmBinaryPath from "@mediapipe/tasks-vision/vision_wasm_module_internal.wasm?url";
+import wasmLoaderPath from "@mediapipe/tasks-vision/vision_wasm_module_internal.js?url";
+import { TasksVisionBlurCompositor } from "./TasksVisionBlurCompositor";
+import type {
+    SerializedWorkerError,
+    TasksVisionWorkerFrame,
+    TasksVisionWorkerRequest,
+    TasksVisionWorkerResponse,
+} from "./MediaPipeTasksVisionWorkerProtocol";
+import type { BackgroundConfig } from "./createBackgroundTransformer";
+
+interface WorkerScope {
+    onmessage: ((event: MessageEvent<TasksVisionWorkerRequest>) => void) | null;
+    postMessage(message: TasksVisionWorkerResponse, transfer?: Transferable[]): void;
+}
+
+const workerScope = self as unknown as WorkerScope;
+
+let config: BackgroundConfig = { mode: "none" };
+let glCanvas: OffscreenCanvas | null = null;
+let gl: WebGL2RenderingContext | null = null;
+let imageSegmenter: ImageSegmenter | null = null;
+let drawingUtils: DrawingUtils | null = null;
+let blurCompositor: TasksVisionBlurCompositor | null = null;
+let backgroundImage: ImageBitmap | null = null;
+let backgroundImageUrl: string | null = null;
+let backgroundCanvas: OffscreenCanvas | null = null;
+let backgroundCanvasContext: OffscreenCanvasRenderingContext2D | null = null;
+let fallbackBlurredCanvas: OffscreenCanvas | null = null;
+let fallbackBlurredContext: OffscreenCanvasRenderingContext2D | null = null;
+
+function serializeError(error: unknown): SerializedWorkerError {
+    if (error instanceof Error) {
+        return { name: error.name, message: error.message, stack: error.stack };
+    }
+    return { name: "Error", message: String(error) };
+}
+
+function postMessage(message: TasksVisionWorkerResponse, transfer?: Transferable[]): void {
+    workerScope.postMessage(message, transfer);
+}
+
+async function initialize(workerConfig: BackgroundConfig, modelPath: string): Promise<void> {
+    if (typeof OffscreenCanvas === "undefined") {
+        postMessage({ type: "unsupported", reason: "OffscreenCanvas is unavailable" });
+        return;
+    }
+
+    glCanvas = new OffscreenCanvas(1, 1);
+    gl = glCanvas.getContext("webgl2");
+    if (!gl) {
+        postMessage({ type: "unsupported", reason: "WebGL2 is unavailable in OffscreenCanvas workers" });
+        return;
+    }
+
+    config = { ...workerConfig };
+
+    try {
+        const filesetResolver = { wasmLoaderPath, wasmBinaryPath };
+        let delegate: "GPU" | "CPU" = "GPU";
+
+        try {
+            imageSegmenter = await ImageSegmenter.createFromOptions(filesetResolver, {
+                baseOptions: { modelAssetPath: modelPath, delegate: "GPU" },
+                canvas: glCanvas,
+                runningMode: "VIDEO",
+                outputCategoryMask: false,
+                outputConfidenceMasks: true,
+            });
+        } catch (gpuError) {
+            console.warn("[MediaPipe Tasks Vision Worker] GPU initialization failed, using CPU:", gpuError);
+            delegate = "CPU";
+            imageSegmenter = await ImageSegmenter.createFromOptions(filesetResolver, {
+                baseOptions: { modelAssetPath: modelPath, delegate: "CPU" },
+                canvas: glCanvas,
+                runningMode: "VIDEO",
+                outputCategoryMask: false,
+                outputConfidenceMasks: true,
+            });
+        }
+
+        drawingUtils = new DrawingUtils(gl);
+        blurCompositor = new TasksVisionBlurCompositor(gl, glCanvas);
+        await updateBackgroundImage();
+        postMessage({ type: "ready", delegate });
+    } catch (error) {
+        dispose();
+        postMessage({ type: "initialization-error", error: serializeError(error) });
+    }
+}
+
+async function updateBackgroundImage(): Promise<void> {
+    const nextUrl = config.mode === "image" ? config.backgroundImage : undefined;
+    if (nextUrl === backgroundImageUrl) {
+        return;
+    }
+
+    let nextBackgroundImage: ImageBitmap | null = null;
+    if (nextUrl) {
+        const response = await fetch(nextUrl);
+        if (!response.ok) {
+            throw new Error(`Failed to load background image: HTTP ${response.status}`);
+        }
+        nextBackgroundImage = await createImageBitmap(await response.blob());
+    }
+
+    backgroundImage?.close();
+    backgroundImage = nextBackgroundImage;
+    // Worker requests are serialized through messageQueue, so this cannot race another update.
+    // eslint-disable-next-line require-atomic-updates
+    backgroundImageUrl = nextUrl ?? null;
+    backgroundCanvas = null;
+    backgroundCanvasContext = null;
+}
+
+async function updateConfig(requestId: number, nextConfig: Partial<BackgroundConfig>): Promise<void> {
+    try {
+        Object.assign(config, nextConfig);
+        await updateBackgroundImage();
+        postMessage({ type: "config-updated", requestId });
+    } catch (error) {
+        postMessage({ type: "config-update-error", requestId, error: serializeError(error) });
+    }
+}
+
+function processFrame(message: TasksVisionWorkerFrame): void {
+    const { frame, backgroundFrame, frameId, timestampMs, width, height } = message;
+    let frameTransferred = false;
+
+    try {
+        if (!imageSegmenter || !glCanvas || !gl) {
+            throw new Error("MediaPipe worker received a frame before initialization");
+        }
+        const activeCanvas = glCanvas;
+        const activeGl = gl;
+
+        if (activeCanvas.width !== width || activeCanvas.height !== height) {
+            activeCanvas.width = width;
+            activeCanvas.height = height;
+        }
+
+        let outputBitmap: ImageBitmap | null = null;
+        let blurBackend: "webgl-blur" | "none" = "none";
+
+        imageSegmenter.segmentForVideo(frame, timestampMs, (result) => {
+            const mask = result.confidenceMasks?.[0];
+            if (!mask) {
+                return;
+            }
+
+            blurBackend = renderFrame(frame, backgroundFrame, mask, width, height);
+            activeGl.flush();
+            outputBitmap = activeCanvas.transferToImageBitmap();
+        });
+
+        if (!outputBitmap) {
+            outputBitmap = frame;
+            frameTransferred = true;
+        }
+
+        postMessage({ type: "frame", frameId, bitmap: outputBitmap, blurBackend }, [outputBitmap]);
+    } catch (error) {
+        postMessage({
+            type: "frame-error",
+            frameId,
+            error: serializeError(error),
+            webGlContextLost: gl?.isContextLost() ?? true,
+        });
+    } finally {
+        if (!frameTransferred) {
+            frame.close();
+        }
+        backgroundFrame?.close();
+    }
+}
+
+function renderFrame(
+    frame: ImageBitmap,
+    backgroundFrame: ImageBitmap | undefined,
+    mask: MPMask,
+    width: number,
+    height: number,
+): "webgl-blur" | "none" {
+    if (!drawingUtils) {
+        throw new Error("DrawingUtils is unavailable");
+    }
+
+    if (config.mode === "blur") {
+        if (blurCompositor?.draw(frame, mask, width, height, config.blurAmount || 15)) {
+            return "webgl-blur";
+        }
+
+        const blurredCanvas = getFallbackBlurredCanvas(width, height);
+        fallbackBlurredContext!.filter = `blur(${config.blurAmount || 15}px)`;
+        fallbackBlurredContext!.drawImage(frame, 0, 0, width, height);
+        fallbackBlurredContext!.filter = "none";
+        drawingUtils.drawConfidenceMask(mask, blurredCanvas, frame);
+        return "none";
+    }
+
+    if (config.mode === "image") {
+        const imageCanvas = getBackgroundCanvas(width, height);
+        drawingUtils.drawConfidenceMask(mask, imageCanvas ?? [0, 0, 0, 255], frame);
+        return "none";
+    }
+
+    if (config.mode === "video") {
+        drawingUtils.drawConfidenceMask(mask, backgroundFrame ?? [0, 0, 0, 255], frame);
+        return "none";
+    }
+
+    throw new Error(`Unsupported background mode: ${config.mode}`);
+}
+
+function getFallbackBlurredCanvas(width: number, height: number): OffscreenCanvas {
+    if (!fallbackBlurredCanvas) {
+        fallbackBlurredCanvas = new OffscreenCanvas(width, height);
+        fallbackBlurredContext = fallbackBlurredCanvas.getContext("2d");
+        if (!fallbackBlurredContext) {
+            throw new Error("Unable to create fallback blur canvas");
+        }
+    }
+    if (fallbackBlurredCanvas.width !== width || fallbackBlurredCanvas.height !== height) {
+        fallbackBlurredCanvas.width = width;
+        fallbackBlurredCanvas.height = height;
+    }
+    fallbackBlurredContext!.clearRect(0, 0, width, height);
+    return fallbackBlurredCanvas;
+}
+
+function getBackgroundCanvas(width: number, height: number): OffscreenCanvas | null {
+    if (!backgroundImage) {
+        return null;
+    }
+
+    let needsRedraw = false;
+    if (!backgroundCanvas) {
+        backgroundCanvas = new OffscreenCanvas(width, height);
+        backgroundCanvasContext = backgroundCanvas.getContext("2d");
+        if (!backgroundCanvasContext) {
+            throw new Error("Unable to create background image canvas");
+        }
+        needsRedraw = true;
+    }
+
+    if (backgroundCanvas.width !== width || backgroundCanvas.height !== height) {
+        backgroundCanvas.width = width;
+        backgroundCanvas.height = height;
+        needsRedraw = true;
+    }
+    if (!needsRedraw) {
+        return backgroundCanvas;
+    }
+
+    const scale = Math.max(width / backgroundImage.width, height / backgroundImage.height);
+    const scaledWidth = backgroundImage.width * scale;
+    const scaledHeight = backgroundImage.height * scale;
+    backgroundCanvasContext!.clearRect(0, 0, width, height);
+    backgroundCanvasContext!.drawImage(
+        backgroundImage,
+        (width - scaledWidth) / 2,
+        (height - scaledHeight) / 2,
+        scaledWidth,
+        scaledHeight,
+    );
+    return backgroundCanvas;
+}
+
+function dispose(): void {
+    blurCompositor?.close();
+    blurCompositor = null;
+    drawingUtils?.close();
+    drawingUtils = null;
+    imageSegmenter?.close();
+    imageSegmenter = null;
+    backgroundImage?.close();
+    backgroundImage = null;
+    gl?.getExtension("WEBGL_lose_context")?.loseContext();
+    gl = null;
+    glCanvas = null;
+}
+
+let messageQueue = Promise.resolve();
+workerScope.onmessage = (event): void => {
+    messageQueue = messageQueue
+        .then(async () => {
+            const message = event.data;
+            if (message.type === "initialize") {
+                await initialize(message.config, message.modelPath);
+            } else if (message.type === "update-config") {
+                await updateConfig(message.requestId, message.config);
+            } else {
+                processFrame(message);
+            }
+        })
+        .catch((error: unknown) => {
+            console.error("[MediaPipe Tasks Vision Worker] Unexpected worker error:", error);
+        });
+};

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerProtocol.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerProtocol.ts
@@ -1,0 +1,43 @@
+import type { BackgroundConfig } from "./createBackgroundTransformer";
+
+export type TasksVisionWorkerInitialization = {
+    type: "initialize";
+    config: BackgroundConfig;
+    modelPath: string;
+};
+
+export type TasksVisionWorkerFrame = {
+    type: "process-frame";
+    frameId: number;
+    frame: ImageBitmap;
+    backgroundFrame?: ImageBitmap;
+    timestampMs: number;
+    width: number;
+    height: number;
+};
+
+export type TasksVisionWorkerConfigUpdate = {
+    type: "update-config";
+    requestId: number;
+    config: Partial<BackgroundConfig>;
+};
+
+export type TasksVisionWorkerRequest =
+    | TasksVisionWorkerInitialization
+    | TasksVisionWorkerFrame
+    | TasksVisionWorkerConfigUpdate;
+
+export type SerializedWorkerError = {
+    name: string;
+    message: string;
+    stack?: string;
+};
+
+export type TasksVisionWorkerResponse =
+    | { type: "ready"; delegate: "GPU" | "CPU" }
+    | { type: "unsupported"; reason: string }
+    | { type: "initialization-error"; error: SerializedWorkerError }
+    | { type: "frame"; frameId: number; bitmap: ImageBitmap; blurBackend: "webgl-blur" | "none" }
+    | { type: "frame-error"; frameId: number; error: SerializedWorkerError; webGlContextLost: boolean }
+    | { type: "config-updated"; requestId: number }
+    | { type: "config-update-error"; requestId: number; error: SerializedWorkerError };

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.ts
@@ -1,8 +1,7 @@
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
-// MediaPipe loads its generated WASM loader with importScripts(), so this worker
-// must have an HTTP URL rather than a blob URL.
-import TasksVisionWorker from "./MediaPipeTasksVisionWorker?worker";
+// Use an emitted URL so the worker type stays explicit in both dev and production.
+import tasksVisionWorkerUrl from "./MediaPipeTasksVisionWorker?worker&url";
 import type {
     SerializedWorkerError,
     TasksVisionWorkerRequest,
@@ -148,7 +147,7 @@ export class MediaPipeTasksVisionWorkerTransformer implements BackgroundTransfor
             throw new Error("Cannot initialize a closed Tasks Vision transformer");
         }
 
-        const worker = new TasksVisionWorker();
+        const worker = new Worker(tasksVisionWorkerUrl, { type: "module" });
         this.worker = worker;
         worker.onmessage = (event: MessageEvent<TasksVisionWorkerResponse>) => this.handleWorkerMessage(event.data);
         worker.onerror = (event: ErrorEvent) => {

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.ts
@@ -1,0 +1,675 @@
+import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
+import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
+import TasksVisionWorker from "./MediaPipeTasksVisionWorker?worker&inline";
+import type {
+    SerializedWorkerError,
+    TasksVisionWorkerRequest,
+    TasksVisionWorkerResponse,
+} from "./MediaPipeTasksVisionWorkerProtocol";
+import type { MediaPipeTasksVisionTransformer } from "./MediaPipeTasksVisionTransformer";
+import type {
+    BackgroundConfig,
+    BackgroundTransformer,
+    BackgroundTransformerFailureHandler,
+} from "./createBackgroundTransformer";
+
+const DEFAULT_FRAME_RATE = 30;
+const WORKER_INITIALIZATION_TIMEOUT_MS = 30_000;
+const MAX_CONSECUTIVE_RECOVERY_ATTEMPTS = 2;
+const SUCCESSFUL_FRAMES_BEFORE_RECOVERY_RESET = 30;
+
+class UnsupportedTasksVisionWorkerError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "UnsupportedTasksVisionWorkerError";
+    }
+}
+
+type PendingConfigRequest = {
+    resolve: () => void;
+    reject: (error: Error) => void;
+};
+
+type PendingInitialFrame = PendingConfigRequest & {
+    generation: number;
+};
+
+function deserializeError(error: SerializedWorkerError): Error {
+    const deserialized = new Error(error.message);
+    deserialized.name = error.name;
+    deserialized.stack = error.stack;
+    return deserialized;
+}
+
+/**
+ * Runs Tasks Vision inference and compositing in a dedicated worker.
+ *
+ * Safari 16 is the only supported browser family that needs the main-thread
+ * compatibility fallback below: 16.0-16.3 has no OffscreenCanvas and 16.4-16.6
+ * only supports its 2D context in workers. Safari 17 added OffscreenCanvas WebGL.
+ * Once WorkAdventure no longer supports Safari 16, remove
+ * UnsupportedTasksVisionWorkerError and MediaPipeTasksVisionTransformer from this
+ * class. Worker restart and terminal-error handling are runtime recovery, not part
+ * of that removable browser compatibility fallback.
+ */
+export class MediaPipeTasksVisionWorkerTransformer implements BackgroundTransformer {
+    private readonly outputCanvas: HTMLCanvasElement;
+    private readonly outputContext: CanvasRenderingContext2D;
+    private readonly inputVideo: HTMLVideoElement;
+    private config: BackgroundConfig;
+    private worker: Worker | null = null;
+    private fallback: MediaPipeTasksVisionTransformer | null = null;
+    private backgroundVideo: HTMLVideoElement | null = null;
+    private backgroundVideoUrl: string | null = null;
+    private outputStream: MediaStream | null = null;
+    private initPromise: Promise<void>;
+    private workerInitializationResolve: (() => void) | null = null;
+    private workerInitializationReject: ((error: Error) => void) | null = null;
+    private workerInitializationTimeout: ReturnType<typeof setTimeout> | null = null;
+    private pendingConfigRequests = new Map<number, PendingConfigRequest>();
+    private pendingInitialFrame: PendingInitialFrame | null = null;
+    private nextConfigRequestId = 1;
+    private timeoutId: ReturnType<typeof setTimeout> | null = null;
+    private recoveryPromise: Promise<void> | null = null;
+    private frameRate = DEFAULT_FRAME_RATE;
+    private frameIntervalMs = 1000 / DEFAULT_FRAME_RATE;
+    private frameInFlight = false;
+    private activeFrameId: number | null = null;
+    private activeFrameGeneration = 0;
+    private nextFrameId = 1;
+    private streamGeneration = 0;
+    private lastTimestampMs = -1;
+    private consecutiveRecoveryAttempts = 0;
+    private successfulFramesSinceRecovery = 0;
+    private frameCount = 0;
+    private startTime = performance.now();
+    private blurBackend: "webgl-blur" | "none" = "none";
+    private workerDelegate: "GPU" | "CPU" | "none" = "none";
+    private processingEnabled = false;
+    private closed = false;
+
+    constructor(
+        config: BackgroundConfig,
+        private readonly onTerminalFailure?: BackgroundTransformerFailureHandler,
+    ) {
+        this.config = { ...config };
+        this.outputCanvas = document.createElement("canvas");
+        const outputContext = this.outputCanvas.getContext("2d", { alpha: false, desynchronized: true });
+        if (!outputContext) {
+            throw new Error("Unable to create Tasks Vision output canvas");
+        }
+        this.outputContext = outputContext;
+
+        this.inputVideo = document.createElement("video");
+        this.inputVideo.autoplay = true;
+        this.inputVideo.muted = true;
+        this.inputVideo.playsInline = true;
+
+        this.initPromise = this.initialize();
+    }
+
+    private async initialize(): Promise<void> {
+        try {
+            await this.startWorker();
+            await this.updateBackgroundVideo();
+        } catch (error) {
+            this.terminateWorker();
+            if (!(error instanceof UnsupportedTasksVisionWorkerError)) {
+                throw error;
+            }
+
+            console.info(
+                `[MediaPipe Tasks Vision] Worker rendering is unsupported (${error.message}); ` +
+                    "using the Safari 16 main-thread compatibility fallback.",
+            );
+            const { MediaPipeTasksVisionTransformer } = await import("./MediaPipeTasksVisionTransformer");
+            const fallback = new MediaPipeTasksVisionTransformer({ ...this.config }, this.onTerminalFailure);
+            this.fallback = fallback;
+            await fallback.waitForInitialization();
+        }
+    }
+
+    private async startWorker(): Promise<void> {
+        if (
+            typeof Worker === "undefined" ||
+            typeof OffscreenCanvas === "undefined" ||
+            typeof createImageBitmap === "undefined"
+        ) {
+            throw new UnsupportedTasksVisionWorkerError("required worker canvas APIs are unavailable");
+        }
+        if (this.closed) {
+            throw new Error("Cannot initialize a closed Tasks Vision transformer");
+        }
+
+        const worker = new TasksVisionWorker();
+        this.worker = worker;
+        worker.onmessage = (event: MessageEvent<TasksVisionWorkerResponse>) => this.handleWorkerMessage(event.data);
+        worker.onerror = (event: ErrorEvent) => {
+            event.preventDefault();
+            const error =
+                event.error instanceof Error ? event.error : new Error(event.message || "Tasks Vision worker error");
+            if (this.workerInitializationReject) {
+                this.rejectWorkerInitialization(error);
+            } else {
+                this.startRecovery(error);
+            }
+        };
+
+        const initializationPromise = new Promise<void>((resolve, reject) => {
+            this.workerInitializationResolve = resolve;
+            this.workerInitializationReject = reject;
+            this.workerInitializationTimeout = setTimeout(() => {
+                this.rejectWorkerInitialization(new Error("Tasks Vision worker initialization timed out"));
+            }, WORKER_INITIALIZATION_TIMEOUT_MS);
+        });
+
+        const baseUrl = document.baseURI;
+        try {
+            this.postToWorker({
+                type: "initialize",
+                config: {
+                    ...this.config,
+                    backgroundImage: this.resolveDocumentUrl(this.config.backgroundImage),
+                },
+                modelPath: new URL("./static/tasksVision/selfie_segmenter.tflite", baseUrl).href,
+            });
+        } catch (error) {
+            this.rejectWorkerInitialization(error instanceof Error ? error : new Error(String(error)));
+        }
+
+        await initializationPromise;
+    }
+
+    private resolveWorkerInitialization(): void {
+        this.clearWorkerInitializationTimeout();
+        this.workerInitializationResolve?.();
+        this.workerInitializationResolve = null;
+        this.workerInitializationReject = null;
+    }
+
+    private rejectWorkerInitialization(error: Error): void {
+        this.clearWorkerInitializationTimeout();
+        this.workerInitializationReject?.(error);
+        this.workerInitializationResolve = null;
+        this.workerInitializationReject = null;
+    }
+
+    private clearWorkerInitializationTimeout(): void {
+        if (this.workerInitializationTimeout) {
+            clearTimeout(this.workerInitializationTimeout);
+            this.workerInitializationTimeout = null;
+        }
+    }
+
+    private handleWorkerMessage(message: TasksVisionWorkerResponse): void {
+        if (message.type === "ready") {
+            this.workerDelegate = message.delegate;
+            console.info(`[MediaPipe Tasks Vision] Worker initialized successfully with ${message.delegate}`);
+            this.resolveWorkerInitialization();
+            return;
+        }
+        if (message.type === "unsupported") {
+            this.rejectWorkerInitialization(new UnsupportedTasksVisionWorkerError(message.reason));
+            return;
+        }
+        if (message.type === "initialization-error") {
+            this.rejectWorkerInitialization(deserializeError(message.error));
+            return;
+        }
+        if (message.type === "config-updated" || message.type === "config-update-error") {
+            this.handleConfigResponse(message);
+            return;
+        }
+        if (message.type === "frame") {
+            this.handleProcessedFrame(message);
+            return;
+        }
+
+        this.handleFrameError(message);
+    }
+
+    private handleConfigResponse(
+        message: Extract<TasksVisionWorkerResponse, { type: "config-updated" | "config-update-error" }>,
+    ): void {
+        const request = this.pendingConfigRequests.get(message.requestId);
+        if (!request) {
+            return;
+        }
+        this.pendingConfigRequests.delete(message.requestId);
+        if (message.type === "config-updated") {
+            request.resolve();
+        } else {
+            request.reject(deserializeError(message.error));
+        }
+    }
+
+    private handleProcessedFrame(message: Extract<TasksVisionWorkerResponse, { type: "frame" }>): void {
+        if (message.frameId !== this.activeFrameId) {
+            message.bitmap.close();
+            return;
+        }
+
+        const frameGeneration = this.activeFrameGeneration;
+        this.frameInFlight = false;
+        this.activeFrameId = null;
+
+        if (!this.closed && frameGeneration === this.streamGeneration) {
+            this.outputContext.drawImage(message.bitmap, 0, 0, this.outputCanvas.width, this.outputCanvas.height);
+            this.blurBackend = message.blurBackend;
+            this.frameCount++;
+            this.markSuccessfulFrame();
+            if (this.pendingInitialFrame?.generation === frameGeneration) {
+                this.pendingInitialFrame.resolve();
+                this.pendingInitialFrame = null;
+            }
+        }
+        message.bitmap.close();
+
+        if (this.processingEnabled) {
+            this.scheduleNextFrame();
+        }
+    }
+
+    private handleFrameError(message: Extract<TasksVisionWorkerResponse, { type: "frame-error" }>): void {
+        if (message.frameId !== this.activeFrameId) {
+            return;
+        }
+        this.frameInFlight = false;
+        this.activeFrameId = null;
+        const error = deserializeError(message.error);
+        console.error(
+            `[MediaPipe Tasks Vision] Worker frame processing failed: ${error.name}: ${error.message}; ` +
+                `timestampMs=${this.lastTimestampMs}; videoTime=${this.inputVideo.currentTime}; ` +
+                `readyState=${this.inputVideo.readyState}; visibility=${document.visibilityState}; ` +
+                `webGlContextLost=${message.webGlContextLost}`,
+        );
+        this.startRecovery(error);
+    }
+
+    private processFrame(): void {
+        if (
+            this.closed ||
+            !this.processingEnabled ||
+            !this.worker ||
+            !this.outputStream ||
+            this.config.mode === "none" ||
+            this.frameInFlight
+        ) {
+            return;
+        }
+        if (
+            !this.outputCanvas.width ||
+            !this.outputCanvas.height ||
+            !this.inputVideo.videoWidth ||
+            !this.inputVideo.videoHeight ||
+            this.inputVideo.readyState < 2
+        ) {
+            this.scheduleNextFrame();
+            return;
+        }
+
+        this.frameInFlight = true;
+        const frameGeneration = this.streamGeneration;
+        this.createAndPostFrame(frameGeneration).catch((error: unknown) => {
+            console.error("[MediaPipe Tasks Vision] Unexpected frame transfer failure:", error);
+        });
+    }
+
+    private async createAndPostFrame(frameGeneration: number): Promise<void> {
+        let frame: ImageBitmap | null = null;
+        let backgroundFrame: ImageBitmap | null = null;
+        try {
+            frame = await createImageBitmap(this.inputVideo);
+            if (this.config.mode === "video" && this.backgroundVideo && this.backgroundVideo.readyState >= 2) {
+                backgroundFrame = await createImageBitmap(this.backgroundVideo);
+            }
+
+            if (this.closed || !this.worker || frameGeneration !== this.streamGeneration) {
+                return;
+            }
+
+            const frameId = this.nextFrameId++;
+            const timestampMs = Math.max(performance.now(), this.lastTimestampMs + 1);
+            this.lastTimestampMs = timestampMs;
+            const message: TasksVisionWorkerRequest = {
+                type: "process-frame",
+                frameId,
+                frame,
+                backgroundFrame: backgroundFrame ?? undefined,
+                timestampMs,
+                width: this.outputCanvas.width,
+                height: this.outputCanvas.height,
+            };
+            const transfer: Transferable[] = [frame];
+            if (backgroundFrame) {
+                transfer.push(backgroundFrame);
+            }
+            this.postToWorker(message, transfer);
+            this.activeFrameId = frameId;
+            this.activeFrameGeneration = frameGeneration;
+            frame = null;
+            backgroundFrame = null;
+        } catch (error) {
+            console.warn("[MediaPipe Tasks Vision] Failed to create or transfer a camera frame:", error);
+        } finally {
+            frame?.close();
+            backgroundFrame?.close();
+            if (this.activeFrameId === null) {
+                this.frameInFlight = false;
+                if (this.processingEnabled) {
+                    this.scheduleNextFrame();
+                }
+            }
+        }
+    }
+
+    private scheduleNextFrame(): void {
+        this.cancelScheduledFrame();
+        if (this.closed || !this.processingEnabled || !this.outputStream || this.config.mode === "none") {
+            return;
+        }
+        this.timeoutId = setTimeout(() => this.processFrame(), this.frameIntervalMs);
+    }
+
+    private cancelScheduledFrame(): void {
+        if (this.timeoutId) {
+            clearTimeout(this.timeoutId);
+            this.timeoutId = null;
+        }
+    }
+
+    private markSuccessfulFrame(): void {
+        if (this.consecutiveRecoveryAttempts === 0) {
+            return;
+        }
+        this.successfulFramesSinceRecovery++;
+        if (this.successfulFramesSinceRecovery >= SUCCESSFUL_FRAMES_BEFORE_RECOVERY_RESET) {
+            this.consecutiveRecoveryAttempts = 0;
+            this.successfulFramesSinceRecovery = 0;
+        }
+    }
+
+    private startRecovery(error: unknown): void {
+        if (this.closed || this.recoveryPromise) {
+            return;
+        }
+        this.cancelScheduledFrame();
+        this.recoveryPromise = this.recoverWorker()
+            .catch((recoveryError: unknown) => {
+                const terminalError = new Error("MediaPipe Tasks Vision worker recovery failed", {
+                    cause: recoveryError,
+                });
+                console.error("[MediaPipe Tasks Vision] Worker recovery failed:", recoveryError, error);
+                this.close();
+                try {
+                    this.onTerminalFailure?.(terminalError);
+                } catch (callbackError) {
+                    console.error("[MediaPipe Tasks Vision] Terminal failure handler failed:", callbackError);
+                }
+            })
+            .finally(() => {
+                this.recoveryPromise = null;
+            });
+    }
+
+    private async recoverWorker(): Promise<void> {
+        if (this.closed || this.consecutiveRecoveryAttempts >= MAX_CONSECUTIVE_RECOVERY_ATTEMPTS) {
+            throw new Error("MediaPipe worker recovery attempts exhausted");
+        }
+
+        this.consecutiveRecoveryAttempts++;
+        this.successfulFramesSinceRecovery = 0;
+        this.frameInFlight = false;
+        this.activeFrameId = null;
+        this.terminateWorker();
+
+        try {
+            await this.startWorker();
+        } catch (error) {
+            if (this.consecutiveRecoveryAttempts >= MAX_CONSECUTIVE_RECOVERY_ATTEMPTS) {
+                throw error;
+            }
+            return this.recoverWorker();
+        }
+
+        if (this.closed) {
+            this.terminateWorker();
+            return;
+        }
+        console.info(
+            `[MediaPipe Tasks Vision] Worker recovered after attempt ${this.consecutiveRecoveryAttempts}/${MAX_CONSECUTIVE_RECOVERY_ATTEMPTS}`,
+        );
+        if (this.processingEnabled) {
+            this.scheduleNextFrame();
+        }
+    }
+
+    public async waitForInitialization(): Promise<void> {
+        await this.initPromise;
+    }
+
+    public async updateConfig(nextConfig: Partial<BackgroundConfig>): Promise<void> {
+        Object.assign(this.config, nextConfig);
+        await this.initPromise;
+        if (this.fallback) {
+            await this.fallback.updateConfig(nextConfig);
+            return;
+        }
+        if (this.recoveryPromise) {
+            await this.recoveryPromise;
+        }
+
+        await this.updateBackgroundVideo();
+        const requestId = this.nextConfigRequestId++;
+        const responsePromise = new Promise<void>((resolve, reject) => {
+            this.pendingConfigRequests.set(requestId, { resolve, reject });
+        });
+        const workerConfig = { ...nextConfig };
+        if (nextConfig.backgroundImage !== undefined) {
+            workerConfig.backgroundImage = this.resolveDocumentUrl(nextConfig.backgroundImage);
+        }
+        this.postToWorker({
+            type: "update-config",
+            requestId,
+            config: workerConfig,
+        });
+        await responsePromise;
+
+        if (this.config.mode === "none") {
+            this.cancelScheduledFrame();
+        } else if (this.outputStream && this.processingEnabled && !this.frameInFlight) {
+            this.processFrame();
+        }
+    }
+
+    private async updateBackgroundVideo(): Promise<void> {
+        const nextUrl = this.config.mode === "video" ? this.config.backgroundVideo : undefined;
+        if (nextUrl === this.backgroundVideoUrl) {
+            return;
+        }
+
+        if (this.backgroundVideo) {
+            this.backgroundVideo.pause();
+            this.backgroundVideo.src = "";
+            this.backgroundVideo = null;
+        }
+        this.backgroundVideoUrl = null;
+
+        if (!nextUrl) {
+            return;
+        }
+
+        const video = document.createElement("video");
+        video.crossOrigin = "anonymous";
+        video.loop = true;
+        video.muted = true;
+        video.autoplay = true;
+        video.playsInline = true;
+        video.src = nextUrl;
+        await video.play();
+        this.backgroundVideo = video;
+        this.backgroundVideoUrl = nextUrl;
+    }
+
+    private resolveDocumentUrl(url: string | undefined): string | undefined {
+        return url ? new URL(url, document.baseURI).href : undefined;
+    }
+
+    public getPerformanceStats(): unknown {
+        if (this.fallback) {
+            return this.fallback.getPerformanceStats();
+        }
+        const elapsed = performance.now() - this.startTime;
+        const fps = this.frameCount > 0 && elapsed > 0 ? Math.round((this.frameCount / elapsed) * 1000) : 0;
+        return {
+            fps,
+            frameCount: this.frameCount,
+            elapsed: Math.round(elapsed),
+            closed: this.closed,
+            blurBackend: this.config.mode === "blur" ? this.blurBackend : "none",
+            captureBackend: "worker-2d-copy-capture",
+            workerDelegate: this.workerDelegate,
+        };
+    }
+
+    public stop(): void {
+        if (this.fallback) {
+            this.fallback.stop();
+            return;
+        }
+        this.processingEnabled = false;
+        this.cancelScheduledFrame();
+        this.rejectPendingInitialFrame(new AbortError("Tasks Vision processing stopped before its first frame"));
+    }
+
+    public close(): void {
+        if (this.closed) {
+            return;
+        }
+        this.closed = true;
+        this.processingEnabled = false;
+        this.cancelScheduledFrame();
+        this.rejectPendingInitialFrame(new Error("Tasks Vision transformer closed before its first frame"));
+        this.fallback?.close();
+        this.fallback = null;
+        this.terminateWorker();
+
+        if (this.outputStream) {
+            for (const track of this.outputStream.getVideoTracks()) {
+                track.stop();
+            }
+            this.outputStream = null;
+        }
+        if (this.backgroundVideo) {
+            this.backgroundVideo.pause();
+            this.backgroundVideo.src = "";
+            this.backgroundVideo = null;
+        }
+        this.inputVideo.pause();
+        this.inputVideo.srcObject = null;
+    }
+
+    private terminateWorker(): void {
+        if (this.workerInitializationReject) {
+            this.rejectWorkerInitialization(new Error("Tasks Vision worker was terminated during initialization"));
+        } else {
+            this.clearWorkerInitializationTimeout();
+        }
+        this.worker?.terminate();
+        this.worker = null;
+        this.workerDelegate = "none";
+        const error = new Error("Tasks Vision worker was terminated");
+        for (const request of this.pendingConfigRequests.values()) {
+            request.reject(error);
+        }
+        this.pendingConfigRequests.clear();
+    }
+
+    public async transform(inputStream: MediaStream, signal?: AbortSignal): Promise<MediaStream> {
+        await this.initPromise;
+        if (this.fallback) {
+            return this.fallback.transform(inputStream, signal);
+        }
+        if (this.recoveryPromise) {
+            await raceAbort(this.recoveryPromise, signal);
+        }
+        if (signal?.aborted) {
+            throw signal.reason ?? new AbortError("Transform aborted after worker initialization");
+        }
+        if (this.config.mode === "none") {
+            return inputStream;
+        }
+
+        this.processingEnabled = false;
+        this.cancelScheduledFrame();
+        this.rejectPendingInitialFrame(new AbortError("Tasks Vision transform was superseded"));
+        this.streamGeneration++;
+        this.inputVideo.srcObject = inputStream;
+
+        const loadedMetadataPromise = new Promise<void>((resolve) => {
+            if (this.inputVideo.readyState >= 2) {
+                resolve();
+            } else {
+                this.inputVideo.addEventListener("loadedmetadata", () => resolve(), { once: true });
+            }
+        });
+        await raceAbort(loadedMetadataPromise, signal);
+        await raceAbort(this.inputVideo.play(), signal);
+        if (signal?.aborted) {
+            throw signal.reason ?? new AbortError("Transform aborted while starting video playback");
+        }
+
+        const videoWidth = this.inputVideo.videoWidth;
+        const videoHeight = this.inputVideo.videoHeight;
+        if (!videoWidth || !videoHeight) {
+            throw new Error(
+                `[MediaPipe Tasks Vision] Invalid video dimensions: ${videoWidth}x${videoHeight}. Cannot process stream.`,
+            );
+        }
+
+        this.frameRate = inputStream.getVideoTracks()[0]?.getSettings().frameRate || DEFAULT_FRAME_RATE;
+        this.frameIntervalMs = 1000 / this.frameRate;
+        this.outputCanvas.width = videoWidth;
+        this.outputCanvas.height = videoHeight;
+
+        if (this.outputStream) {
+            for (const track of this.outputStream.getVideoTracks()) {
+                track.stop();
+            }
+        }
+        const outputStream = this.outputCanvas.captureStream(this.frameRate);
+        this.outputStream = outputStream;
+        for (const audioTrack of inputStream.getAudioTracks()) {
+            outputStream.addTrack(audioTrack);
+        }
+
+        this.processingEnabled = true;
+        const initialFramePromise = new Promise<void>((resolve, reject) => {
+            this.pendingInitialFrame = { generation: this.streamGeneration, resolve, reject };
+        });
+        if (!this.frameInFlight) {
+            this.processFrame();
+        }
+        try {
+            await raceAbort(initialFramePromise, signal);
+        } catch (error) {
+            if (this.pendingInitialFrame?.generation === this.streamGeneration) {
+                this.pendingInitialFrame = null;
+            }
+            throw error;
+        }
+        return outputStream;
+    }
+
+    private rejectPendingInitialFrame(error: Error): void {
+        this.pendingInitialFrame?.reject(error);
+        this.pendingInitialFrame = null;
+    }
+
+    private postToWorker(message: TasksVisionWorkerRequest, transfer?: Transferable[]): void {
+        if (!this.worker) {
+            throw new Error("Tasks Vision worker is unavailable");
+        }
+        this.worker.postMessage(message, transfer ?? []);
+    }
+}

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.ts
@@ -1,6 +1,8 @@
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
-import TasksVisionWorker from "./MediaPipeTasksVisionWorker?worker&inline";
+// MediaPipe loads its generated WASM loader with importScripts(), so this worker
+// must have an HTTP URL rather than a blob URL.
+import TasksVisionWorker from "./MediaPipeTasksVisionWorker?worker";
 import type {
     SerializedWorkerError,
     TasksVisionWorkerRequest,

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.ts
@@ -15,6 +15,7 @@ import type {
 
 const DEFAULT_FRAME_RATE = 30;
 const WORKER_INITIALIZATION_TIMEOUT_MS = 30_000;
+const CONFIG_UPDATE_TIMEOUT_MS = 30_000;
 const MAX_CONSECUTIVE_RECOVERY_ATTEMPTS = 2;
 const SUCCESSFUL_FRAMES_BEFORE_RECOVERY_RESET = 30;
 
@@ -25,12 +26,16 @@ class UnsupportedTasksVisionWorkerError extends Error {
     }
 }
 
-type PendingConfigRequest = {
+type PendingRequestCallbacks = {
     resolve: () => void;
     reject: (error: Error) => void;
 };
 
-type PendingInitialFrame = PendingConfigRequest & {
+type PendingConfigRequest = PendingRequestCallbacks & {
+    timeoutId: ReturnType<typeof setTimeout>;
+};
+
+type PendingInitialFrame = PendingRequestCallbacks & {
     generation: number;
 };
 
@@ -231,11 +236,10 @@ export class MediaPipeTasksVisionWorkerTransformer implements BackgroundTransfor
     private handleConfigResponse(
         message: Extract<TasksVisionWorkerResponse, { type: "config-updated" | "config-update-error" }>,
     ): void {
-        const request = this.pendingConfigRequests.get(message.requestId);
+        const request = this.takePendingConfigRequest(message.requestId);
         if (!request) {
             return;
         }
-        this.pendingConfigRequests.delete(message.requestId);
         if (message.type === "config-updated") {
             request.resolve();
         } else {
@@ -462,17 +466,30 @@ export class MediaPipeTasksVisionWorkerTransformer implements BackgroundTransfor
         await this.updateBackgroundVideo();
         const requestId = this.nextConfigRequestId++;
         const responsePromise = new Promise<void>((resolve, reject) => {
-            this.pendingConfigRequests.set(requestId, { resolve, reject });
+            const timeoutId = setTimeout(() => {
+                const request = this.takePendingConfigRequest(requestId);
+                if (!request) {
+                    return;
+                }
+                const error = new Error(`Tasks Vision worker config update ${requestId} timed out`);
+                request.reject(error);
+                this.startRecovery(error);
+            }, CONFIG_UPDATE_TIMEOUT_MS);
+            this.pendingConfigRequests.set(requestId, { resolve, reject, timeoutId });
         });
         const workerConfig = { ...nextConfig };
         if (nextConfig.backgroundImage !== undefined) {
             workerConfig.backgroundImage = this.resolveDocumentUrl(nextConfig.backgroundImage);
         }
-        this.postToWorker({
-            type: "update-config",
-            requestId,
-            config: workerConfig,
-        });
+        try {
+            this.postToWorker({
+                type: "update-config",
+                requestId,
+                config: workerConfig,
+            });
+        } catch (error) {
+            this.takePendingConfigRequest(requestId)?.reject(error instanceof Error ? error : new Error(String(error)));
+        }
         await responsePromise;
 
         if (this.config.mode === "none") {
@@ -513,6 +530,16 @@ export class MediaPipeTasksVisionWorkerTransformer implements BackgroundTransfor
 
     private resolveDocumentUrl(url: string | undefined): string | undefined {
         return url ? new URL(url, document.baseURI).href : undefined;
+    }
+
+    private takePendingConfigRequest(requestId: number): PendingConfigRequest | undefined {
+        const request = this.pendingConfigRequests.get(requestId);
+        if (!request) {
+            return undefined;
+        }
+        this.pendingConfigRequests.delete(requestId);
+        clearTimeout(request.timeoutId);
+        return request;
     }
 
     public getPerformanceStats(): unknown {
@@ -580,6 +607,7 @@ export class MediaPipeTasksVisionWorkerTransformer implements BackgroundTransfor
         this.workerDelegate = "none";
         const error = new Error("Tasks Vision worker was terminated");
         for (const request of this.pendingConfigRequests.values()) {
+            clearTimeout(request.timeoutId);
             request.reject(error);
         }
         this.pendingConfigRequests.clear();

--- a/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
@@ -15,12 +15,12 @@ function logFailure(error: unknown): void {
 }
 
 export class TasksVisionBlurCompositor {
-    private readonly pipeline: WebGlBlurPipeline;
+    private readonly pipeline: WebGlBlurPipeline<HTMLCanvasElement | OffscreenCanvas>;
     private unavailable = false;
 
     constructor(
         private readonly gl: WebGL2RenderingContext,
-        canvas: HTMLCanvasElement,
+        canvas: HTMLCanvasElement | OffscreenCanvas,
     ) {
         this.pipeline = new WebGlBlurPipeline({ canvas, gl, restoreState: true });
     }

--- a/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
@@ -7,8 +7,10 @@ const WEBGL_MIN_BLUR_MAX_SIDE = 288;
 const WEBGL_BLUR_MAX_RADIUS = 18;
 const DUAL_KAWASE_MIN_SIDE = 24;
 
-type WebGlBlurPipelineOptions = {
-    canvas: HTMLCanvasElement;
+type WebGlCanvas = HTMLCanvasElement | OffscreenCanvas;
+
+type WebGlBlurPipelineOptions<TCanvas extends WebGlCanvas> = {
+    canvas: TCanvas;
     gl: WebGlBlurContext;
     ownsContext?: boolean;
     restoreState?: boolean;
@@ -221,7 +223,7 @@ void main() {
 }
 `;
 
-export class WebGlBlurPipeline {
+export class WebGlBlurPipeline<TCanvas extends WebGlCanvas = HTMLCanvasElement> {
     private downsampleProgram: WebGLProgram | null = null;
     private upsampleProgram: WebGLProgram | null = null;
     private compositeProgram: WebGLProgram | null = null;
@@ -254,7 +256,7 @@ export class WebGlBlurPipeline {
     private maskTexelSizeLocation: WebGLUniformLocation | null = null;
     private contextLost = false;
 
-    private readonly canvas: HTMLCanvasElement;
+    private readonly canvas: TCanvas;
     private readonly gl: WebGlBlurContext;
     private readonly ownsContext: boolean;
     private readonly restoreState: boolean;
@@ -270,7 +272,7 @@ export class WebGlBlurPipeline {
         this.releaseResources();
     };
 
-    constructor(options: WebGlBlurPipelineOptions) {
+    constructor(options: WebGlBlurPipelineOptions<TCanvas>) {
         this.canvas = options.canvas;
         this.gl = options.gl;
         this.ownsContext = options.ownsContext ?? false;
@@ -287,7 +289,7 @@ export class WebGlBlurPipeline {
         width: number,
         height: number,
         blurAmount: number,
-    ): HTMLCanvasElement | null {
+    ): TCanvas | null {
         if (this.isUnavailable()) {
             return null;
         }
@@ -342,7 +344,7 @@ export class WebGlBlurPipeline {
         width: number,
         height: number,
         blurAmount: number,
-    ): HTMLCanvasElement | null {
+    ): TCanvas | null {
         if (this.isUnavailable()) {
             return null;
         }

--- a/play/src/front/WebRtc/BackgroundProcessor/createBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/createBackgroundTransformer.ts
@@ -1,5 +1,5 @@
 import { BACKGROUND_TRANSFORMER_ENGINE } from "../../Enum/EnvironmentVariable";
-import { MediaPipeTasksVisionTransformer } from "./MediaPipeTasksVisionTransformer";
+import { MediaPipeTasksVisionWorkerTransformer } from "./MediaPipeTasksVisionWorkerTransformer";
 import { MediaPipeBackgroundTransformer } from "./MediaPipeBackgroundTransformer";
 import { FallbackBackgroundTransformer } from "./FallbackBackgroundTransformer";
 
@@ -40,7 +40,7 @@ export function createBackgroundTransformer(
 
     if (engine === "tasks-vision") {
         try {
-            const transformer = new MediaPipeTasksVisionTransformer(config, onTerminalFailure);
+            const transformer = new MediaPipeTasksVisionWorkerTransformer(config, onTerminalFailure);
             return transformer;
         } catch (error) {
             console.error("[BackgroundTransformer] Failed to create Tasks Vision transformer, using fallback:", error);

--- a/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.test.ts
+++ b/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.test.ts
@@ -9,9 +9,11 @@ const workerMocks = vi.hoisted(
             terminate: ReturnType<typeof vi.fn>;
         }>;
         response: "ready" | "unsupported";
+        respondToConfigUpdates: boolean;
     } => ({
         instances: [],
         response: "ready",
+        respondToConfigUpdates: true,
     }),
 );
 
@@ -44,6 +46,9 @@ vi.mock("../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWo
         public postMessage(message: { type: string; requestId?: number; config?: { backgroundImage?: string } }): void {
             this.messages.push(message);
             if (message.type === "update-config") {
+                if (!workerMocks.respondToConfigUpdates) {
+                    return;
+                }
                 queueMicrotask(() => {
                     this.onmessage?.({
                         data: { type: "config-updated", requestId: message.requestId },
@@ -87,6 +92,7 @@ describe("MediaPipeTasksVisionWorkerTransformer", () => {
 
     beforeEach(() => {
         workerMocks.response = "ready";
+        workerMocks.respondToConfigUpdates = true;
         workerMocks.instances.length = 0;
         vi.stubGlobal("Worker", class {});
         vi.stubGlobal("OffscreenCanvas", class {});
@@ -115,6 +121,7 @@ describe("MediaPipeTasksVisionWorkerTransformer", () => {
     afterEach(() => {
         transformer?.close();
         transformer = undefined;
+        vi.useRealTimers();
         vi.unstubAllGlobals();
         vi.restoreAllMocks();
         fallbackMocks.close.mockReset();
@@ -166,5 +173,20 @@ describe("MediaPipeTasksVisionWorkerTransformer", () => {
                 backgroundImage: new URL("./static/images/background/library.jpg", document.baseURI).href,
             },
         });
+    });
+
+    it("rejects a stalled config update and recovers the worker", async () => {
+        transformer = new MediaPipeTasksVisionWorkerTransformer({ mode: "blur" });
+        await transformer.waitForInitialization();
+        vi.useFakeTimers();
+        workerMocks.respondToConfigUpdates = false;
+
+        const updatePromise = transformer.updateConfig({ blurAmount: 25 });
+        const updateRejection = expect(updatePromise).rejects.toThrow("Tasks Vision worker config update 1 timed out");
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        await updateRejection;
+        expect(workerMocks.instances[0].terminate).toHaveBeenCalledOnce();
+        expect(workerMocks.instances).toHaveLength(2);
     });
 });

--- a/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.test.ts
+++ b/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const workerMocks = vi.hoisted(
+    (): {
+        instances: Array<{
+            onmessage: ((event: MessageEvent) => void) | null;
+            messages: Array<{ type: string; requestId?: number; config?: { backgroundImage?: string } }>;
+            response: "ready" | "unsupported";
+            terminate: ReturnType<typeof vi.fn>;
+        }>;
+        response: "ready" | "unsupported";
+    } => ({
+        instances: [],
+        response: "ready",
+    }),
+);
+
+const fallbackMocks = vi.hoisted(() => ({
+    close: vi.fn(),
+    getPerformanceStats: vi.fn(() => ({ captureBackend: "main-thread-fallback" })),
+    stop: vi.fn(),
+    transform: vi.fn(),
+    updateConfig: vi.fn().mockResolvedValue(undefined),
+    waitForInitialization: vi.fn().mockResolvedValue(undefined),
+    constructor: vi.fn(),
+}));
+
+vi.mock("../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker?worker&inline", () => ({
+    default: class {
+        public onmessage: ((event: MessageEvent) => void) | null = null;
+        public onerror: ((event: ErrorEvent) => void) | null = null;
+        public messages: Array<{
+            type: string;
+            requestId?: number;
+            config?: { backgroundImage?: string };
+        }> = [];
+        public response = workerMocks.response;
+        public terminate = vi.fn();
+
+        constructor() {
+            workerMocks.instances.push(this);
+        }
+
+        public postMessage(message: { type: string; requestId?: number; config?: { backgroundImage?: string } }): void {
+            this.messages.push(message);
+            if (message.type === "update-config") {
+                queueMicrotask(() => {
+                    this.onmessage?.({
+                        data: { type: "config-updated", requestId: message.requestId },
+                    } as MessageEvent);
+                });
+                return;
+            }
+            if (message.type !== "initialize") {
+                return;
+            }
+            queueMicrotask(() => {
+                const data =
+                    this.response === "ready"
+                        ? { type: "ready", delegate: "GPU" }
+                        : { type: "unsupported", reason: "WebGL2 is unavailable in OffscreenCanvas workers" };
+                this.onmessage?.({ data } as MessageEvent);
+            });
+        }
+    },
+}));
+
+vi.mock("../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer", () => ({
+    MediaPipeTasksVisionTransformer: class {
+        public close = fallbackMocks.close;
+        public getPerformanceStats = fallbackMocks.getPerformanceStats;
+        public stop = fallbackMocks.stop;
+        public transform = fallbackMocks.transform;
+        public updateConfig = fallbackMocks.updateConfig;
+        public waitForInitialization = fallbackMocks.waitForInitialization;
+
+        constructor(config: unknown, onTerminalFailure: unknown) {
+            fallbackMocks.constructor(config, onTerminalFailure);
+        }
+    },
+}));
+
+import { MediaPipeTasksVisionWorkerTransformer } from "../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer";
+
+describe("MediaPipeTasksVisionWorkerTransformer", () => {
+    let transformer: MediaPipeTasksVisionWorkerTransformer | undefined;
+
+    beforeEach(() => {
+        workerMocks.response = "ready";
+        workerMocks.instances.length = 0;
+        vi.stubGlobal("Worker", class {});
+        vi.stubGlobal("OffscreenCanvas", class {});
+        vi.stubGlobal("createImageBitmap", vi.fn());
+        vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+        const outputContext = { drawImage: vi.fn() } as unknown as CanvasRenderingContext2D;
+        const outputCanvas = {
+            getContext: vi.fn(() => outputContext),
+        } as unknown as HTMLCanvasElement;
+        const inputVideo = {
+            pause: vi.fn(),
+            srcObject: null,
+        } as unknown as HTMLVideoElement;
+        vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+            if (tagName === "canvas") {
+                return outputCanvas;
+            }
+            if (tagName === "video") {
+                return inputVideo;
+            }
+            throw new Error(`Unexpected element requested by test: ${tagName}`);
+        });
+    });
+
+    afterEach(() => {
+        transformer?.close();
+        transformer = undefined;
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+        fallbackMocks.close.mockReset();
+        fallbackMocks.getPerformanceStats.mockClear();
+        fallbackMocks.stop.mockReset();
+        fallbackMocks.transform.mockReset();
+        fallbackMocks.updateConfig.mockClear();
+        fallbackMocks.waitForInitialization.mockClear();
+        fallbackMocks.constructor.mockReset();
+    });
+
+    it("uses the worker after its WebGL2 initialization succeeds", async () => {
+        transformer = new MediaPipeTasksVisionWorkerTransformer({ mode: "blur" });
+
+        await transformer.waitForInitialization();
+
+        expect(workerMocks.instances).toHaveLength(1);
+        expect(fallbackMocks.constructor).not.toHaveBeenCalled();
+        expect(transformer.getPerformanceStats()).toMatchObject({
+            captureBackend: "worker-2d-copy-capture",
+            workerDelegate: "GPU",
+        });
+    });
+
+    it("uses the removable Safari 16 fallback when worker WebGL2 is unavailable", async () => {
+        workerMocks.response = "unsupported";
+        transformer = new MediaPipeTasksVisionWorkerTransformer({ mode: "blur", blurAmount: 12 });
+
+        await transformer.waitForInitialization();
+
+        expect(workerMocks.instances).toHaveLength(1);
+        expect(workerMocks.instances[0].terminate).toHaveBeenCalledOnce();
+        expect(fallbackMocks.constructor).toHaveBeenCalledWith({ mode: "blur", blurAmount: 12 }, undefined);
+        expect(transformer.getPerformanceStats()).toEqual({ captureBackend: "main-thread-fallback" });
+    });
+
+    it("resolves relative background image URLs against the document before sending them to the worker", async () => {
+        transformer = new MediaPipeTasksVisionWorkerTransformer({ mode: "blur" });
+        await transformer.waitForInitialization();
+
+        await transformer.updateConfig({
+            mode: "image",
+            backgroundImage: "./static/images/background/library.jpg",
+        });
+
+        expect(workerMocks.instances[0].messages[1]).toMatchObject({
+            type: "update-config",
+            config: {
+                backgroundImage: new URL("./static/images/background/library.jpg", document.baseURI).href,
+            },
+        });
+    });
+});

--- a/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.test.ts
+++ b/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.test.ts
@@ -5,6 +5,8 @@ const workerMocks = vi.hoisted(
         instances: Array<{
             onmessage: ((event: MessageEvent) => void) | null;
             messages: Array<{ type: string; requestId?: number; config?: { backgroundImage?: string } }>;
+            url: string | URL;
+            options?: WorkerOptions;
             response: "ready" | "unsupported";
             terminate: ReturnType<typeof vi.fn>;
         }>;
@@ -27,47 +29,8 @@ const fallbackMocks = vi.hoisted(() => ({
     constructor: vi.fn(),
 }));
 
-vi.mock("../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker?worker", () => ({
-    default: class {
-        public onmessage: ((event: MessageEvent) => void) | null = null;
-        public onerror: ((event: ErrorEvent) => void) | null = null;
-        public messages: Array<{
-            type: string;
-            requestId?: number;
-            config?: { backgroundImage?: string };
-        }> = [];
-        public response = workerMocks.response;
-        public terminate = vi.fn();
-
-        constructor() {
-            workerMocks.instances.push(this);
-        }
-
-        public postMessage(message: { type: string; requestId?: number; config?: { backgroundImage?: string } }): void {
-            this.messages.push(message);
-            if (message.type === "update-config") {
-                if (!workerMocks.respondToConfigUpdates) {
-                    return;
-                }
-                queueMicrotask(() => {
-                    this.onmessage?.({
-                        data: { type: "config-updated", requestId: message.requestId },
-                    } as MessageEvent);
-                });
-                return;
-            }
-            if (message.type !== "initialize") {
-                return;
-            }
-            queueMicrotask(() => {
-                const data =
-                    this.response === "ready"
-                        ? { type: "ready", delegate: "GPU" }
-                        : { type: "unsupported", reason: "WebGL2 is unavailable in OffscreenCanvas workers" };
-                this.onmessage?.({ data } as MessageEvent);
-            });
-        }
-    },
+vi.mock("../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker?worker&url", () => ({
+    default: "/assets/tasks-vision-worker.js",
 }));
 
 vi.mock("../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer", () => ({
@@ -94,7 +57,59 @@ describe("MediaPipeTasksVisionWorkerTransformer", () => {
         workerMocks.response = "ready";
         workerMocks.respondToConfigUpdates = true;
         workerMocks.instances.length = 0;
-        vi.stubGlobal("Worker", class {});
+        vi.stubGlobal(
+            "Worker",
+            class {
+                public onmessage: ((event: MessageEvent) => void) | null = null;
+                public onerror: ((event: ErrorEvent) => void) | null = null;
+                public messages: Array<{
+                    type: string;
+                    requestId?: number;
+                    config?: { backgroundImage?: string };
+                }> = [];
+                public response = workerMocks.response;
+                public terminate = vi.fn();
+
+                constructor(
+                    public url: string | URL,
+                    public options?: WorkerOptions,
+                ) {
+                    workerMocks.instances.push(this);
+                }
+
+                public postMessage(message: {
+                    type: string;
+                    requestId?: number;
+                    config?: { backgroundImage?: string };
+                }): void {
+                    this.messages.push(message);
+                    if (message.type === "update-config") {
+                        if (!workerMocks.respondToConfigUpdates) {
+                            return;
+                        }
+                        queueMicrotask(() => {
+                            this.onmessage?.({
+                                data: { type: "config-updated", requestId: message.requestId },
+                            } as MessageEvent);
+                        });
+                        return;
+                    }
+                    if (message.type !== "initialize") {
+                        return;
+                    }
+                    queueMicrotask(() => {
+                        const data =
+                            this.response === "ready"
+                                ? { type: "ready", delegate: "GPU" }
+                                : {
+                                      type: "unsupported",
+                                      reason: "WebGL2 is unavailable in OffscreenCanvas workers",
+                                  };
+                        this.onmessage?.({ data } as MessageEvent);
+                    });
+                }
+            },
+        );
         vi.stubGlobal("OffscreenCanvas", class {});
         vi.stubGlobal("createImageBitmap", vi.fn());
         vi.spyOn(console, "info").mockImplementation(() => undefined);
@@ -139,6 +154,10 @@ describe("MediaPipeTasksVisionWorkerTransformer", () => {
         await transformer.waitForInitialization();
 
         expect(workerMocks.instances).toHaveLength(1);
+        expect(workerMocks.instances[0]).toMatchObject({
+            url: "/assets/tasks-vision-worker.js",
+            options: { type: "module" },
+        });
         expect(fallbackMocks.constructor).not.toHaveBeenCalled();
         expect(transformer.getPerformanceStats()).toMatchObject({
             captureBackend: "worker-2d-copy-capture",

--- a/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.test.ts
+++ b/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorkerTransformer.test.ts
@@ -27,7 +27,7 @@ const fallbackMocks = vi.hoisted(() => ({
     constructor: vi.fn(),
 }));
 
-vi.mock("../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker?worker&inline", () => ({
+vi.mock("../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionWorker?worker", () => ({
     default: class {
         public onmessage: ((event: MessageEvent) => void) | null = null;
         public onerror: ((event: ErrorEvent) => void) | null = null;


### PR DESCRIPTION
## Summary

- run MediaPipe Tasks Vision segmentation and compositing in a dedicated Web Worker
- use `OffscreenCanvas` and WebGL2 for worker-side blur, with worker recovery for runtime failures
- retain and document the removable main-thread fallback required by Safari 16
- resolve document-relative background image URLs before sending them to the worker
- enable the Tasks Vision engine in `.env.template`

## Why

The main-thread Tasks Vision transformer competes with Phaser and other rendering work. Moving segmentation and compositing to a worker reduces work on the UI thread while keeping the current transformer available for Safari 16 versions that do not expose worker WebGL through `OffscreenCanvas`.

The worker proxy also owns frame timestamps, serializes configuration updates, and restarts the worker after recoverable failures. Image background URLs are made absolute in the document context because relative URLs cannot be resolved correctly from an inline worker blob.

## Benchmarks

Before, one frame would be processed in ~1.5ms in the main thread
After, the main thread only uses ~0.45ms so it leaves more space for the rest of the program.