### PR TITLE
feat(chat): surface proximity questions as highlighted cards in the timeline

### DIFF
--- a/play/src/front/Chat/Components/Room/QuestionCard.svelte
+++ b/play/src/front/Chat/Components/Room/QuestionCard.svelte
@@ -2,6 +2,8 @@
     import LL, { locale } from "../../../../i18n/i18n-svelte";
     import type { ChatQuestionItem } from "../../Connection/ChatConnection";
     import { roomSidePanelStore } from "../../Stores/RoomSidePanelStore";
+    import Button from "../../../Components/UI/Button.svelte";
+    import Chip from "../../../Components/UI/Chip.svelte";
     import { IconCheck, IconHelpCircle, IconList, IconLoader, IconTrash } from "@wa-icons";
 
     interface Props {
@@ -65,21 +67,16 @@
 <div class="px-3">
     <div
         data-testid="questionCard"
-        class="question-card rounded-2xl bg-contrast/90 border border-solid border-white/10 border-l-4 border-l-yellow-300/70 p-4 max-w-2xl"
+        class="question-card rounded-2xl bg-contrast/90 border border-solid border-white/10 p-4 max-w-2xl"
     >
         <div class="flex flex-wrap items-center gap-2">
-            <span
-                class="flex items-center gap-1 rounded-full border border-solid border-yellow-300/35 bg-yellow-400/15 px-2 py-0.5 text-xxs font-bold uppercase text-yellow-100"
-            >
-                <IconHelpCircle font-size={12} />
+            <Chip variant="warning" size="xs">
+                <IconHelpCircle font-size={12} class="mr-1" />
                 {$LL.chat.question.badge()}
-            </span>
+            </Chip>
             {#if $questionState.isAnswered}
-                <span
-                    class="rounded-full bg-emerald-500/20 px-2 py-0.5 text-xxs font-bold uppercase text-emerald-100"
-                    data-testid="questionAnsweredBadge"
-                >
-                    {$LL.chat.question.answered()}
+                <span data-testid="questionAnsweredBadge">
+                    <Chip variant="success" size="xs">{$LL.chat.question.answered()}</Chip>
                 </span>
             {/if}
         </div>
@@ -95,64 +92,75 @@
         </div>
 
         <div class="mt-3 flex flex-wrap items-center gap-2">
-            <button
-                type="button"
-                class="m-0 flex items-center gap-1.5 rounded-full border border-solid px-3 py-1.5 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-45 {$questionState.hasUpvoted
-                    ? 'border-yellow-300/35 bg-yellow-400/15 text-yellow-100'
-                    : 'border-white/10 bg-black/15 text-white/80 hover:bg-white/10'}"
+            <Button
+                variant={$questionState.hasUpvoted ? "primary" : "light"}
+                appearance={$questionState.hasUpvoted ? "filled" : "border"}
+                size="xs"
                 disabled={!$questionState.canUpvote || isUpvoting}
                 aria-label={$LL.chat.question.upvote()}
                 aria-pressed={$questionState.hasUpvoted}
-                data-testid="questionUpvoteButton"
+                dataTestId="questionUpvoteButton"
                 onclick={toggleUpvote}
             >
-                <span aria-hidden="true">👍</span>
+                {#snippet icon()}
+                    <span aria-hidden="true">👍</span>
+                {/snippet}
                 <span data-testid="questionUpvoteCount">{$questionState.upvoteCount}</span>
-            </button>
+            </Button>
 
             {#if $questionState.canMarkAnswered}
-                <button
-                    type="button"
-                    class="m-0 flex items-center gap-1.5 rounded-full border border-solid border-emerald-300/25 bg-emerald-500/10 px-3 py-1.5 text-xs font-semibold text-emerald-100 transition-colors hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-45"
+                <Button
+                    variant="success"
+                    appearance="border"
+                    size="xs"
                     disabled={isMarkingAnswered}
-                    data-testid="questionMarkAnsweredButton"
+                    dataTestId="questionMarkAnsweredButton"
                     onclick={markAnswered}
                 >
-                    {#if isMarkingAnswered}
-                        <IconLoader class="animate-[spin_2s_linear_infinite]" font-size={14} />
-                    {:else}
-                        <IconCheck font-size={14} />
-                    {/if}
+                    {#snippet icon()}
+                        {#if isMarkingAnswered}
+                            <IconLoader class="animate-[spin_2s_linear_infinite]" font-size={14} />
+                        {:else}
+                            <IconCheck font-size={14} />
+                        {/if}
+                    {/snippet}
                     {$LL.chat.question.markAnswered()}
-                </button>
+                </Button>
             {/if}
 
             {#if $questionState.canDelete}
-                <button
-                    type="button"
-                    class="m-0 flex items-center gap-1.5 rounded-full border border-solid border-red-300/25 bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-100 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-45"
+                <Button
+                    variant="danger"
+                    appearance="border"
+                    size="xs"
                     disabled={isDeleting}
-                    data-testid="questionDeleteButton"
+                    dataTestId="questionDeleteButton"
                     onclick={removeQuestion}
                 >
-                    {#if isDeleting}
-                        <IconLoader class="animate-[spin_2s_linear_infinite]" font-size={14} />
-                    {:else}
-                        <IconTrash font-size={14} />
-                    {/if}
+                    {#snippet icon()}
+                        {#if isDeleting}
+                            <IconLoader class="animate-[spin_2s_linear_infinite]" font-size={14} />
+                        {:else}
+                            <IconTrash font-size={14} />
+                        {/if}
+                    {/snippet}
                     {$LL.chat.delete()}
-                </button>
+                </Button>
             {/if}
 
-            <button
-                type="button"
-                class="m-0 ms-auto flex items-center gap-1.5 rounded-full border border-solid border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-white/75 transition-colors hover:bg-white/10 hover:text-white"
-                data-testid="questionViewAllButton"
+            <Button
+                variant="light"
+                appearance="ghost"
+                size="xs"
+                class="ms-auto"
+                dataTestId="questionViewAllButton"
                 onclick={openQuestionsPanel}
             >
-                <IconList font-size={14} />
+                {#snippet icon()}
+                    <IconList font-size={14} />
+                {/snippet}
                 {$LL.chat.question.viewAll()}
-            </button>
+            </Button>
         </div>
     </div>
 </div>

--- a/play/src/front/Chat/Components/Room/QuestionCard.svelte
+++ b/play/src/front/Chat/Components/Room/QuestionCard.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+    import LL, { locale } from "../../../../i18n/i18n-svelte";
+    import type { ChatQuestionItem } from "../../Connection/ChatConnection";
+    import { roomSidePanelStore } from "../../Stores/RoomSidePanelStore";
+    import { IconCheck, IconHelpCircle, IconList, IconLoader, IconTrash } from "@wa-icons";
+
+    interface Props {
+        question: ChatQuestionItem;
+    }
+
+    let { question }: Props = $props();
+
+    let questionState = $derived(question.state);
+    let isUpvoting = $state(false);
+    let isMarkingAnswered = $state(false);
+    let isDeleting = $state(false);
+
+    function toggleUpvote() {
+        if (!$questionState.canUpvote || isUpvoting) {
+            return;
+        }
+
+        isUpvoting = true;
+        question
+            .toggleUpvote()
+            .catch((error) => console.error("Failed to update question upvote", error))
+            .finally(() => {
+                isUpvoting = false;
+            });
+    }
+
+    function markAnswered() {
+        if (!$questionState.canMarkAnswered || isMarkingAnswered) {
+            return;
+        }
+
+        isMarkingAnswered = true;
+        question
+            .markAnswered()
+            .catch((error) => console.error("Failed to mark question as answered", error))
+            .finally(() => {
+                isMarkingAnswered = false;
+            });
+    }
+
+    function removeQuestion() {
+        if (!$questionState.canDelete || isDeleting) {
+            return;
+        }
+
+        isDeleting = true;
+        question
+            .remove()
+            .catch((error) => console.error("Failed to delete question", error))
+            .finally(() => {
+                isDeleting = false;
+            });
+    }
+
+    function openQuestionsPanel() {
+        roomSidePanelStore.setActiveSection("questions");
+    }
+</script>
+
+<div class="px-3">
+    <div
+        data-testid="questionCard"
+        class="question-card rounded-2xl bg-contrast/90 border border-solid border-white/10 border-l-4 border-l-yellow-300/70 p-4 max-w-2xl"
+    >
+        <div class="flex flex-wrap items-center gap-2">
+            <span
+                class="flex items-center gap-1 rounded-full border border-solid border-yellow-300/35 bg-yellow-400/15 px-2 py-0.5 text-xxs font-bold uppercase text-yellow-100"
+            >
+                <IconHelpCircle font-size={12} />
+                {$LL.chat.question.badge()}
+            </span>
+            {#if $questionState.isAnswered}
+                <span
+                    class="rounded-full bg-emerald-500/20 px-2 py-0.5 text-xxs font-bold uppercase text-emerald-100"
+                    data-testid="questionAnsweredBadge"
+                >
+                    {$LL.chat.question.answered()}
+                </span>
+            {/if}
+        </div>
+
+        <div class="mt-2 whitespace-pre-wrap text-sm font-semibold text-white overflow-wrap-anywhere">
+            {$questionState.body}
+        </div>
+
+        <div class="mt-2 text-xs text-white/55">
+            {$questionState.senderName ?? $LL.chat.question.unknownAuthor()} · {new Date(
+                $questionState.createdAt,
+            ).toLocaleTimeString($locale, { hour: "2-digit", minute: "2-digit" })}
+        </div>
+
+        <div class="mt-3 flex flex-wrap items-center gap-2">
+            <button
+                type="button"
+                class="m-0 flex items-center gap-1.5 rounded-full border border-solid px-3 py-1.5 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-45 {$questionState.hasUpvoted
+                    ? 'border-yellow-300/35 bg-yellow-400/15 text-yellow-100'
+                    : 'border-white/10 bg-black/15 text-white/80 hover:bg-white/10'}"
+                disabled={!$questionState.canUpvote || isUpvoting}
+                aria-label={$LL.chat.question.upvote()}
+                aria-pressed={$questionState.hasUpvoted}
+                data-testid="questionUpvoteButton"
+                onclick={toggleUpvote}
+            >
+                <span aria-hidden="true">👍</span>
+                <span data-testid="questionUpvoteCount">{$questionState.upvoteCount}</span>
+            </button>
+
+            {#if $questionState.canMarkAnswered}
+                <button
+                    type="button"
+                    class="m-0 flex items-center gap-1.5 rounded-full border border-solid border-emerald-300/25 bg-emerald-500/10 px-3 py-1.5 text-xs font-semibold text-emerald-100 transition-colors hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-45"
+                    disabled={isMarkingAnswered}
+                    data-testid="questionMarkAnsweredButton"
+                    onclick={markAnswered}
+                >
+                    {#if isMarkingAnswered}
+                        <IconLoader class="animate-[spin_2s_linear_infinite]" font-size={14} />
+                    {:else}
+                        <IconCheck font-size={14} />
+                    {/if}
+                    {$LL.chat.question.markAnswered()}
+                </button>
+            {/if}
+
+            {#if $questionState.canDelete}
+                <button
+                    type="button"
+                    class="m-0 flex items-center gap-1.5 rounded-full border border-solid border-red-300/25 bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-100 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-45"
+                    disabled={isDeleting}
+                    data-testid="questionDeleteButton"
+                    onclick={removeQuestion}
+                >
+                    {#if isDeleting}
+                        <IconLoader class="animate-[spin_2s_linear_infinite]" font-size={14} />
+                    {:else}
+                        <IconTrash font-size={14} />
+                    {/if}
+                    {$LL.chat.delete()}
+                </button>
+            {/if}
+
+            <button
+                type="button"
+                class="m-0 ms-auto flex items-center gap-1.5 rounded-full border border-solid border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-white/75 transition-colors hover:bg-white/10 hover:text-white"
+                data-testid="questionViewAllButton"
+                onclick={openQuestionsPanel}
+            >
+                <IconList font-size={14} />
+                {$LL.chat.question.viewAll()}
+            </button>
+        </div>
+    </div>
+</div>
+
+<style>
+    .overflow-wrap-anywhere {
+        overflow-wrap: anywhere;
+    }
+</style>

--- a/play/src/front/Chat/Components/Room/QuestionCard.svelte
+++ b/play/src/front/Chat/Components/Room/QuestionCard.svelte
@@ -4,7 +4,7 @@
     import { roomSidePanelStore } from "../../Stores/RoomSidePanelStore";
     import Button from "../../../Components/UI/Button.svelte";
     import Chip from "../../../Components/UI/Chip.svelte";
-    import { IconCheck, IconHelpCircle, IconList, IconLoader, IconTrash } from "@wa-icons";
+    import { IconCheck, IconHelpCircle, IconList, IconLoader, IconThumbUp, IconTrash } from "@wa-icons";
 
     interface Props {
         question: ChatQuestionItem;
@@ -16,6 +16,9 @@
     let isUpvoting = $state(false);
     let isMarkingAnswered = $state(false);
     let isDeleting = $state(false);
+
+    let cardBorderClass = $derived($questionState.isAnswered ? "border-success/30" : "border-white/10");
+    let statusAccentClass = $derived($questionState.isAnswered ? "bg-success" : "bg-warning");
 
     function toggleUpvote() {
         if (!$questionState.canUpvote || isUpvoting) {
@@ -67,16 +70,21 @@
 <div class="px-3">
     <div
         data-testid="questionCard"
-        class="question-card rounded-2xl bg-contrast/90 border border-solid border-white/10 p-4 max-w-2xl"
+        class="question-card relative overflow-hidden rounded-2xl bg-contrast/90 border border-solid p-4 max-w-2xl transition-colors {cardBorderClass}"
     >
+        <div class="absolute inset-y-0 left-0 w-1 {statusAccentClass}" aria-hidden="true"></div>
+
         <div class="flex flex-wrap items-center gap-2">
-            <Chip variant="warning" size="xs">
+            <Chip variant="warning" appearance="border" size="xs">
                 <IconHelpCircle font-size={12} class="mr-1" />
                 {$LL.chat.question.badge()}
             </Chip>
             {#if $questionState.isAnswered}
-                <span data-testid="questionAnsweredBadge">
-                    <Chip variant="success" size="xs">{$LL.chat.question.answered()}</Chip>
+                <span data-testid="questionAnsweredBadge" class="ms-auto">
+                    <Chip variant="success" appearance="border" size="xs">
+                        <IconCheck font-size={12} class="mr-1" />
+                        {$LL.chat.question.answered()}
+                    </Chip>
                 </span>
             {/if}
         </div>
@@ -103,7 +111,7 @@
                 onclick={toggleUpvote}
             >
                 {#snippet icon()}
-                    <span aria-hidden="true">👍</span>
+                    <IconThumbUp font-size={14} />
                 {/snippet}
                 <span data-testid="questionUpvoteCount">{$questionState.upvoteCount}</span>
             </Button>

--- a/play/src/front/Chat/Components/Room/QuestionCard.svelte
+++ b/play/src/front/Chat/Components/Room/QuestionCard.svelte
@@ -5,6 +5,8 @@
     import Button from "../../../Components/UI/Button.svelte";
     import { IconCheck, IconHelpCircle, IconList, IconLoader, IconThumbUp, IconTrash } from "@wa-icons";
 
+    type PendingAction = "upvote" | "answer" | "delete";
+
     interface Props {
         question: ChatQuestionItem;
     }
@@ -12,67 +14,29 @@
     let { question }: Props = $props();
 
     let questionState = $derived(question.state);
-    let isUpvoting = $state(false);
-    let isMarkingAnswered = $state(false);
-    let isDeleting = $state(false);
+    let pending: PendingAction | undefined = $state();
 
-    let cardBorderClass = $derived($questionState.isAnswered ? "border-success/30" : "border-white/10");
-    let statusAccentClass = $derived($questionState.isAnswered ? "bg-success" : "bg-warning");
-
-    function toggleUpvote() {
-        if (!$questionState.canUpvote || isUpvoting) {
+    function run(action: PendingAction, request: () => Promise<void>) {
+        if (pending) {
             return;
         }
 
-        isUpvoting = true;
-        question
-            .toggleUpvote()
-            .catch((error) => console.error("Failed to update question upvote", error))
+        pending = action;
+        request()
+            .catch((error) => console.error(`Failed to ${action} question`, error))
             .finally(() => {
-                isUpvoting = false;
+                pending = undefined;
             });
-    }
-
-    function markAnswered() {
-        if (!$questionState.canMarkAnswered || isMarkingAnswered) {
-            return;
-        }
-
-        isMarkingAnswered = true;
-        question
-            .markAnswered()
-            .catch((error) => console.error("Failed to mark question as answered", error))
-            .finally(() => {
-                isMarkingAnswered = false;
-            });
-    }
-
-    function removeQuestion() {
-        if (!$questionState.canDelete || isDeleting) {
-            return;
-        }
-
-        isDeleting = true;
-        question
-            .remove()
-            .catch((error) => console.error("Failed to delete question", error))
-            .finally(() => {
-                isDeleting = false;
-            });
-    }
-
-    function openQuestionsPanel() {
-        roomSidePanelStore.setActiveSection("questions");
     }
 </script>
 
 <div class="px-3">
     <div
         data-testid="questionCard"
-        class="question-card relative overflow-hidden rounded-2xl bg-contrast/90 border border-solid p-4 max-w-2xl transition-colors {cardBorderClass}"
+        class="question-card rounded-2xl bg-contrast/90 border border-solid p-4 max-w-2xl transition-colors {$questionState.isAnswered
+            ? 'border-success/30'
+            : 'border-white/10'}"
     >
-        <div class="absolute inset-y-0 left-0 w-1 {statusAccentClass}" aria-hidden="true"></div>
-
         <div class="flex flex-wrap items-center gap-2">
             <span
                 class="inline-flex h-6 items-center gap-1 rounded-md bg-warning/15 px-2 text-xs font-medium text-warning"
@@ -91,7 +55,7 @@
             {/if}
         </div>
 
-        <div class="mt-2 whitespace-pre-wrap text-sm font-semibold text-white overflow-wrap-anywhere">
+        <div class="mt-2 whitespace-pre-wrap wrap-anywhere text-sm font-semibold text-white">
             {$questionState.body}
         </div>
 
@@ -106,11 +70,11 @@
                 variant={$questionState.hasUpvoted ? "primary" : "light"}
                 appearance={$questionState.hasUpvoted ? "filled" : "border"}
                 size="xs"
-                disabled={!$questionState.canUpvote || isUpvoting}
+                disabled={!$questionState.canUpvote || pending === "upvote"}
                 aria-label={$LL.chat.question.upvote()}
                 aria-pressed={$questionState.hasUpvoted}
                 dataTestId="questionUpvoteButton"
-                onclick={toggleUpvote}
+                onclick={() => run("upvote", () => question.toggleUpvote())}
             >
                 {#snippet icon()}
                     <IconThumbUp font-size={14} />
@@ -123,12 +87,12 @@
                     variant="success"
                     appearance="border"
                     size="xs"
-                    disabled={isMarkingAnswered}
+                    disabled={pending === "answer"}
                     dataTestId="questionMarkAnsweredButton"
-                    onclick={markAnswered}
+                    onclick={() => run("answer", () => question.markAnswered())}
                 >
                     {#snippet icon()}
-                        {#if isMarkingAnswered}
+                        {#if pending === "answer"}
                             <IconLoader class="animate-[spin_2s_linear_infinite]" font-size={14} />
                         {:else}
                             <IconCheck font-size={14} />
@@ -143,12 +107,12 @@
                     variant="danger"
                     appearance="border"
                     size="xs"
-                    disabled={isDeleting}
+                    disabled={pending === "delete"}
                     dataTestId="questionDeleteButton"
-                    onclick={removeQuestion}
+                    onclick={() => run("delete", () => question.remove())}
                 >
                     {#snippet icon()}
-                        {#if isDeleting}
+                        {#if pending === "delete"}
                             <IconLoader class="animate-[spin_2s_linear_infinite]" font-size={14} />
                         {:else}
                             <IconTrash font-size={14} />
@@ -164,7 +128,7 @@
                 size="xs"
                 class="ms-auto"
                 dataTestId="questionViewAllButton"
-                onclick={openQuestionsPanel}
+                onclick={() => roomSidePanelStore.setActiveSection("questions")}
             >
                 {#snippet icon()}
                     <IconList font-size={14} />
@@ -174,9 +138,3 @@
         </div>
     </div>
 </div>
-
-<style>
-    .overflow-wrap-anywhere {
-        overflow-wrap: anywhere;
-    }
-</style>

--- a/play/src/front/Chat/Components/Room/QuestionCard.svelte
+++ b/play/src/front/Chat/Components/Room/QuestionCard.svelte
@@ -3,7 +3,6 @@
     import type { ChatQuestionItem } from "../../Connection/ChatConnection";
     import { roomSidePanelStore } from "../../Stores/RoomSidePanelStore";
     import Button from "../../../Components/UI/Button.svelte";
-    import Chip from "../../../Components/UI/Chip.svelte";
     import { IconCheck, IconHelpCircle, IconList, IconLoader, IconThumbUp, IconTrash } from "@wa-icons";
 
     interface Props {
@@ -75,16 +74,19 @@
         <div class="absolute inset-y-0 left-0 w-1 {statusAccentClass}" aria-hidden="true"></div>
 
         <div class="flex flex-wrap items-center gap-2">
-            <Chip variant="warning" appearance="border" size="xs">
-                <IconHelpCircle font-size={12} class="mr-1" />
+            <span
+                class="inline-flex h-6 items-center gap-1 rounded-md bg-warning/15 px-2 text-xs font-medium text-warning"
+            >
+                <IconHelpCircle font-size={12} />
                 {$LL.chat.question.badge()}
-            </Chip>
+            </span>
             {#if $questionState.isAnswered}
-                <span data-testid="questionAnsweredBadge" class="ms-auto">
-                    <Chip variant="success" appearance="border" size="xs">
-                        <IconCheck font-size={12} class="mr-1" />
-                        {$LL.chat.question.answered()}
-                    </Chip>
+                <span
+                    data-testid="questionAnsweredBadge"
+                    class="ms-auto inline-flex h-6 items-center gap-1 rounded-md bg-success/15 px-2 text-xs font-medium text-success"
+                >
+                    <IconCheck font-size={12} />
+                    {$LL.chat.question.answered()}
                 </span>
             {/if}
         </div>

--- a/play/src/front/Chat/Components/Room/RoomTimeline.svelte
+++ b/play/src/front/Chat/Components/Room/RoomTimeline.svelte
@@ -27,6 +27,7 @@
     import MessageInputBar from "./MessageInputBar.svelte";
     import MessageSystem from "./MessageSystem.svelte";
     import PollCard from "./PollCard.svelte";
+    import QuestionCard from "./QuestionCard.svelte";
     import TypingUsers from "./TypingUsers.svelte";
     import { shouldReserveFloatingCloseButtonSpace } from "./RoomTimelineHeaderLayout";
     import { IconChevronLeft, IconChevronRight, IconLoader, IconMailBox, IconInfoCircle } from "@wa-icons";
@@ -715,6 +716,8 @@
                             <MessageSystem message={item.timelineItem.message} />
                         {:else if item.timelineItem.kind === "poll"}
                             <PollCard poll={item.timelineItem.poll} />
+                        {:else if item.timelineItem.kind === "question"}
+                            <QuestionCard question={item.timelineItem.question} />
                         {:else}
                             <Message
                                 message={item.timelineItem.message}

--- a/play/src/front/Chat/Connection/ChatConnection.ts
+++ b/play/src/front/Chat/Connection/ChatConnection.ts
@@ -414,6 +414,12 @@ export type ChatTimelineItem =
           id: string;
           date: Date | null;
           poll: ChatPollItem;
+      }
+    | {
+          kind: "question";
+          id: string;
+          date: Date | null;
+          question: ChatQuestionItem;
       };
 
 export type ChatMessageType = "proximity" | "text" | "incoming" | "outcoming" | "image" | "file" | "audio" | "video";

--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -159,7 +159,7 @@ export class ProximityChatRoom implements ChatRoom {
     );
     private readonly unreadQuestionIdsStore = writable<ReadonlySet<string>>(new Set());
     readonly unreadQuestionCount: Readable<number> = derived(this.unreadQuestionIdsStore, (ids) => ids.size);
-    timelineItems = createProximityTimelineItemsStore(this.messages, this.pollItems);
+    timelineItems = createProximityTimelineItemsStore(this.messages, this.pollItems, this.qaItems);
     readonly pollCreation: ChatPollCreationCapability;
     readonly questionCreation: ChatQuestionCreationCapability;
     messageReactions: MapStore<string, MapStore<string, ChatMessageReaction>> = new MapStore();
@@ -538,10 +538,7 @@ export class ProximityChatRoom implements ChatRoom {
             this.addUnreadQuestionIds(newQuestionIds);
         }
 
-        if (!get(this.canModerateQuestions)) {
-            return;
-        }
-
+        // Notify every participant of a new question (not only moderators), mirroring notifyNewPolls.
         if (get(selectedRoomStore) !== this) {
             this.hasUnreadMessages.set(true);
             this.unreadNotificationCount.set(get(this.unreadNotificationCount) + newQuestions.length);
@@ -555,13 +552,12 @@ export class ProximityChatRoom implements ChatRoom {
 
         this.unreadMessagesCount.set(get(this.unreadMessagesCount) + newQuestions.length);
         for (const question of newQuestions) {
+            // No sidePanelSection: clicking the toast scrolls to and highlights the question card in the timeline.
             chatNotificationStore.addNotification(
                 question.senderName ?? this.unknownUserName,
                 get(LL).chat.question.notification({ question: question.body }),
                 this,
                 question.id,
-                true,
-                "questions",
             );
         }
     }

--- a/play/src/front/Chat/Connection/Proximity/ProximityTimelineItemsStore.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityTimelineItemsStore.ts
@@ -1,11 +1,12 @@
 import { derived, readable, type Readable } from "svelte/store";
-import type { ChatMessage, ChatPollItem, ChatTimelineItem } from "../ChatConnection";
+import type { ChatMessage, ChatPollItem, ChatQuestionItem, ChatTimelineItem } from "../ChatConnection";
 
 export function createProximityTimelineItemsStore(
     messages: Readable<readonly ChatMessage[]>,
     polls: Readable<readonly ChatPollItem[]> = readable([]),
+    questions: Readable<readonly ChatQuestionItem[]> = readable([]),
 ): Readable<readonly ChatTimelineItem[]> {
-    return derived([messages, polls], ([$messages, $polls]) => {
+    return derived([messages, polls, questions], ([$messages, $polls, $questions]) => {
         const messageItems = Array.from($messages, mapMessageToTimelineItem);
         const pollItems = Array.from($polls, (poll): ChatTimelineItem => {
             return {
@@ -15,8 +16,16 @@ export function createProximityTimelineItemsStore(
                 poll,
             };
         });
+        const questionItems = Array.from($questions, (question): ChatTimelineItem => {
+            return {
+                kind: "question",
+                id: question.id,
+                date: question.date,
+                question,
+            };
+        });
 
-        return [...messageItems, ...pollItems].sort(compareTimelineItemsByDate);
+        return [...messageItems, ...pollItems, ...questionItems].sort(compareTimelineItemsByDate);
     });
 }
 

--- a/play/src/front/Chat/Connection/Proximity/tests/ProximityTimelineItemsStore.test.ts
+++ b/play/src/front/Chat/Connection/Proximity/tests/ProximityTimelineItemsStore.test.ts
@@ -1,7 +1,7 @@
 import { get, readable } from "svelte/store";
 import { describe, expect, it } from "vitest";
 import { MapStore } from "@workadventure/store-utils";
-import type { ChatMessage, ChatPollItem } from "../../ChatConnection";
+import type { ChatMessage, ChatPollItem, ChatQuestionItem } from "../../ChatConnection";
 import { createProximityTimelineItemsStore } from "../ProximityTimelineItemsStore";
 
 describe("ProximityTimelineItemsStore", () => {
@@ -16,6 +16,28 @@ describe("ProximityTimelineItemsStore", () => {
 
         expect(timelineItems.map((item) => item.id)).toEqual(["poll-1", "message-1", "system-1"]);
         expect(timelineItems.map((item) => item.kind)).toEqual(["poll", "message", "system"]);
+    });
+
+    it("should interleave questions with messages and polls by date", () => {
+        const messages = readable<readonly ChatMessage[]>([createMessage("message-1", new Date(20), "proximity")]);
+        const polls = readable<readonly ChatPollItem[]>([createPoll("poll-1", new Date(30))]);
+        const questions = readable<readonly ChatQuestionItem[]>([
+            createQuestion("question-1", new Date(10)),
+            createQuestion("question-2", new Date(40)),
+        ]);
+
+        const timelineItems = get(createProximityTimelineItemsStore(messages, polls, questions));
+
+        expect(timelineItems.map((item) => item.id)).toEqual(["question-1", "message-1", "poll-1", "question-2"]);
+        expect(timelineItems.map((item) => item.kind)).toEqual(["question", "message", "poll", "question"]);
+    });
+
+    it("should default to no questions when the store is omitted", () => {
+        const messages = readable<readonly ChatMessage[]>([createMessage("message-1", new Date(20), "proximity")]);
+
+        const timelineItems = get(createProximityTimelineItemsStore(messages));
+
+        expect(timelineItems.map((item) => item.kind)).toEqual(["message"]);
     });
 });
 
@@ -66,5 +88,32 @@ function createPoll(id: string, date: Date): ChatPollItem {
         vote: () => Promise.resolve(),
         end: () => Promise.resolve(),
         remove: () => Promise.resolve(),
+    };
+}
+
+function createQuestion(id: string, date: Date): ChatQuestionItem {
+    return {
+        id,
+        date,
+        sender: undefined,
+        state: readable({
+            id,
+            body: id,
+            senderId: "sender",
+            senderName: undefined,
+            createdAt: date.getTime(),
+            isAnswered: false,
+            upvoteCount: 0,
+            hasUpvoted: false,
+            canUpvote: true,
+            canDelete: false,
+            canMarkAnswered: false,
+        }),
+        canUpvote: readable(true),
+        canDelete: readable(false),
+        canMarkAnswered: readable(false),
+        toggleUpvote: () => Promise.resolve(),
+        remove: () => Promise.resolve(),
+        markAnswered: () => Promise.resolve(),
     };
 }

--- a/play/src/front/Components/Icons.ts
+++ b/play/src/front/Components/Icons.ts
@@ -17,6 +17,7 @@ export { default as IconArrowLeft } from "~icons/tabler/arrow-left";
 export { default as IconArrowBackUp } from "~icons/tabler/arrow-back-up";
 export { default as IconArrowDown } from "~icons/tabler/arrow-down";
 export { default as IconArrowUp } from "~icons/tabler/arrow-up";
+export { default as IconThumbUp } from "~icons/tabler/thumb-up";
 export { default as IconMoodSmile } from "~icons/tabler/mood-smile";
 export { default as IconPencil } from "~icons/tabler/pencil";
 export { default as IconTrash } from "~icons/tabler/trash";

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -287,6 +287,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "وضع علامة كتمت الإجابة",
         unknownAuthor: "غير معروف",
         notification: "سؤال: {question}",
+        badge: "سؤال",
+        viewAll: "عرض كل الأسئلة",
     },
     file: {
         fileContentNoEmbed: "المحتوى غير متاح للعرض. يرجى تنزيله",

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -288,6 +288,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "Marca com a resposta",
         unknownAuthor: "Desconegut",
         notification: "Pregunta: {question}",
+        badge: "Pregunta",
+        viewAll: "Mostra totes les preguntes",
     },
     file: {
         fileContentNoEmbed: "El contingut no està disponible per visualitzar. Si us plau, descarregueu-lo",

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -290,6 +290,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "Als beantwortet markieren",
         unknownAuthor: "Unbekannt",
         notification: "Frage: {question}",
+        badge: "Frage",
+        viewAll: "Alle Fragen anzeigen",
     },
     file: {
         fileContentNoEmbed: "Inhalt nicht verfügbar. Bitte herunterladen",

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -289,6 +289,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "Ako wótegronjone markěrowaś",
         unknownAuthor: "Njeznaty",
         notification: "Pšašanje: {question}",
+        badge: "Pšašanje",
+        viewAll: "Wšě pšašanja pokazaś",
     },
     file: {
         fileContentNoEmbed: "Wopśimjeśe njedajo se woglědaś. Musyśo jo ześěgnuś dołoj",

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -288,6 +288,8 @@ const chat: BaseTranslation = {
         markAnswered: "Mark answered",
         unknownAuthor: "Unknown",
         notification: "Question: {question}",
+        badge: "Question",
+        viewAll: "See all questions",
     },
     file: {
         fileContentNoEmbed: "Content unavailable for viewing. Please download it",

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -288,6 +288,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "Marcar como respondida",
         unknownAuthor: "Desconocido",
         notification: "Pregunta: {question}",
+        badge: "Pregunta",
+        viewAll: "Ver todas las preguntas",
     },
     file: {
         fileContentNoEmbed: "Contenido no disponible para visualizar. Por favor, descárguelo",

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -290,6 +290,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "Marquer comme répondue",
         unknownAuthor: "Inconnu",
         notification: "Question : {question}",
+        badge: "Question",
+        viewAll: "Voir toutes les questions",
     },
     file: {
         fileContentNoEmbed: "Le contenu n'est pas lisible dans le navigateur. Vous pouvez télécharger le document",

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -289,6 +289,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "Jako wotmołwjene markěrować",
         unknownAuthor: "Njeznaty",
         notification: "Prašenje: {question}",
+        badge: "Prašenje",
+        viewAll: "Wšě prašenja pokazać",
     },
     file: {
         fileContentNoEmbed: "Wobsah nic wužiwajomny. Prošu instalować",

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -289,6 +289,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "Segna come risposta",
         unknownAuthor: "Sconosciuto",
         notification: "Domanda: {question}",
+        badge: "Domanda",
+        viewAll: "Vedi tutte le domande",
     },
     file: {
         fileContentNoEmbed: "Contenuto non disponibile per la visualizzazione. Si prega di scaricarlo",

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -289,6 +289,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "回答済みにする",
         unknownAuthor: "不明",
         notification: "質問: {question}",
+        badge: "質問",
+        viewAll: "すべての質問を表示",
     },
     file: {
         fileContentNoEmbed: "コンテンツを閲覧できません。ダウンロードしてください。",

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -290,6 +290,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "답변됨으로 표시",
         unknownAuthor: "알 수 없음",
         notification: "질문: {question}",
+        badge: "질문",
+        viewAll: "모든 질문 보기",
     },
     file: {
         fileContentNoEmbed: "내용을 바로 볼 수 없습니다. 파일을 다운로드해 확인해 주세요",

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -289,6 +289,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "Markeren als beantwoord",
         unknownAuthor: "Onbekend",
         notification: "Vraag: {question}",
+        badge: "Vraag",
+        viewAll: "Alle vragen bekijken",
     },
     file: {
         fileContentNoEmbed: "Inhoud niet beschikbaar om te bekijken. Download het alstublieft.",

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -289,6 +289,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "Marcar como respondida",
         unknownAuthor: "Desconhecido",
         notification: "Pergunta: {question}",
+        badge: "Pergunta",
+        viewAll: "Ver todas as perguntas",
     },
     file: {
         fileContentNoEmbed: "Conteúdo indisponível para visualização. Por favor, baixe",

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -286,6 +286,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "标记为已回答",
         unknownAuthor: "未知",
         notification: "问题：{question}",
+        badge: "问题",
+        viewAll: "查看所有问题",
     },
     file: {
         fileContentNoEmbed: "内容无法查看。请下载",

--- a/play/src/i18n/zh-TW/chat.ts
+++ b/play/src/i18n/zh-TW/chat.ts
@@ -286,6 +286,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         markAnswered: "標記為已回答",
         unknownAuthor: "未知",
         notification: "問題：{question}",
+        badge: "問題",
+        viewAll: "查看所有問題",
     },
     file: {
         fileContentNoEmbed: "內容無法檢視。請下載",


### PR DESCRIPTION
## What & why

In meetings (proximity chat), participants can already ask questions, upvote them 👍, filter open/answered, mark answered and delete — but only inside a **side panel**, so questions were easy to miss. This surfaces them directly **in the chat timeline**.

## Changes

- **Questions render inline in the proximity timeline** as a highlighted "Question" card, interleaved chronologically like polls, via a new `kind: "question"` `ChatTimelineItem` and a new `QuestionCard.svelte`.
- **Inline 👍 upvote** on the card (reuses `ChatQuestionItem.toggleUpvote`), plus an "answered" badge, moderator mark-answered / delete actions, and a **"See all questions"** link that opens the questions panel (`roomSidePanelStore.setActiveSection("questions")`).
- **All participants are notified** of a new question (previously moderators only, mirroring `notifyNewPolls`). The toast no longer deep-links to the side panel section — clicking it scrolls to and pulse-highlights the question card in the timeline (`focusTimelineEvent`). The asker is still not notified of their own question (`getUnreadRemoteQuestionIds` filters by sender).
- i18n: added `chat.question.badge` and `chat.question.viewAll` to all 15 locales.

No backend changes — upvote/answer/delete reuse the existing space-metadata path authorized by `back/src/Model/ProximityQAMetadataProcessor.ts`.

## Verification

- `typecheck`, `svelte-check`, `lint`, `i18n:check` all pass. (The 2 pre-existing `@workadventure/messages` type errors in `SimplePeer.ts` / `IoSocketController.ts` are unrelated and present on `master` — confirmed by re-running with these changes stashed.)
- Extended `ProximityTimelineItemsStore` unit tests (questions interleave with messages/polls by date) — green.
- Suggested manual check: two participants in a meeting — A asks a question → B sees the highlighted card + toast → 👍 increments for both → moderator "mark answered" shows the badge → "See all questions" opens the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
