### PR TITLE
fix(zones): bound the number of zones a viewport can subscribe to

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -52,6 +52,12 @@ export type EventSocket = ServerWritableStream<EventRequest, EventResponse>;
 const PONG_TIMEOUT = 70000; // PONG_TIMEOUT is > 1 minute because of Chrome heavy throttling. See: https://docs.google.com/document/d/11FhKHRcABGS4SWPFGwoL6g0ALMqrFKapCk5ZTKKupEk/edit#
 const PING_INTERVAL = 80000;
 
+// Maximum number of zones a single pusher connection (i.e. a single listenRoom stream) may subscribe to for a room.
+// The pusher already bounds the size of a viewport, this is a safety net so that a buggy or hostile pusher cannot
+// make the back accumulate an unbounded number of zone listeners. The bound is very generous: it corresponds to a
+// map of about 70 000 x 70 000 pixels (roughly 2200 x 2200 tiles) entirely covered by players.
+const MAX_SUBSCRIBED_ZONES_PER_ROOM_SOCKET = 50_000;
+
 const roomManager = {
     connectToRoom: (call: UserSocket): void => {
         let room: GameRoom | null = null;
@@ -336,6 +342,8 @@ const roomManager = {
         debug("listenRoom called");
         let roomId: string | null = null;
         const subscribedZones = new Map<string, { x: number; y: number }>();
+        let zoneLimitReported = false;
+        let zonesCleanedUp = false;
         // We use this promise to serialize the processing of incoming messages. Only one message is processed at a time.
         let messageProcessingPromise = Promise.resolve();
 
@@ -367,6 +375,19 @@ const roomManager = {
                                     console.warn(
                                         `WARNING: Double subscription to zone (${subscribeMessage.x},${subscribeMessage.y}) in room ${roomId}. This indicates a bug in the pusher.`,
                                     );
+                                    return;
+                                }
+
+                                if (subscribedZones.size >= MAX_SUBSCRIBED_ZONES_PER_ROOM_SOCKET) {
+                                    // The pusher will keep sending subscriptions, so we only report the first
+                                    // refusal (the error is logged, sent to Sentry and pushed back on the socket)
+                                    // and stay silent afterwards.
+                                    if (!zoneLimitReported) {
+                                        zoneLimitReported = true;
+                                        throw new Error(
+                                            `Too many subscribed zones (${subscribedZones.size}) for room ${roomId}. Refusing subscription to zone (${subscribeMessage.x},${subscribeMessage.y}). This indicates a bug in the pusher or an oversized viewport sent by a client.`,
+                                        );
+                                    }
                                     return;
                                 }
 
@@ -419,17 +440,24 @@ const roomManager = {
         });
 
         const cleanupAllZones = async () => {
-            if (roomId !== null) {
-                try {
-                    await socketManager.removeRoomListener(call, roomId);
-                } finally {
-                    const theRoomId = roomId;
-                    await Promise.all(
-                        Array.from(subscribedZones.values()).map((zone) =>
-                            socketManager.removeZoneListener(call, theRoomId, zone.x, zone.y),
-                        ),
-                    );
-                }
+            // This function is called from the "cancelled", "close" and "error" handlers, which may all fire for a
+            // single disconnection. Only the first call does anything: replaying it would call removeRoomListener
+            // again, which throws once the room has been deleted by cleanupRoomIfEmpty (pure Sentry noise during
+            // disconnect storms).
+            if (roomId === null || zonesCleanedUp) {
+                return;
+            }
+            zonesCleanedUp = true;
+            const theRoomId = roomId;
+            try {
+                await socketManager.removeRoomListener(call, theRoomId);
+            } finally {
+                // No Promise.all here: the removals are synchronous once the room is resolved, and the number of
+                // subscribed zones is not bounded by anything we control on this side (Promise.all throws a
+                // RangeError above 2^21 elements).
+                const zones = Array.from(subscribedZones.values());
+                subscribedZones.clear();
+                await socketManager.removeZoneListeners(call, theRoomId, zones);
             }
         };
 

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -967,6 +967,31 @@ export class SocketManager {
         this.cleanupRoomIfEmpty(room);
     }
 
+    /**
+     * Removes many zone listeners at once.
+     *
+     * Compared to calling removeZoneListener in a loop, the room is resolved only once and the room cleanup is
+     * only attempted once. It also lets callers get rid of a Promise.all over an unbounded number of zones
+     * (Promise.all throws a RangeError above 2^21 elements).
+     */
+    async removeZoneListeners(
+        call: RoomSocket,
+        roomId: string,
+        zones: Iterable<{ x: number; y: number }>,
+    ): Promise<void> {
+        const room = await this.roomsPromises.get(roomId);
+        if (!room) {
+            console.warn("In removeZoneListeners, could not find room with id '" + roomId + "'");
+            return;
+        }
+
+        // GameRoom.removeZoneListener is synchronous, so no Promise juggling is needed here.
+        for (const zone of zones) {
+            room.removeZoneListener(call, zone.x, zone.y);
+        }
+        this.cleanupRoomIfEmpty(room);
+    }
+
     async addRoomListener(call: RoomSocket, roomId: string) {
         const room = await this.getOrCreateRoom(roomId);
         if (!room) {

--- a/play/src/pusher/models/PositionDispatcher.ts
+++ b/play/src/pusher/models/PositionDispatcher.ts
@@ -9,6 +9,7 @@
  * number of players around the current player.
  */
 import type { ZoneMessage } from "@workadventure/messages";
+import * as Sentry from "@sentry/node";
 import type { PusherWebSocket } from "../services/PusherWebSocket";
 import { Zone } from "./Zone";
 import type { ZoneEventListener } from "./Zone";
@@ -20,8 +21,23 @@ interface ZoneDescriptor {
     j: number;
 }
 
+/**
+ * Maximum number of zones a single viewport is allowed to cover.
+ *
+ * The viewport is sent by the client and is therefore untrusted: nothing prevents a buggy (or malicious) client
+ * from announcing a viewport spanning the whole int32 range, which would make us subscribe to millions of zones
+ * on the back (and freeze the pusher in the nested loop below).
+ *
+ * 1600 zones is a 40x40 grid of 320px zones, i.e. a 12800x12800px window, about 25 times a standard 1080p
+ * viewport. A viewport can legitimately go above that on a very large map (the front allows dezooming until the
+ * whole map fits on screen), which is why an oversized viewport is cropped rather than rejected: see
+ * boundZoneRectangle().
+ */
+export const MAX_ZONES_PER_VIEWPORT = 1600;
+
 export class PositionDispatcher {
     private zones: Map<string, Zone> = new Map();
+    private oversizedViewportsCropped = 0;
 
     constructor(
         public readonly roomId: string,
@@ -43,22 +59,98 @@ export class PositionDispatcher {
     }
 
     /**
+     * Ensures the rectangle of zones covered by a viewport stays under MAX_ZONES_PER_VIEWPORT.
+     *
+     * An oversized viewport is cropped around its center rather than rejected: we keep serving the player what
+     * is in the middle of their screen instead of freezing them on their previous zones. This covers the two
+     * cases at once:
+     *  - a legitimate one (a player fully dezoomed on a very large map): they keep seeing the players around the
+     *    center of their view, and lose the ones on the far edges;
+     *  - an abnormal one (a buggy front sending a viewport of a few million pixels, or a hand-crafted client
+     *    trying to subscribe to the whole map): the fan-out is bounded, whatever they send.
+     */
+    private boundZoneRectangle(
+        topLeft: ZoneDescriptor,
+        bottomRight: ZoneDescriptor,
+        viewport: ViewportInterface,
+    ): { topLeft: ZoneDescriptor; bottomRight: ZoneDescriptor } {
+        const width = bottomRight.i - topLeft.i + 1;
+        const height = bottomRight.j - topLeft.j + 1;
+        if (width * height <= MAX_ZONES_PER_VIEWPORT) {
+            return { topLeft, bottomRight };
+        }
+
+        // Shrink both sides by the same ratio to keep the aspect ratio of the viewport.
+        const ratio = Math.sqrt(MAX_ZONES_PER_VIEWPORT / (width * height));
+        let croppedWidth = Math.max(1, Math.floor(width * ratio));
+        let croppedHeight = Math.max(1, Math.floor(height * ratio));
+        // On a very elongated viewport, one of the two sides is floored to 1 and the ratio no longer holds:
+        // trim the longest side so that the product is under the limit in every case.
+        if (croppedWidth * croppedHeight > MAX_ZONES_PER_VIEWPORT) {
+            if (croppedWidth >= croppedHeight) {
+                croppedWidth = Math.max(1, Math.floor(MAX_ZONES_PER_VIEWPORT / croppedHeight));
+            } else {
+                croppedHeight = Math.max(1, Math.floor(MAX_ZONES_PER_VIEWPORT / croppedWidth));
+            }
+        }
+
+        const centerI = Math.floor((topLeft.i + bottomRight.i) / 2);
+        const centerJ = Math.floor((topLeft.j + bottomRight.j) / 2);
+        const croppedTopLeft = {
+            i: centerI - Math.floor((croppedWidth - 1) / 2),
+            j: centerJ - Math.floor((croppedHeight - 1) / 2),
+        };
+
+        this.oversizedViewportsCropped++;
+        // Only report the first occurrence for this room: viewports are sent at a high rate, we do not want to
+        // flood the logs / Sentry when a client keeps sending the same oversized viewport.
+        if (this.oversizedViewportsCropped === 1) {
+            const message = `Oversized viewport cropped in room ${this.roomId}: ${
+                width * height
+            } zones requested (max ${MAX_ZONES_PER_VIEWPORT})`;
+            console.warn(message, viewport);
+            Sentry.captureMessage(message, {
+                extra: { roomId: this.roomId, requestedZones: width * height, viewport },
+            });
+        }
+
+        return {
+            topLeft: croppedTopLeft,
+            bottomRight: {
+                i: croppedTopLeft.i + croppedWidth - 1,
+                j: croppedTopLeft.j + croppedHeight - 1,
+            },
+        };
+    }
+
+    /**
      * Sets the viewport coordinates.
      */
     public setViewport(socket: PusherWebSocket, viewport: ViewportInterface): void {
-        if (viewport.left > viewport.right || viewport.top > viewport.bottom) {
+        if (
+            !Number.isFinite(viewport.left) ||
+            !Number.isFinite(viewport.right) ||
+            !Number.isFinite(viewport.top) ||
+            !Number.isFinite(viewport.bottom) ||
+            viewport.left > viewport.right ||
+            viewport.top > viewport.bottom
+        ) {
             console.warn("Invalid viewport received: ", viewport);
             return;
         }
 
+        // The rectangle must be bounded BEFORE looping: it is the loop itself that would freeze the pusher.
+        const { topLeft, bottomRight } = this.boundZoneRectangle(
+            this.getZoneDescriptorFromCoordinates(viewport.left, viewport.top),
+            this.getZoneDescriptorFromCoordinates(viewport.right, viewport.bottom),
+            viewport,
+        );
+
         const oldZones = socket.getUserData().listenedZones;
         const newZones = new Set<string>();
 
-        const topLeftDesc = this.getZoneDescriptorFromCoordinates(viewport.left, viewport.top);
-        const bottomRightDesc = this.getZoneDescriptorFromCoordinates(viewport.right, viewport.bottom);
-
-        for (let j = topLeftDesc.j; j <= bottomRightDesc.j; j++) {
-            for (let i = topLeftDesc.i; i <= bottomRightDesc.i; i++) {
+        for (let j = topLeft.j; j <= bottomRight.j; j++) {
+            for (let i = topLeft.i; i <= bottomRight.i; i++) {
                 newZones.add(this.getZoneKey(i, j));
             }
         }

--- a/play/tests/pusher/PositionDispatcher.test.ts
+++ b/play/tests/pusher/PositionDispatcher.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import * as Sentry from "@sentry/node";
+import { MAX_ZONES_PER_VIEWPORT, PositionDispatcher } from "../../src/pusher/models/PositionDispatcher";
+import type { PusherRoom } from "../../src/pusher/models/PusherRoom";
+import type { PusherWebSocket } from "../../src/pusher/services/PusherWebSocket";
+import type { ZoneEventListener } from "../../src/pusher/models/Zone";
+
+vi.mock("@sentry/node", () => ({
+    captureMessage: vi.fn(),
+    captureException: vi.fn(),
+}));
+
+function createDispatcher() {
+    const pusherRoom = {
+        subscribeToZone: vi.fn(),
+        unsubscribeFromZone: vi.fn(),
+    };
+
+    const dispatcher = new PositionDispatcher(
+        "http://play.workadventure.localhost/@/team/world/room",
+        320,
+        320,
+        {} as ZoneEventListener,
+        pusherRoom as unknown as PusherRoom,
+    );
+
+    const listenedZones = new Set<string>();
+    const socket = {
+        getUserData: () => ({ listenedZones }),
+    } as unknown as PusherWebSocket;
+
+    return { dispatcher, pusherRoom, socket, listenedZones };
+}
+
+describe("PositionDispatcher", () => {
+    it("subscribes to the zones covered by a regular viewport", () => {
+        const { dispatcher, pusherRoom, socket } = createDispatcher();
+
+        // Roughly a 1080p screen plus the margin added by the front: 8x6 zones of 320px
+        dispatcher.setViewport(socket, { left: 0, top: 0, right: 2520, bottom: 1680 });
+
+        expect(pusherRoom.subscribeToZone).toHaveBeenCalledTimes(8 * 6);
+    });
+
+    it("ignores a viewport whose coordinates are inverted", () => {
+        const { dispatcher, pusherRoom, socket } = createDispatcher();
+
+        dispatcher.setViewport(socket, { left: 1000, top: 0, right: 0, bottom: 1000 });
+
+        expect(pusherRoom.subscribeToZone).not.toHaveBeenCalled();
+    });
+
+    it("ignores a viewport whose coordinates are not finite", () => {
+        const { dispatcher, pusherRoom, socket } = createDispatcher();
+
+        dispatcher.setViewport(socket, { left: 0, top: 0, right: Number.NaN, bottom: 1000 });
+
+        expect(pusherRoom.subscribeToZone).not.toHaveBeenCalled();
+    });
+
+    it("crops an oversized viewport around its center instead of subscribing to a huge number of zones", () => {
+        const { dispatcher, pusherRoom, socket } = createDispatcher();
+
+        // Such a viewport covers ~9.7 million zones. Before the guard, this froze the pusher in the subscription
+        // loop and made the back accumulate enough zones to break Promise.all on disconnection.
+        dispatcher.setViewport(socket, { left: 0, top: 0, right: 1_000_000, bottom: 1_000_000 });
+
+        const subscribedZoneKeys = new Set(
+            pusherRoom.subscribeToZone.mock.calls.map((call) => `${call[0]},${call[1]}`),
+        );
+
+        expect(subscribedZoneKeys.size).toBeLessThanOrEqual(MAX_ZONES_PER_VIEWPORT);
+        // The window is still large enough to be useful, and centered on what the player is looking at.
+        expect(subscribedZoneKeys.size).toBeGreaterThan(MAX_ZONES_PER_VIEWPORT / 2);
+        expect(subscribedZoneKeys.has("1562,1562")).toBe(true);
+        expect(subscribedZoneKeys.has("0,0")).toBe(false);
+    });
+
+    it("crops an oversized viewport that is extremely elongated", () => {
+        const { dispatcher, pusherRoom, socket } = createDispatcher();
+
+        // A single row of 3126 zones: cropping both sides by the same ratio is not enough here, the longest
+        // side has to be trimmed on its own.
+        dispatcher.setViewport(socket, { left: 0, top: 0, right: 1_000_000, bottom: 0 });
+
+        expect(pusherRoom.subscribeToZone.mock.calls.length).toBeLessThanOrEqual(MAX_ZONES_PER_VIEWPORT);
+        expect(pusherRoom.subscribeToZone.mock.calls.length).toBeGreaterThan(0);
+    });
+
+    it("only reports the first oversized viewport of a room", () => {
+        const { dispatcher, socket } = createDispatcher();
+        const captureMessage = vi.mocked(Sentry.captureMessage);
+        captureMessage.mockClear();
+
+        dispatcher.setViewport(socket, { left: 0, top: 0, right: 1_000_000, bottom: 1_000_000 });
+        dispatcher.setViewport(socket, { left: 0, top: 0, right: 2_000_000, bottom: 2_000_000 });
+
+        expect(captureMessage).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## The problem

Production reports the following error:

```
RangeError: Too many elements passed to Promise.all
  File "/usr/src/back/src/RoomManager.ts", line 427, in cleanupAllZones
```

This is a hard V8 limit: the remaining-elements counter of `Promise.all` is stored on a 21 bits field, so it throws above 2 097 151 elements. In other words, a single `listenRoom` stream (one pusher/room pair) had accumulated **more than 2 million subscribed zones**. The crash is only the visible symptom: long before throwing, such a room had already blown up the memory of both the pusher and the back.

Nothing bounded the chain going from the client viewport to the zone subscriptions:

`front → viewportMessage` → `SocketManager.handleViewport` → `PusherRoom.setViewport` → `PositionDispatcher.setViewport` (nested loop over `viewport / 320`) → `subscribeToZone` → `subscribedZones` on the back.

`ViewportMessage` is an `int32` coming from the browser and the only validation was `left > right || top > bottom`. A client announcing `{left: 0, top: 0, right: 1_000_000, bottom: 1_000_000}` generates ~9.7 million zones: the pusher freezes in the subscription loop, the back accumulates, and `Promise.all` blows up when the stream closes.

## The fix, in three layers

### 1. `PositionDispatcher` crops oversized viewports (pusher)

`MAX_ZONES_PER_VIEWPORT = 1600`, i.e. a 40x40 grid of 320px zones (12 800x12 800 px), about 25 times a standard 1080p viewport. The new `boundZoneRectangle()` method is called **before** the nested loop — it is the loop itself that would freeze the pusher — and:

1. shrinks both sides by the same ratio `sqrt(MAX / total)`, preserving the aspect ratio;
2. re-centers the window on the center of the requested viewport;
3. if the viewport is very elongated and one side is floored to 1, trims the longest side on its own, so that the product stays under the limit in every case.

**Why crop rather than reject**: the front allows dezooming until the whole map fits on screen (`CameraManager.ts:139`, `maxZoomOut = getTargetZoomModifierFor(mapSize)`). On a map larger than ~400x400 tiles, a fully dezoomed player goes above 1600 zones without doing anything abnormal. Cropping keeps serving them the players at the center of their view instead of freezing them on their previous zones, and bounds the fan-out of a hand-crafted client just the same.

Plain rejection is kept for **invalid** viewports: inverted coordinates, and now non-finite ones (`NaN` used to pass the `left > right` check).

A `console.warn` + `Sentry.captureMessage` is emitted **only once per room**: viewports are sent at a high rate, otherwise this would flood the logs.

### 2. `RoomManager` caps the subscriptions per stream (back)

`MAX_SUBSCRIBED_ZONES_PER_ROOM_SOCKET = 50 000` per `listenRoom` stream: the back no longer trusts the pusher. Only the first refusal is reported, then it stays silent, otherwise every subsequent subscription would spam Sentry.

### 3. Removal of the `Promise.all`

`GameRoom.removeZoneListener` is purely synchronous — so the `Promise.all` had no reason to exist, and every call was redoing a `roomsPromises.get()` **and** a `cleanupRoomIfEmpty()`. The new `SocketManager.removeZoneListeners()` resolves the room once, loops synchronously, and attempts the cleanup only once.

`cleanupAllZones` is wired to the `cancelled`, `close` **and** `error` handlers, which may all fire for a single disconnection, so it used to run several times: the same zones were removed again, and `removeRoomListener` threw `could not find room` once `cleanupRoomIfEmpty` had deleted the room — a `console.error` + `Sentry.captureException` on every clean disconnect of the last pusher. A `zonesCleanedUp` guard now makes every call after the first a real no-op.

## Tests

New file `play/tests/pusher/PositionDispatcher.test.ts`, 6 cases: regular viewport (48 zones), inverted coordinates, non-finite coordinates, centered cropping (9.7M zones requested → at most 1600 subscribed, the center zone present, the far corner gone), extremely elongated viewport (the branch trimming the longest side), and a single Sentry report per room.

The existing `back` suite passes unchanged (222 tests).
