### PR TITLE
fix(self-hosting): add missing Matrix domain configuration

### DIFF
--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -165,6 +165,8 @@ OPENID_WOKA_NAME_POLICY=user_input
 MATRIX_API_URI=
 # The public URL of the Matrix server. This is the URL that the WorkAdventure clients will use to communicate with the Matrix server.
 MATRIX_PUBLIC_URI=
+# The Matrix server name used in Matrix user and room IDs. This must match the server_name in the Synapse configuration.
+MATRIX_DOMAIN=
 # A valid Matrix user that will be used to create rooms and invite users.
 MATRIX_ADMIN_USER=
 MATRIX_ADMIN_PASSWORD=

--- a/docs/others/self-hosting/matrix.md
+++ b/docs/others/self-hosting/matrix.md
@@ -103,6 +103,8 @@ If you are using docker-compose to start WorkAdventure, you can set the followin
 MATRIX_API_URI=
 # The public URL of the Matrix server. This is the URL that the WorkAdventure clients will use to communicate with the Matrix server.
 MATRIX_PUBLIC_URI=
+# The Matrix server name used in Matrix user and room IDs. This must match the server_name in the Synapse configuration.
+MATRIX_DOMAIN=
 # A valid Matrix user that will be used to create rooms and invite users.
 MATRIX_ADMIN_USER=
 MATRIX_ADMIN_PASSWORD=
@@ -122,6 +124,8 @@ play:
     MATRIX_API_URI: ""
     # The public URL of the Matrix server. This is the URL that the WorkAdventure clients will use to communicate with the Matrix server.
     MATRIX_PUBLIC_URI: ""
+    # The Matrix server name used in Matrix user and room IDs. This must match the server_name in the Synapse configuration.
+    MATRIX_DOMAIN: ""
     # A valid Matrix user that will be used to create rooms and invite users.
     MATRIX_ADMIN_USER: ""
   secretEnv:


### PR DESCRIPTION
## Description

Add the missing `MATRIX_DOMAIN` setting to the production environment template and Matrix self-hosting guide.

The local admin enables Matrix Chat only when `MATRIX_PUBLIC_URI`, `MATRIX_API_URI`, `MATRIX_ADMIN_USER`, `MATRIX_ADMIN_PASSWORD`, and `MATRIX_DOMAIN` are all configured. The production Compose file already forwards `MATRIX_DOMAIN`, but the environment template and setup examples did not define it, so following the documented configuration left Matrix Chat disabled.

## Changes

- Add `MATRIX_DOMAIN` to `.env.prod.template`
- Add `MATRIX_DOMAIN` to the Docker Compose and Helm configuration examples
- Clarify that the value must match `server_name` in the Synapse configuration

## Verification

- Ran `git diff --check`
- Confirmed that `docker-compose.prod.yaml` already forwards `MATRIX_DOMAIN` to the play container
