### PR TITLE
fix(tests): harden the audio-toast locator handler

### DIFF
--- a/tests/tests/utils/doNotDisturbInfoToast.ts
+++ b/tests/tests/utils/doNotDisturbInfoToast.ts
@@ -1,31 +1,57 @@
 import type { Page } from "@playwright/test";
 
 /**
- * By default Playwright, after running a locator handler, blocks the triggering action until the handler's
- * locator becomes hidden. When the toast cannot be cleared — headless Firefox regularly refuses to resume the
- * AudioContext, and the app re-raises the toast when a retry fails — that wait never ends, so the action that
- * triggered the handler is never evaluated even once. It then fails at the test timeout with a message that
- * describes nothing ("Received: undefined", or an empty class string for `not.toHaveClass`).
+ * A locator handler runs *inside* the action that triggered it, so anything that wedges in the handler wedges
+ * that action too. Observed in CI, the call log ends on
  *
- * `noWaitAfter` is what breaks that: the toast sits in the top-right corner (see MainLayout), it never covers
- * the action bar the assertions target, so there is no reason to wait on it. Note that bounding the handler
- * with `times` alone does NOT help — the very first invocation blocks forever, so the limit is never reached.
+ *   - found getByTestId('audio-playback-retry'), intercepting action to run the handler
+ *
+ * with no matching "locator handler has finished", and the triggering assertion then dies at the 120s test
+ * timeout having never been evaluated once ("Received: undefined", or an empty class string for
+ * `not.toHaveClass` — a value that trivially passes, which is the tell that it never ran).
+ *
+ * The click below already passes a Playwright `timeout`, and in a standalone reproduction that bound is
+ * honoured — so whatever wedges in CI is not reproducible here and remains unexplained. Rather than trust the
+ * inner timeout, the handler enforces its own: `withDeadline` resolves on a timer independent of Playwright,
+ * so the handler returns even if the action inside it never settles. Verified against a handler that hangs
+ * forever, in both chromium and firefox: without the deadline the triggering assertion starves for its whole
+ * timeout, with it the assertion proceeds and passes.
  */
-const CLICK_TIMEOUT_MS = 2_000;
+const DISMISS_DEADLINE_MS = 1_000;
 
 /**
- * A stuck toast would otherwise have the handler re-fire on every actionability poll for the rest of the test,
- * dispatching an endless stream of clicks into the app under test (each one also triggers the toast's own
- * pointerdown listener). Retrying a handful of times is enough for the toast's real use case: it appears once,
- * on load, and the first click normally clears it.
+ * A toast that cannot be dismissed would otherwise re-enter the handler on every actionability poll for the
+ * rest of the test, spending the deadline each time and dispatching an endless stream of clicks into the app
+ * under test (each also triggers the toast's own pointerdown listener). The toast's real use case is a single
+ * appearance on load that the first click clears, so a handful of attempts is plenty.
  */
-const MAX_DISMISS_ATTEMPTS = 10;
+const MAX_DISMISS_ATTEMPTS = 5;
 
 /**
  * `addLocatorHandler` appends a handler, it does not replace one, and several helpers on the login path call
  * this for the same page. Without this guard they stack up and fight over the same button.
  */
 const pagesWithHandler = new WeakSet<Page>();
+
+/**
+ * Resolves when `work` settles or when `ms` elapses, whichever comes first. Never rejects.
+ *
+ * `work` is always given a `.catch`, so a rejection arriving after the deadline cannot surface as an
+ * unhandled rejection and fail an unrelated test.
+ */
+async function withDeadline(work: Promise<unknown>, ms: number): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+        await Promise.race([
+            work.catch(() => undefined),
+            new Promise<void>((resolve) => {
+                timer = setTimeout(resolve, ms);
+            }),
+        ]);
+    } finally {
+        clearTimeout(timer);
+    }
+}
 
 /**
  * When the audio context is still suspended, the "no browser sound" info toast may appear with an
@@ -41,17 +67,18 @@ export async function dismissNoBrowserSoundInfoToast(page: Page): Promise<void> 
     await page.addLocatorHandler(
         page.getByTestId("audio-playback-retry"),
         async (retryButton) => {
-            try {
-                // The toast can start disappearing as the AudioContext resumes, so do not wait for stable
-                // actionability.
-                // eslint-disable-next-line playwright/no-force-option
-                await retryButton.click({ force: true, timeout: CLICK_TIMEOUT_MS });
-            } catch {
-                // Dismissing the toast is best effort: it never carries the assertion the caller cares about.
-                // Throwing here would surface inside whatever unrelated action happened to trigger the
-                // handler, so swallow it and let that action report its own result.
-            }
+            // Dismissing the toast is best effort: it never carries the assertion the caller cares about, so
+            // failures are swallowed and the triggering action is left to report its own result. The toast can
+            // start disappearing as the AudioContext resumes, so do not wait for stable actionability.
+            // eslint-disable-next-line playwright/no-force-option
+            await withDeadline(retryButton.click({ force: true, timeout: DISMISS_DEADLINE_MS }), DISMISS_DEADLINE_MS);
         },
-        { noWaitAfter: true, times: MAX_DISMISS_ATTEMPTS },
+        {
+            // Do not block the triggering action waiting for the toast to disappear. The toast renders in the
+            // top-right corner (MainLayout) and never covers the action bar the assertions target, so a retry
+            // that fails to resume audio must not hold that action hostage.
+            noWaitAfter: true,
+            times: MAX_DISMISS_ATTEMPTS,
+        },
     );
 }

--- a/tests/tests/utils/doNotDisturbInfoToast.ts
+++ b/tests/tests/utils/doNotDisturbInfoToast.ts
@@ -1,21 +1,57 @@
 import type { Page } from "@playwright/test";
 
 /**
+ * By default Playwright, after running a locator handler, blocks the triggering action until the handler's
+ * locator becomes hidden. When the toast cannot be cleared — headless Firefox regularly refuses to resume the
+ * AudioContext, and the app re-raises the toast when a retry fails — that wait never ends, so the action that
+ * triggered the handler is never evaluated even once. It then fails at the test timeout with a message that
+ * describes nothing ("Received: undefined", or an empty class string for `not.toHaveClass`).
+ *
+ * `noWaitAfter` is what breaks that: the toast sits in the top-right corner (see MainLayout), it never covers
+ * the action bar the assertions target, so there is no reason to wait on it. Note that bounding the handler
+ * with `times` alone does NOT help — the very first invocation blocks forever, so the limit is never reached.
+ */
+const CLICK_TIMEOUT_MS = 2_000;
+
+/**
+ * A stuck toast would otherwise have the handler re-fire on every actionability poll for the rest of the test,
+ * dispatching an endless stream of clicks into the app under test (each one also triggers the toast's own
+ * pointerdown listener). Retrying a handful of times is enough for the toast's real use case: it appears once,
+ * on load, and the first click normally clears it.
+ */
+const MAX_DISMISS_ATTEMPTS = 10;
+
+/**
+ * `addLocatorHandler` appends a handler, it does not replace one, and several helpers on the login path call
+ * this for the same page. Without this guard they stack up and fight over the same button.
+ */
+const pagesWithHandler = new WeakSet<Page>();
+
+/**
  * When the audio context is still suspended, the "no browser sound" info toast may appear with an
  * "Enable sound" action. Clicking it resumes the audio context and clears the toast.
  * No-op if the toast is not shown before the microphone is in visible state.
  */
-export async function dismissNoBrowserSoundInfoToast(page: Page, timeoutMs: number = 5_000): Promise<void> {
-    await page.addLocatorHandler(page.getByTestId("audio-playback-retry"), async (retryButton) => {
-        try {
-            // The toast can start disappearing as the AudioContext resumes, so do not wait for stable actionability.
-            // eslint-disable-next-line playwright/no-force-option
-            await retryButton.click({ force: true, timeout: timeoutMs });
-        } catch (e) {
-            if (page.isClosed() || (await retryButton.isHidden().catch(() => true))) {
-                return;
+export async function dismissNoBrowserSoundInfoToast(page: Page): Promise<void> {
+    if (pagesWithHandler.has(page)) {
+        return;
+    }
+    pagesWithHandler.add(page);
+
+    await page.addLocatorHandler(
+        page.getByTestId("audio-playback-retry"),
+        async (retryButton) => {
+            try {
+                // The toast can start disappearing as the AudioContext resumes, so do not wait for stable
+                // actionability.
+                // eslint-disable-next-line playwright/no-force-option
+                await retryButton.click({ force: true, timeout: CLICK_TIMEOUT_MS });
+            } catch {
+                // Dismissing the toast is best effort: it never carries the assertion the caller cares about.
+                // Throwing here would surface inside whatever unrelated action happened to trigger the
+                // handler, so swallow it and let that action report its own result.
             }
-            throw e;
-        }
-    });
+        },
+        { noWaitAfter: true, times: MAX_DISMISS_ATTEMPTS },
+    );
 }


### PR DESCRIPTION
> **Rewritten.** This PR originally claimed to fix ~half of all E2E flakiness. That claim was wrong and is retracted below. What remains is worthwhile hardening, not a stability fix. See #6424 for the follow-up that makes the real cause diagnosable.

## What this PR actually does

Three defects in `dismissNoBrowserSoundInfoToast`, each verified in isolation:

1. **The handler could block the action that triggered it.** By default Playwright waits for the handler's locator to go hidden before letting that action proceed; an unclearable toast means it never does. `noWaitAfter` fixes this — the toast renders in the top-right corner (`MainLayout`) and never covers the action bar the assertions target, so there was never a reason to block on it. Measured: undismissable toast, target appears after 2 s → without `noWaitAfter` the assertion fails at its full timeout, with it it passes in 2.3 s. (`times` alone does **not** help: the first invocation blocks forever, so the limit is never reached.)
2. **The handler could hang indefinitely.** It now enforces its own deadline, racing the click against a plain timer rather than trusting Playwright's inner `timeout`. Verified against a handler that hangs forever, in both chromium and firefox: 20 s starve → 2.0 s pass.
3. **Handlers stacked.** `addLocatorHandler` appends rather than replaces, and three helpers on the login path (`auth.ts:120`, `auth.ts:188`, `oidc.ts:23`) call this for the same page. Now registered once per page.

Plus an attempt cap, so an unclearable toast cannot re-enter the handler on every actionability poll for the rest of the test, dispatching an endless stream of clicks into the app under test.

Verified end-to-end through the actual shipped helper (imported, not a copy): passes in ~2.3 s against a permanent toast in both browsers, idempotent across repeated registration.

## The claim I retract

I originally reported that this signature accounted for 41 of 85 failure blocks and 27 of 36 distinct failing tests:

```
- found getByTestId('audio-playback-retry'), intercepting action to run the handler
```

**That was correlation, not causation.** I tested what the fixed helper produces when the *app* is broken and the handler is healthy:

```
Expected: visible
Timeout: 25000ms
Error: element(s) not found                                    <-- note
  5 × found getByTestId('audio-playback-retry'), intercepting action to run the handler
    - locator handler has finished
```

CI shows something **different**: `Received: undefined`, a *single* `found`, no `finished`, plus a separate `Test timeout of 120000ms exceeded`. That is the signature of the **120 s test timeout killing the assertion mid-flight** — the toast merely happens to be on screen when the clock runs out. The toast appears whenever audio playback is blocked, which correlates with a struggling page; it is a symptom, not the cause.

Measured effect on CI, like-for-like on the same shard (firefox 1/4):

| | total blocks | audio signature | still "starved" |
|---|---|---|---|
| before | 18 | 7 | 7 |
| after | 16 | 6 | 5 |

Within noise. **This PR does not fix the E2E instability.**

## What is actually failing

The same job shows 5 failures of an unrelated kind — Playwright dispatches a click and it never completes:

```
- element is visible, enabled and stable
- scrolling into view if needed
- done scrolling
- performing click action        <-- then nothing, 50s
```

Three of those are on the **OIDC login page**, a plain ASP.NET form that is not the WA app at all. The count was 5 before this PR and 5 after. A failure-time page snapshot also shows the app fully loaded (action bar, "Alice", "Online") while the assertion was failing. That points at a browser/environment-level stall in Firefox, which no test-helper change can address.

I also checked and ruled out Firefox autoplay policy as the reason the toast appears: Firefox plays a `MediaStream` via `srcObject` without any user gesture, with and without `media.autoplay.*` prefs. Setting those prefs would have changed nothing.

## Merge or close

Reasonable either way. The changes are correct and independently verified, and they remove three real failure modes from a helper that sits on the shared login path — but they demonstrably do not move the CI numbers. Happy to close it if you would rather not carry hardening that does not pay for itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)