### PR TITLE
fix(tests): drop the dead duplicate field in AreaLivekit

### DIFF
--- a/tests/tests/utils/AreaLivekit.ts
+++ b/tests/tests/utils/AreaLivekit.ts
@@ -15,17 +15,6 @@ class AreaLivekit {
     };
 
     public entityPositionInArea: Coordinates = { x: 4 * 32, y: 3 * 32 };
-    public entityPositionOutsideArea: Coordinates = { x: 6 * 32, y: 6 * 32 };
-
-    public entityPositionInArea = {
-        x: this.entityPositionInArea.x + 10,
-        y: this.entityPositionInArea.y - 16,
-    };
-
-    public mouseCoordinatesToClickOnEntityOutsideArea = {
-        x: this.entityPositionOutsideArea.x + 10,
-        y: this.entityPositionOutsideArea.y,
-    };
 
     async openAreaEditorAndAddAreaLivekit(page: Page, startWithAudioMuted = false, startWithVideoMuted = false) {
         await Menu.openMapEditor(page);


### PR DESCRIPTION
## Problem

`tests/tests/utils/AreaLivekit.ts` declares `entityPositionInArea` twice:

```ts
public entityPositionInArea: Coordinates = { x: 4 * 32, y: 3 * 32 };
public entityPositionOutsideArea: Coordinates = { x: 6 * 32, y: 6 * 32 };

public entityPositionInArea = {
    x: this.entityPositionInArea.x + 10,
    y: this.entityPositionInArea.y - 16,
};
```

The second declaration shadows the first, so the plain area position is unreachable and `tsc` reports `TS2300: Duplicate identifier 'entityPositionInArea'`.

It comes from dea0c1fd3 ("Replacing small table with coffee machine"), which renamed the *callers* in `livekit.spec.ts` from `mouseCoordinatesToClickOnEntityInsideArea` to `entityPositionInArea` — the rename accidentally swept the field declaration along with them.

## Fix

That same commit also moved the click-based tests to hardcoded coordinates, so a repo-wide search finds **no caller** for either `mouseCoordinatesToClickOnEntityInsideArea` or `mouseCoordinatesToClickOnEntityOutsideArea`. Rather than restore a dead field's name, both are removed — and with them `entityPositionOutsideArea`, whose only readers they were. (The `entityPositionOutsideArea` hits in `areaAccessRights.ts` are a different class and are untouched.)

What remains of the class is `areaSize`, `entityPositionInArea`, and `openAreaEditorAndAddAreaLivekit()` — all live.

## Callers

`livekit.spec.ts:303` and `:310` are the only two uses and are left untouched — that's the change dea0c1fd3 intended. They now teleport to `entityPositionInArea` = `{128, 96}`, the centre of the area (`topLeft {1, 64}` → `bottomRight {224, 128}`), instead of the shadowed `{138, 80}`. The sibling spec `map_editor_livekit.spec.ts` hardcodes exactly `teleportToPosition(page, 4 * 32, 3 * 32)` on the same map, so both specs now target the same tile. It never imports `AreaLivekit`, so nothing there needed changing.

## Testing

- `tsc --noEmit -p tests/tests/tsconfig.json` reports nothing for `AreaLivekit.ts` or `livekit.spec.ts` (remaining errors in that run are pre-existing local-env noise: missing generated protos / `iframe_api` typings, affecting nearly every spec).
- `prettier --check` passes.
- The Playwright suite itself was not run locally (needs the docker stack) — leaving that to CI.