### PR TITLE
fix(oidc): normalize callback URLs

### DIFF
--- a/play/src/pusher/enums/EnvironmentVariable.ts
+++ b/play/src/pusher/enums/EnvironmentVariable.ts
@@ -59,8 +59,8 @@ export const OPID_CLIENT_ISSUER = env.OPENID_CLIENT_ISSUER || env.OPID_CLIENT_IS
 if (OPID_CLIENT_ID && !PUSHER_URL) {
     throw new Error("Missing PUSHER_URL environment variable.");
 }
-export const OPID_CLIENT_REDIRECT_URL = PUSHER_URL + "/openid-callback";
-export const OPID_CLIENT_REDIRECT_LOGOUT_URL = PUSHER_URL + "/logout-callback";
+export const OPID_CLIENT_REDIRECT_URL = new URL("openid-callback", PUSHER_URL).toString();
+export const OPID_CLIENT_REDIRECT_LOGOUT_URL = new URL("logout-callback", PUSHER_URL).toString();
 export const OPID_PROFILE_SCREEN_PROVIDER =
     env.OPENID_PROFILE_SCREEN_PROVIDER ||
     env.OPID_PROFILE_SCREEN_PROVIDER ||

--- a/play/src/pusher/enums/EnvironmentVariable.ts
+++ b/play/src/pusher/enums/EnvironmentVariable.ts
@@ -59,8 +59,9 @@ export const OPID_CLIENT_ISSUER = env.OPENID_CLIENT_ISSUER || env.OPID_CLIENT_IS
 if (OPID_CLIENT_ID && !PUSHER_URL) {
     throw new Error("Missing PUSHER_URL environment variable.");
 }
-export const OPID_CLIENT_REDIRECT_URL = new URL("openid-callback", PUSHER_URL).toString();
-export const OPID_CLIENT_REDIRECT_LOGOUT_URL = new URL("logout-callback", PUSHER_URL).toString();
+const PUSHER_URL_WITHOUT_TRAILING_SLASH = PUSHER_URL.replace(/\/+$/, "");
+export const OPID_CLIENT_REDIRECT_URL = PUSHER_URL_WITHOUT_TRAILING_SLASH + "/openid-callback";
+export const OPID_CLIENT_REDIRECT_LOGOUT_URL = PUSHER_URL_WITHOUT_TRAILING_SLASH + "/logout-callback";
 export const OPID_PROFILE_SCREEN_PROVIDER =
     env.OPENID_PROFILE_SCREEN_PROVIDER ||
     env.OPID_PROFILE_SCREEN_PROVIDER ||

--- a/play/tests/pusher/EnvironmentVariable.test.ts
+++ b/play/tests/pusher/EnvironmentVariable.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("OIDC redirect URLs", () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    afterEach(() => {
+        vi.doUnmock("../../src/pusher/enums/EnvironmentVariableValidator");
+    });
+
+    it.each(["https://example.com", "https://example.com/"])(
+        "should build callback URLs when PUSHER_URL is %s",
+        async (pusherUrl) => {
+            vi.doMock("../../src/pusher/enums/EnvironmentVariableValidator", () => ({
+                EnvironmentVariables: {
+                    safeParse: () => ({
+                        success: true,
+                        data: { PUSHER_URL: pusherUrl },
+                    }),
+                },
+            }));
+
+            const { OPID_CLIENT_REDIRECT_LOGOUT_URL, OPID_CLIENT_REDIRECT_URL } =
+                await import("../../src/pusher/enums/EnvironmentVariable");
+
+            expect(OPID_CLIENT_REDIRECT_URL).toBe("https://example.com/openid-callback");
+            expect(OPID_CLIENT_REDIRECT_LOGOUT_URL).toBe("https://example.com/logout-callback");
+        },
+    );
+});

--- a/play/tests/pusher/EnvironmentVariable.test.ts
+++ b/play/tests/pusher/EnvironmentVariable.test.ts
@@ -9,23 +9,29 @@ describe("OIDC redirect URLs", () => {
         vi.doUnmock("../../src/pusher/enums/EnvironmentVariableValidator");
     });
 
-    it.each(["https://example.com", "https://example.com/"])(
-        "should build callback URLs when PUSHER_URL is %s",
-        async (pusherUrl) => {
-            vi.doMock("../../src/pusher/enums/EnvironmentVariableValidator", () => ({
-                EnvironmentVariables: {
-                    safeParse: () => ({
-                        success: true,
-                        data: { PUSHER_URL: pusherUrl },
-                    }),
-                },
-            }));
+    it.each([
+        ["https://example.com", "https://example.com"],
+        ["https://example.com/", "https://example.com"],
+        ["https://example.com/pusher", "https://example.com/pusher"],
+        ["https://example.com/pusher/", "https://example.com/pusher"],
+        ["/pusher", "/pusher"],
+        ["/pusher/", "/pusher"],
+        ["", ""],
+        [undefined, ""],
+    ])("should build callback URLs when PUSHER_URL is %s", async (pusherUrl, expectedBaseUrl) => {
+        vi.doMock("../../src/pusher/enums/EnvironmentVariableValidator", () => ({
+            EnvironmentVariables: {
+                safeParse: () => ({
+                    success: true,
+                    data: { PUSHER_URL: pusherUrl },
+                }),
+            },
+        }));
 
-            const { OPID_CLIENT_REDIRECT_LOGOUT_URL, OPID_CLIENT_REDIRECT_URL } =
-                await import("../../src/pusher/enums/EnvironmentVariable");
+        const { OPID_CLIENT_REDIRECT_LOGOUT_URL, OPID_CLIENT_REDIRECT_URL } =
+            await import("../../src/pusher/enums/EnvironmentVariable");
 
-            expect(OPID_CLIENT_REDIRECT_URL).toBe("https://example.com/openid-callback");
-            expect(OPID_CLIENT_REDIRECT_LOGOUT_URL).toBe("https://example.com/logout-callback");
-        },
-    );
+        expect(OPID_CLIENT_REDIRECT_URL).toBe(`${expectedBaseUrl}/openid-callback`);
+        expect(OPID_CLIENT_REDIRECT_LOGOUT_URL).toBe(`${expectedBaseUrl}/logout-callback`);
+    });
 });


### PR DESCRIPTION
## Description

Normalize trailing slashes when building the OIDC login and logout callback URLs.

This prevents duplicate slashes when `PUSHER_URL` has a trailing slash while preserving the existing behavior for absolute URLs, relative URLs, and configurations where `PUSHER_URL` is unset.

## Tests

- Added regression tests for absolute and relative `PUSHER_URL` values, with and without a trailing slash
- Added coverage for an empty or unset `PUSHER_URL`
- Ran the focused Vitest test
- Ran Prettier
- Ran ESLint

Fixes #4493
