### PR TITLE
fix(play): keep the speaker megaphone icon inside the name pill

### DIFF
--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -2,6 +2,7 @@ import * as Phaser from "phaser";
 import { AvailabilityStatus } from "@workadventure/messages";
 import type { GameScene } from "../Game/GameScene";
 import { waScaleManager, WaScaleManagerEvent } from "../Services/WaScaleManager";
+import { PLAYER_NAME_GAP, PLAYER_NAME_HEIGHT } from "./UsernameDisplaySizes";
 import { UsernameMegaphoneDisplay } from "./UsernameMegaphoneDisplay";
 import { UsernameStatusDisplay } from "./UsernameStatusDisplay";
 
@@ -9,14 +10,10 @@ const CORRECTION_RATE = 0.65; // When one game pixel is smaller than one screen 
 const USERNAME_FONT_FAMILY = "Roboto";
 const USERNAME_FONT_SIZE = 10;
 const USERNAME_FONT_WEIGHT = 500;
-const USERNAME_SIZE_ANIMATION_DURATION = 375;
-const USERNAME_SIZE_ANIMATION_EASING = "cubic-bezier(0.2, 0, 0, 1)";
 
 const PLAYER_NAME_BACKGROUND_COLOR = "rgba(27, 42, 65, 0.5)";
 const PLAYER_NAME_BACKGROUND_RADIUS = 8;
-const PLAYER_NAME_HEIGHT = 14;
 const PLAYER_NAME_PADDING = 4;
-const PLAYER_NAME_GAP = 4;
 
 type Position = { x: number; y: number };
 
@@ -30,7 +27,6 @@ export class UsernameDisplay {
     private displayScale: number;
     private readonly statusDisplay: UsernameStatusDisplay;
     private readonly megaphoneDisplay: UsernameMegaphoneDisplay;
-    private sizeAnimation: Animation | undefined;
 
     private readonly onZoomChanged = (zoomModifier: number): void => {
         this.displayScale = this.getDisplayScale(zoomModifier);
@@ -88,15 +84,6 @@ export class UsernameDisplay {
         return Math.max(zoomModifier > 0 ? CORRECTION_RATE / zoomModifier : 1, 1);
     }
 
-    private showMegaphone(show = true, forceClose = false): void {
-        if (show === this.megaphoneDisplay.isShown()) {
-            return;
-        }
-        this.animateSizeChange(() => {
-            this.megaphoneDisplay.show(show, forceClose);
-        }, show);
-    }
-
     public setPlayerNameOutlineColor(outlineColor: number | undefined): void {
         if (this.playerNameOutlineColor === outlineColor) {
             return;
@@ -106,9 +93,14 @@ export class UsernameDisplay {
         this.updateUsernameBackgroundColor(outlineColor);
     }
 
-    public setAvailabilityStatus(availabilityStatus: AvailabilityStatus, instant = false, forceClose = false): void {
+    public setAvailabilityStatus(availabilityStatus: AvailabilityStatus, instant = false): void {
         this.statusDisplay.setAvailabilityStatus(availabilityStatus, instant);
-        this.showMegaphone(availabilityStatus === AvailabilityStatus.SPEAKER, forceClose);
+        if (availabilityStatus === AvailabilityStatus.UNCHANGED) {
+            // UNCHANGED is 0, so it would compare unequal to SPEAKER and hide the megaphone, while
+            // the status dot correctly ignores it.
+            return;
+        }
+        this.megaphoneDisplay.show(availabilityStatus === AvailabilityStatus.SPEAKER, instant);
     }
 
     public getAvailabilityStatus(): AvailabilityStatus {
@@ -136,7 +128,6 @@ export class UsernameDisplay {
     }
 
     public destroy(): void {
-        this.stopSizeAnimation();
         this.element.remove();
         this.statusDisplay.destroy();
         this.megaphoneDisplay.destroy();
@@ -158,49 +149,6 @@ export class UsernameDisplay {
             x: this.x,
             y: this.y - (PLAYER_NAME_HEIGHT / 2) * this.displayScale,
         };
-    }
-
-    private animateSizeChange(changeElement: () => void, megaphoneShownAfterChange: boolean): void {
-        this.stopSizeAnimation();
-
-        const previousWidth = this.element.offsetWidth;
-        changeElement();
-        const nextWidth = megaphoneShownAfterChange ? this.element.offsetWidth : this.measureWidthWithoutMegaphone();
-
-        if (previousWidth === nextWidth) {
-            return;
-        }
-
-        this.element.style.overflow = "hidden";
-        this.element.style.width = `${previousWidth}px`;
-
-        this.sizeAnimation = this.element.animate([{ width: `${previousWidth}px` }, { width: `${nextWidth}px` }], {
-            duration: USERNAME_SIZE_ANIMATION_DURATION,
-            easing: USERNAME_SIZE_ANIMATION_EASING,
-        });
-
-        this.sizeAnimation.onfinish = () => {
-            this.sizeAnimation = undefined;
-            this.element.style.overflow = "";
-            this.element.style.width = "";
-        };
-    }
-
-    private stopSizeAnimation(): void {
-        this.sizeAnimation?.cancel();
-        this.sizeAnimation = undefined;
-        this.element.style.overflow = "";
-        this.element.style.width = "";
-    }
-
-    private measureWidthWithoutMegaphone(): number {
-        const previousDisplay = this.megaphoneDisplay.element.style.display;
-
-        this.megaphoneDisplay.element.style.display = "none";
-        const width = this.element.offsetWidth;
-        this.megaphoneDisplay.element.style.display = previousDisplay;
-
-        return width;
     }
 
     private createPlayerNameElement(): HTMLParagraphElement {

--- a/play/src/front/Phaser/Components/UsernameDisplaySizes.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplaySizes.ts
@@ -1,0 +1,15 @@
+/**
+ * Layout constants shared by the username pill and the badges laid out inside it.
+ *
+ * They live in their own module so a badge can size itself against the pill without importing the
+ * pill that builds it.
+ */
+
+/** Height of the pill, in game pixels. Multiplied by `--username-dom-scale` at render time. */
+export const PLAYER_NAME_HEIGHT = 14;
+
+/** Gap between the pill's children, in game pixels. */
+export const PLAYER_NAME_GAP = 4;
+
+/** Side of the (square) megaphone icon, in game pixels. */
+export const MEGAPHONE_ICON_SIZE = PLAYER_NAME_HEIGHT * 0.75;

--- a/play/src/front/Phaser/Components/UsernameMegaphoneDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameMegaphoneDisplay.ts
@@ -87,11 +87,16 @@ export class UsernameMegaphoneDisplay {
         );
 
         this.animation.onfinish = () => {
-            this.animation = undefined;
             if (!show) {
                 this.element.style.opacity = "0";
                 this.element.style.display = "none";
             }
+            // Release the animation's hold on the element now that the inline styles above describe
+            // the resting state. A finished `fill: "forwards"` animation keeps applying its last
+            // keyframe, and an animation effect outranks inline styles, so leaving it in place would
+            // pin the icon collapsed and transparent: every later show() would set the right inline
+            // styles and still paint nothing.
+            this.stopAnimation();
         };
     }
 

--- a/play/src/front/Phaser/Components/UsernameMegaphoneDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameMegaphoneDisplay.ts
@@ -1,3 +1,33 @@
+import { MEGAPHONE_ICON_SIZE, PLAYER_NAME_GAP } from "./UsernameDisplaySizes";
+
+const ANIMATION_DURATION = 350;
+const SHOW_EASING = "cubic-bezier(0.34, 1.56, 0.64, 1)";
+const HIDE_EASING = "cubic-bezier(0.2, 0, 0, 1)";
+
+// The icon is sized in explicit game pixels rather than as a percentage of the pill or through
+// `aspect-ratio`. An <img> only derives its width from those once it has intrinsic dimensions: while
+// the SVG is still loading it is laid out 0 wide, and if the request fails it falls back to the
+// broken-image box, which is several times wider than the pill's own height and spills out of it.
+const ICON_SIZE = `calc(${MEGAPHONE_ICON_SIZE}px * var(--username-dom-scale, 1))`;
+const ICON_MARGIN_LEFT = `calc(-2px * var(--username-dom-scale, 1))`;
+// Collapsed: no box at all, and a margin that cancels the pill's flex gap, so entering the flow does
+// not widen the pill by one gap before the animation has started.
+const ICON_COLLAPSED_SIZE = "0px";
+const ICON_COLLAPSED_MARGIN_LEFT = `calc(${-PLAYER_NAME_GAP}px * var(--username-dom-scale, 1))`;
+
+const COLLAPSED_KEYFRAME: Keyframe = {
+    width: ICON_COLLAPSED_SIZE,
+    height: ICON_COLLAPSED_SIZE,
+    marginLeft: ICON_COLLAPSED_MARGIN_LEFT,
+    opacity: 0,
+};
+const EXPANDED_KEYFRAME: Keyframe = {
+    width: ICON_SIZE,
+    height: ICON_SIZE,
+    marginLeft: ICON_MARGIN_LEFT,
+    opacity: 1,
+};
+
 export class UsernameMegaphoneDisplay {
     public readonly element: HTMLImageElement;
 
@@ -11,53 +41,55 @@ export class UsernameMegaphoneDisplay {
         this.element.draggable = false;
         this.element.style.display = "none";
         this.element.style.flex = "0 0 auto";
-        this.element.style.height = `75%`;
-        this.element.style.marginLeft = `calc(-2px * var(--username-dom-scale, 1))`;
+        this.element.style.width = ICON_SIZE;
+        this.element.style.height = ICON_SIZE;
+        this.element.style.marginLeft = ICON_MARGIN_LEFT;
         this.element.style.opacity = "0";
         this.element.style.pointerEvents = "none";
-        this.element.style.transformOrigin = "center";
     }
 
-    public show(show = true, forceClose = false): void {
-        if (this.shown === show && !forceClose) {
+    /**
+     * Reveals or hides the icon by growing or shrinking its own box, never by moving it: the pill is
+     * sized by its content, so it widens along with the icon and the icon is fully visible inside
+     * the name background at every frame.
+     *
+     * @param instant apply the new state without playing any animation. Used when the display is
+     * initialised with a status that is already SPEAKER: the icon must simply be there.
+     */
+    public show(show = true, instant = false): void {
+        if (this.shown === show && !instant) {
             return;
         }
 
         this.stopAnimation();
         this.shown = show;
 
-        if (forceClose && !show) {
-            this.element.style.display = "none";
-            this.element.style.opacity = "0";
-            this.element.style.transform = "";
+        if (instant) {
+            this.element.style.display = show ? "" : "none";
+            this.element.style.opacity = show ? "1" : "0";
             return;
         }
 
-        if (show) {
-            this.element.style.display = "";
-            this.element.style.opacity = "0";
-            this.animation = this.element.animate(
-                [
-                    { opacity: 0, transform: "translateX(calc(-50px * var(--username-dom-scale, 1))) scale(0.17)" },
-                    { opacity: 1, transform: "translateX(0) scale(1)" },
-                ],
-                {
-                    duration: 350,
-                    easing: "cubic-bezier(0.34, 1.56, 0.64, 1)",
-                },
-            );
-        } else {
-            this.animation = this.element.animate([{ opacity: 1 }, { opacity: 0 }], {
-                duration: 350,
-                easing: "cubic-bezier(0.34, 1.56, 0.64, 1)",
-            });
-        }
+        this.element.style.display = "";
+        // Put the resting state in place before the animation runs. The reveal does not fill, so the
+        // element falls back to its inline styles the moment it ends: those must already describe a
+        // visible icon, rather than relying on `onfinish` to make it visible after the fact.
+        this.element.style.opacity = "1";
+        this.animation = this.element.animate(
+            show ? [COLLAPSED_KEYFRAME, EXPANDED_KEYFRAME] : [EXPANDED_KEYFRAME, COLLAPSED_KEYFRAME],
+            {
+                duration: ANIMATION_DURATION,
+                easing: show ? SHOW_EASING : HIDE_EASING,
+                // While hiding, hold the collapsed box until `display: none` is applied, otherwise the
+                // element snaps back to its resting size for one frame.
+                fill: show ? "none" : "forwards",
+            },
+        );
 
         this.animation.onfinish = () => {
             this.animation = undefined;
-            this.element.style.opacity = show ? "1" : "0";
-            this.element.style.transform = "";
             if (!show) {
+                this.element.style.opacity = "0";
                 this.element.style.display = "none";
             }
         };

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -185,7 +185,7 @@ export abstract class Character extends Container implements OutlineableInterfac
                 this.playerName,
                 playerNameOutlineColor,
             );
-            this.usernameDisplay.setAvailabilityStatus(this.availabilityStatus, true, true);
+            this.usernameDisplay.setAvailabilityStatus(this.availabilityStatus, true);
             this.usernameDisplay.setPlayerDepth(this.depth);
 
             this.outlineColorStoreUnsubscribe = this.outlineColorStore.subscribe((color) => {
@@ -327,7 +327,7 @@ export abstract class Character extends Container implements OutlineableInterfac
         if (availabilityStatus !== AvailabilityStatus.UNCHANGED) {
             this.availabilityStatus = availabilityStatus;
         }
-        this.usernameDisplay?.setAvailabilityStatus(availabilityStatus, instant, false);
+        this.usernameDisplay?.setAvailabilityStatus(availabilityStatus, instant);
     }
 
     public getAvailabilityStatus() {


### PR DESCRIPTION
## Problem

The megaphone icon shown for a `SPEAKER` could be painted outside the rounded background of the player name pill.

<img width="300" alt="the icon spilling past the pill" src="https://github.com/user-attachments/assets/placeholder" />

The icon is an `<img>` sized with `height: 75%` and **no width**, so its layout width came entirely from the SVG's intrinsic dimensions. Measured in a browser on the real DOM structure:

| `<img>` state | pill width | icon width | spill past right edge |
|---|---|---|---|
| SVG loaded | 94.8 | 21 | −8 (inside) |
| request in flight | 94.8 | 0 | — |
| **request failed** | 94.8 | **59.1** | **+30px outside** |

When the request fails the element falls back to the broken-image box — 21px tall but 59px wide — while the pill had sized itself as if the icon were square.

On top of that, the icon was revealed by sliding in from `translateX(-50px)`, which starts 71px past the pill's left edge on a short name. That was contained only by a width animation that pinned an explicit pixel width and clipped the pill's content for 375ms — and the clip was skipped precisely when the measured width did not change, i.e. exactly while the SVG had not loaded yet. That is the deterministic path taken by `Character`, which applies the initial status microseconds after creating the `<img>`.

## Fix

Make the icon's box deterministic and let the pill size itself on its content:

- the icon is sized in **explicit game pixels** derived from the pill height, so its box no longer depends on the resource being loaded, or loading at all;
- it is revealed by **growing that box** from nothing to its resting size instead of being moved, so the pill — a shrink-to-fit flex container — widens along with it and the icon is fully visible inside the name background at every frame;
- the collapsed keyframe cancels the pill's flex gap, so entering the flow does not widen the pill by one gap before the animation starts, and the hide animation fills forwards so the icon does not snap back to full size for one frame before `display: none`;
- `instant` is honoured, so a Woka created while already `SPEAKER` simply has the icon rather than replaying the entry animation for every Woka at once when you enter a room during a presentation.

Because the pill is intrinsically sized again, the width animation it needed becomes dead weight: `animateSizeChange`, `stopSizeAnimation`, `measureWidthWithoutMegaphone` and their two constants are removed, and `UsernameDisplay` no longer pins a width or clips its content. **`style.css` is untouched.** The sizes shared by the pill and its badges now live in `UsernameDisplaySizes`.

Also fixes two latent defects on the same path:
- the `forceClose` argument was unreachable, swallowed by the `show === isShown()` guard before it could reach the icon;
- an `UNCHANGED` status (which is `0`) compared unequal to `SPEAKER` and would have hidden the icon while the status dot correctly ignored it.

## Verification

Measured in a browser on a faithful reproduction of the produced DOM (pill absolutely positioned inside the DOM layer container), at two zoom levels, for a loaded / in-flight / failed image:

| | pill | icon | worst spill |
|---|---|---|---|
| before | 169.6 (fixed) | 42 | **+71px outside** |
| after, open | 139.5 → 193.9 → 189.5 | 0 → 45.7 → 42 | −5.2 (always inside) |
| after, close | 189.5 → 139.5 | 42 → 0 | always inside |

All three image states now behave identically. Start jump is 0px, and the resting size is unchanged from today.

`tsc --noEmit` clean, eslint and prettier clean.

Note that the icon must never be revealed with a `transform`: a translation is precisely what paints it where the pill does not extend, since the pill is sized by its content and cannot follow.

## Follow-up: the icon disappearing after a few seconds

Fixed in the second commit, from Copilot's review. The hide animation fills forwards so the icon does not snap back to its resting size for the one frame between the animation ending and `onfinish` applying `display: none` — but `onfinish` only dropped the reference to it, so the finished animation kept applying its last keyframe forever, and an animation effect outranks inline styles. `stopAnimation()` then had nothing left to cancel, so every later `show()` set the right inline styles and still painted a 0x0 transparent box.

Measured over seven show/hide cycles, before and after:

| step | before | after |
|---|---|---|
| show (instant) | visible | visible |
| hide | hidden | hidden |
| show | **hidden** | visible |
| hide | hidden | hidden |
| show (instant) | **hidden** | visible |
| hide | hidden | hidden |
| show | **hidden** | visible |
| hide interrupted by a show | **hidden** | visible |

So the icon was visible only until the first hide, on the animated and the instant path alike.

## Still open

`availabilityStatusStore` evaluates `SOUND_BLOCKED` before `SPEAKER`, and `signalAudioPlaybackBlocked()` latches for the lifetime of the app once the browser blocks audio playback. So a speaker whose audio gets blocked legitimately leaves `SPEAKER` and the icon hides (the status dot turns from gold to blue at the same moment). With the fix above the icon now comes back when the status returns to `SPEAKER`, so this is no longer a stuck state — but whether `SPEAKER` should outrank `SOUND_BLOCKED`, or whether the icon should follow `isSpeakerStore` directly instead of the availability status, is a product call and is left out of this PR.
