### PR TITLE
feat(play/storybook): story gate + scaffolding to make adoption self-sustaining

### DIFF
--- a/.github/workflows/story-gate.yml
+++ b/.github/workflows/story-gate.yml
@@ -1,0 +1,31 @@
+name: "Storybook story gate"
+
+# Fails a PR that adds a new design-system component (Components/UI or Components/Input)
+# without a colocated *.stories.svelte, so Storybook coverage of the design system never regresses.
+# Only runs when those folders (or the gate script) change, so it is cheap.
+
+on:
+    pull_request:
+        paths:
+            - "play/src/front/Components/UI/**"
+            - "play/src/front/Components/Input/**"
+            - "play/scripts/check-stories.mjs"
+
+jobs:
+    story-gate:
+        name: "Every new UI/Input component has a story"
+        runs-on: "ubuntu-latest"
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v5"
+              with:
+                  # Full history so we can diff the PR against its base.
+                  fetch-depth: 0
+
+            - name: "Setup NodeJS"
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 24
+
+            - name: "Check every new UI/Input component ships with a story"
+              run: node play/scripts/check-stories.mjs "${{ github.event.pull_request.base.sha }}"

--- a/play/AGENTS.md
+++ b/play/AGENTS.md
@@ -51,6 +51,10 @@ Do not edit generated `src/i18n/i18n-*.ts` files directly.
 
 ## Storybook stories
 
+- **Scaffold** a story in one command: `npm run new-story -- src/front/Components/UI/MyComponent.svelte`
+  (colocates the file, picks the title from the folder, drops in a `Default` story to fill in).
+- **Required for the design system**: a CI gate (`.github/workflows/story-gate.yml`) fails a PR that adds
+  a new `Components/UI/` or `Components/Input/` component without a colocated `*.stories.svelte`.
 - **Colocate** the story with its component: `Button.stories.svelte` next to `Button.svelte`.
 - **Title taxonomy** (the `title` in `defineMeta`) groups the sidebar:
   - `Design System/*` — the primitives in `Components/UI/` (Button, Badge, Chip, Avatar, Alert…).

--- a/play/package.json
+++ b/play/package.json
@@ -40,7 +40,8 @@
     "i18n:check": "TSX_TSCONFIG_PATH=tsconfig.json tsx ./scripts/diff-i18n.ts --check",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test:storybook": "vitest --project=storybook"
+    "test:storybook": "vitest --project=storybook",
+    "new-story": "node scripts/new-story.mjs"
   },
   "lint-staged": {
     "*.svelte": [

--- a/play/scripts/check-stories.mjs
+++ b/play/scripts/check-stories.mjs
@@ -1,0 +1,38 @@
+// Story gate: every NEW component in the design-system layer (Components/UI and Components/Input)
+// must ship with a colocated `*.stories.svelte`. Keeps Storybook coverage from regressing as the
+// codebase grows. Runs in CI on pull requests; a no-op outside a PR (no base ref).
+//
+// Usage: node play/scripts/check-stories.mjs <base-sha>
+// (run from the repository root)
+
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+const base = process.argv[2];
+if (!base) {
+    console.log("Story gate: no base ref provided (not a pull request) — skipping.");
+    process.exit(0);
+}
+
+// Components in these folders are the typed design-system layer and must always be story-ised.
+const WATCHED = /^play\/src\/front\/Components\/(UI|Input)\/[^/]+\.svelte$/;
+
+const addedFiles = execSync(`git diff --name-only --diff-filter=A ${base}...HEAD`, { encoding: "utf8" })
+    .split("\n")
+    .filter(Boolean);
+
+const newComponents = addedFiles.filter((file) => WATCHED.test(file) && !file.endsWith(".stories.svelte"));
+
+const missing = newComponents.filter((file) => !existsSync(file.replace(/\.svelte$/, ".stories.svelte")));
+
+if (missing.length > 0) {
+    console.error("Story gate: the following new design-system components have no Storybook story:\n");
+    for (const file of missing) {
+        console.error(`  - ${file}`);
+        console.error(`    add ${file.replace(/\.svelte$/, ".stories.svelte")} (scaffold: cd play && npm run new-story -- <path>)`);
+    }
+    console.error("\nEvery new component in Components/UI or Components/Input must ship with a colocated *.stories.svelte.");
+    process.exit(1);
+}
+
+console.log(`Story gate: OK — ${newComponents.length} new design-system component(s), all with a story.`);

--- a/play/scripts/new-story.mjs
+++ b/play/scripts/new-story.mjs
@@ -1,0 +1,58 @@
+// Scaffolds a colocated Storybook story for a component, so writing one costs ~10 seconds.
+//
+// Usage (from play/):  npm run new-story -- src/front/Components/UI/MyComponent.svelte
+
+import { existsSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+const componentPath = process.argv[2];
+if (!componentPath || !componentPath.endsWith(".svelte") || componentPath.endsWith(".stories.svelte")) {
+    console.error("Usage: npm run new-story -- <path/to/Component.svelte>");
+    process.exit(1);
+}
+if (!existsSync(componentPath)) {
+    console.error(`Component not found: ${componentPath}`);
+    process.exit(1);
+}
+
+const name = basename(componentPath, ".svelte");
+const dir = dirname(componentPath);
+const storyPath = join(dir, `${name}.stories.svelte`);
+
+if (existsSync(storyPath)) {
+    console.error(`A story already exists: ${storyPath}`);
+    process.exit(1);
+}
+
+// Title taxonomy (see play/AGENTS.md) derived from the component's folder.
+function groupFor(folder) {
+    if (folder.includes("/Components/UI")) return "Design System";
+    if (folder.includes("/Components/Input")) return "Forms";
+    if (/Toast|PopUp|Modal|Menu|Warning|Notification/.test(folder)) return "Feedback";
+    return "Feature";
+}
+
+const title = `${groupFor(dir)}/${name.replace(/([a-z0-9])([A-Z])/g, "$1 $2")}`;
+
+const template = `<script module lang="ts">
+    import { expect } from "storybook/test";
+    import { defineMeta } from "@storybook/addon-svelte-csf";
+    import ${name} from "./${name}.svelte";
+
+    const { Story } = defineMeta({
+        title: "${title}",
+        component: ${name},
+        tags: ["autodocs"],
+    });
+</script>
+
+<Story
+    name="Default"
+    play={async ({ canvasElement }) => {
+        await expect(canvasElement.firstElementChild).toBeInTheDocument();
+    }}
+/>
+`;
+
+writeFileSync(storyPath, template);
+console.log(`Created ${storyPath}\nTitle: ${title}\nNow fill in argTypes / args / play assertions.`);


### PR DESCRIPTION
## What

Adoption mechanics that make Storybook coverage **self-sustaining** instead of a one-off push. Stacks on #6384.

### 1. Story gate (CI)

`.github/workflows/story-gate.yml` + `play/scripts/check-stories.mjs` fail a PR that adds a new component under `Components/UI/` or `Components/Input/` **without** a colocated `*.stories.svelte`.

- Scope: the typed **design-system layer** (UI + Input) — the components that should always be documented/tested in isolation. Not the whole app.
- Triggers only when those folders (or the gate script) change → cheap.
- Verified both ways locally: 0 new components → pass; a UI component without a story → fail with a message pointing at the scaffolder.
- Currently gates **new** files; can be tightened to modified files later.

### 2. Scaffolding

`npm run new-story -- src/front/Components/UI/MyComponent.svelte` (`play/scripts/new-story.mjs`) creates the colocated story in ~10s: picks the sidebar title from the folder taxonomy and drops in a `Default` story to fill in. Makes the gate painless to satisfy.

`AGENTS.md` documents both.

---

## About Chromatic (documented here — **not** activated in this PR)

The Storybook install (#6374) already wired a **Chromatic** workflow (`.github/workflows/chromatic.yml`), gated behind a repo secret + variable so it stays dormant until we choose to turn it on. Recording here what it is and why it's worth switching on later.

**What it is.** Chromatic is a cloud service (by the Storybook team) that runs **visual-regression tests** on your stories. On each PR it builds the Storybook, takes a screenshot ("snapshot") of every story in a real browser, and diffs it **pixel-by-pixel** against the last accepted baseline.

**Why it's useful — it catches what our current checks can't.** `svelte-check`, `lint` and the `play` assertions verify types, structure and behaviour, but none of them see a component that *renders wrong*: a broken spacing, a wrong colour, a dropped design-system class, a layout that collapses at a viewport. Chromatic flags those visual diffs for a human to **accept** (new baseline) or **reject** (regression).

**Concrete benefits for us:**
- **Design-system safety net.** Our DS primitives (Button/Chip/Badge/Alert/Avatar) are reused everywhere; a small CSS change can silently break dozens of screens. Chromatic makes any visual change to them explicit and reviewable.
- **Matrix coverage for free.** We already expose dark/light backgrounds, `en-US`/`fr-FR` and mobile/desktop viewports as Storybook globals — Chromatic "modes" can snapshot each component across all of them automatically.
- **A shared, always-current catalog.** Chromatic hosts the built Storybook at a URL — a living component reference for designers/PM, no local setup.
- **Design ↔ code link.** Its Figma "Storybook Connect" plugin links stories to Figma frames, keeping design and implementation in sync.
- **UI Review workflow.** Designers can approve component changes directly on the Chromatic build attached to the PR.

**Cost is controlled.** Chromatic bills per snapshot; **TurboSnap** (`onlyChanged: true`, already set) only re-snapshots stories affected by a change, and the workflow is scoped to keep the snapshot count small. There is a free tier.

**How to activate (later, out of scope here):**
1. Create a Chromatic project and copy its project token.
2. Add repo **secret** `CHROMATIC_PROJECT_TOKEN` and repo **variable** `ENABLE_CHROMATIC = "true"`.
3. That's it — the existing workflow starts publishing and diffing. No code change needed.

## Test plan

- [x] `node play/scripts/check-stories.mjs <base>` — pass (0 new) and fail (UI component without story) both verified.
- [x] `npm run new-story -- …` — generates a valid, correctly-titled story.
- CI: the story-gate workflow runs on this PR (it touches the gate script) and passes (no new UI/Input component).
