### PR TITLE
fix(ci): stop an unused apt repo from killing whole E2E shards

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -1,0 +1,58 @@
+name: "Install Playwright"
+description: "Installs Playwright browsers and their system dependencies, hardened against transient apt/CDN failures."
+
+inputs:
+  browser:
+    description: "Browser to install (firefox, chromium, webkit, ...)."
+    required: true
+  working-directory:
+    description: "Directory the Playwright dependencies are installed in."
+    required: false
+    default: "tests"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Drop apt repositories Playwright does not need
+      shell: bash
+      run: |
+        # `playwright install --with-deps` runs `apt-get update`, and apt exits non-zero when ANY configured
+        # repository fails to fetch — which aborts the whole step and kills the entire shard. The Google
+        # Chrome repository preinstalled on the runner is the observed offender:
+        #
+        #   E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/.../Packages.gz
+        #      File has unexpected size (1403 != 1407). Mirror sync in progress?
+        #   E: Some index files failed to download.
+        #   Failed to install browsers / Error: Installation process exited with code: 100
+        #
+        # Nothing here needs it: the browsers come from Playwright's own CDN and `--with-deps` only pulls
+        # Ubuntu system libraries. It would only matter for the branded `chrome`/`msedge` channels, which
+        # this repo does not use (they are commented out in tests/playwright.config.ts).
+        #
+        # Matched by content rather than by filename so this keeps working across runner image changes and
+        # the newer deb822 `.sources` format.
+        matches="$(sudo grep -rl "dl\.google\.com" /etc/apt/sources.list.d/ 2>/dev/null || true)"
+        if [ -n "$matches" ]; then
+          echo "Removing unused apt repositories:"
+          echo "$matches"
+          echo "$matches" | sudo xargs -r rm -f
+        fi
+
+    - name: Install Playwright browsers
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        # The remaining Ubuntu mirrors and Playwright's browser CDN can still fail transiently, so retry
+        # rather than lose a 20 minute shard to a blip.
+        for attempt in 1 2 3; do
+          if npx playwright install --with-deps ${{ inputs.browser }}; then
+            exit 0
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            delay=$((attempt * 15))
+            echo "::warning::playwright install failed (attempt ${attempt}/3), retrying in ${delay}s"
+            sleep "$delay"
+          fi
+        done
+        echo "::error::playwright install failed after 3 attempts"
+        exit 1

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -211,8 +211,9 @@ jobs:
         run: npm ci
         working-directory: tests
       - name: Install Playwright
-        run: npx playwright install --with-deps ${{ matrix.browser }}
-        working-directory: tests
+        uses: ./.github/actions/install-playwright
+        with:
+          browser: ${{ matrix.browser }}
       - name: Set up virtual audio output for Firefox
         if: ${{ contains(matrix.project, 'firefox') }}
         run: |
@@ -504,8 +505,9 @@ jobs:
         run: npm ci
         working-directory: tests
       - name: Install Playwright
-        run: npx playwright install --with-deps chromium
-        working-directory: tests
+        uses: ./.github/actions/install-playwright
+        with:
+          browser: chromium
       - name: 'Setup .env file'
         run: cp .env.prod.template .env
         working-directory: contrib/docker
@@ -888,8 +890,9 @@ jobs:
         run: npm ci
         working-directory: tests
       - name: Install Playwright
-        run: npx playwright install --with-deps chromium
-        working-directory: tests
+        uses: ./.github/actions/install-playwright
+        with:
+          browser: chromium
 
       - name: "Install Room Api client dependencies"
         run: npm ci


### PR DESCRIPTION
## The problem

`playwright install --with-deps` runs `apt-get update`, and **apt exits non-zero when _any_ configured repository fails to fetch**. The Google Chrome repository preinstalled on GitHub runners desynced during a recent run:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz
   File has unexpected size (1403 != 1407). Mirror sync in progress? [IP: 142.251.215.174 443]
E: Some index files failed to download. They have been ignored, or old ones used instead.
Failed to install browsers
Error: Installation process exited with code: 100
```

That aborted the step and took the **entire `webkit 3/4` shard down after 36 seconds** — before a single test ran (run [31373184195](https://github.com/workadventure/workadventure/actions/runs/31373184195), PR #6415).

## The fix

**Drop the repository before installing.** Nothing here needs it: the browsers come from Playwright's own CDN, and `--with-deps` only pulls Ubuntu system libraries. It would only matter for the branded `chrome`/`msedge` channels, which are commented out in `tests/playwright.config.ts` — I checked, there is no other reference to `dl.google.com`, `google-chrome` or `--channel` anywhere in the workflows or test config.

Matching is by **content, not filename**, so it survives runner image changes and the newer deb822 `.sources` format.

**Retry up to three times.** Removing that repo fixes the observed failure deterministically, but the remaining Ubuntu mirrors and Playwright's browser CDN can still blip, and losing a 20-minute shard to that is expensive.

Both are extracted into a local composite action, since all three jobs ran the same command.

## Verification

I tested both shell snippets rather than eyeballing them.

**Repo removal** — against a replica of the runner layout with both formats:

```
before: google-chrome.list  google-chrome-remote.sources  microsoft-prod.list  ubuntu.list
removed: google-chrome.list, google-chrome-remote.sources
after:  microsoft-prod.list  ubuntu.list          <-- unrelated repos untouched
```

Also verified the no-match and missing-directory cases exit 0, so the step cannot fail under `set -e` on a runner image that no longer ships the repo.

**Retry loop** — with a stubbed installer, under `set -e`:

| Succeeds on | Calls made | Step exit |
|---|---|---|
| 1st attempt | 1 | 0 |
| 2nd attempt | 2 | 0 |
| 3rd attempt | 3 | 0 |
| never | 3 | 1 |

No spurious sleep after the final attempt.

**Call sites** — all three jobs (`end-to-end-tests`, `prod-single-domain-deploy-tests`, `helm-test`) run `actions/checkout` before the install step, which a local `uses: ./...` action requires. Verified programmatically, not by eye. Both YAML files parse.

## Note

This is #3 of the E2E instability series, after #6419. #2 (the recording tests) turned out to be egress-pipeline breakage rather than a test bug — an egress that logs `chrome: START_RECORDING` but never emits `egress_active` — so no test-side change legitimately fixes it; it needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)