### PR TITLE
fix(map-storage): decode URL paths before building storage keys

### DIFF
--- a/map-storage/src/MapStorageServer.ts
+++ b/map-storage/src/MapStorageServer.ts
@@ -33,7 +33,7 @@ import { ModifyCustomEntityMapStorageCommand } from "./Commands/Entity/ModifyCus
 import { UploadEntityMapStorageCommand } from "./Commands/Entity/UploadEntityMapStorageCommand";
 import { entitiesManager } from "./EntitiesManager";
 import { mapsManager } from "./MapsManager";
-import { mapPathUsingDomainWithPrefix } from "./Services/PathMapper";
+import { mapPathUsingUrl } from "./Services/PathMapper";
 import { DeleteAreaMapStorageCommand } from "./Commands/Area/DeleteAreaMapStorageCommand";
 import { UpdateAreaMapStorageCommand } from "./Commands/Area/UpdateAreaMapStorageCommand";
 import { DeleteEntityMapStorageCommand } from "./Commands/Entity/DeleteEntityMapStorageCommand";
@@ -65,11 +65,18 @@ const mapStorageServer: MapStorageServer = {
         call: ServerUnaryCall<MapStorageClearAfterUploadMessage, Empty>,
         callback: sendUnaryData<Empty>,
     ): void {
-        const wamUrl = call.request.wamUrl;
-        const url = new URL(wamUrl);
-        const wamKey = mapPathUsingDomainWithPrefix(url.pathname, url.hostname);
-        mapsManager.clearAfterUpload(wamKey);
-        callback(null);
+        try {
+            const wamUrl = call.request.wamUrl;
+            const url = new URL(wamUrl);
+            const wamKey = mapPathUsingUrl(url);
+            mapsManager.clearAfterUpload(wamKey);
+            callback(null);
+        } catch (e: unknown) {
+            const error = asError(e);
+            console.error(`[${new Date().toISOString()}] An error occurred in handleClearAfterUpload`, e);
+            Sentry.captureException(e);
+            callback({ name: "MapStorageError", message: error.message }, null);
+        }
     },
     handleUpdateMapToNewestMessage(
         call: ServerUnaryCall<UpdateMapToNewestWithKeyMessage, Empty>,
@@ -77,7 +84,7 @@ const mapStorageServer: MapStorageServer = {
     ): void {
         try {
             const mapUrl = new URL(call.request.mapKey);
-            const mapKey = mapPathUsingDomainWithPrefix(mapUrl.pathname, mapUrl.hostname);
+            const mapKey = mapPathUsingUrl(mapUrl);
             const updateMapToNewestMessage = call.request.updateMapToNewestMessage;
             if (!updateMapToNewestMessage) {
                 callback({ name: "MapStorageError", message: "UpdateMapToNewest message does not exist" }, null);
@@ -114,7 +121,7 @@ const mapStorageServer: MapStorageServer = {
 
             // The mapKey is the complete URL to the map. Let's map it to our virtual path.
             const mapUrl = new URL(call.request.mapKey);
-            const mapKey = mapPathUsingDomainWithPrefix(mapUrl.pathname, mapUrl.hostname);
+            const mapKey = mapPathUsingUrl(mapUrl);
 
             await mapsManager.waitForLock(mapKey, async () => {
                 const editMapCommandMessage = call.request.editMapCommandMessage;

--- a/map-storage/src/Services/PathMapper.ts
+++ b/map-storage/src/Services/PathMapper.ts
@@ -35,7 +35,9 @@ export function decodeStoragePath(pathname: string): string {
                 // is then already the literal storage key, so keep it untouched.
                 return segment;
             }
-            if (decoded === ".." || decoded.includes("/")) {
+            // A backslash is a separator for path.normalize() on Windows, so an encoded one would
+            // otherwise let a segment normalize its way out of the domain directory.
+            if (decoded === ".." || decoded.includes("/") || decoded.includes("\\")) {
                 throw new Error("Invalid path provided");
             }
             return decoded;

--- a/map-storage/src/Services/PathMapper.ts
+++ b/map-storage/src/Services/PathMapper.ts
@@ -10,6 +10,46 @@ export function mapPath(filePath: string, req: Request): string {
     return mapPathUsingDomain(filePath, req.headers["x-forwarded-host"]?.toString() ?? req.hostname);
 }
 
+/**
+ * Turns the percent-encoded path of a URL into the literal path used as a storage key.
+ *
+ * Storage keys are literal: an upload writes the entry names it is given (see UploadController),
+ * so a map in a directory named "My maps" is stored under "My maps/foo.wam". A URL carrying that
+ * same map spells it "/My%20maps/foo.wam" (`URL.pathname` and `req.path` are both percent-encoded),
+ * so it MUST be decoded before it is used to read or write, otherwise we look up a key that does
+ * not exist.
+ *
+ * Decoding is done segment by segment so that an encoded separator ("%2F") cannot silently add a
+ * path level. Segments that decode to a separator or to ".." are rejected rather than normalized,
+ * so a caller cannot escape the domain directory.
+ */
+export function decodeStoragePath(pathname: string): string {
+    return pathname
+        .split("/")
+        .map((segment) => {
+            let decoded: string;
+            try {
+                decoded = decodeURIComponent(segment);
+            } catch {
+                // Not valid percent-encoding (typically a literal "%" in a file name). The segment
+                // is then already the literal storage key, so keep it untouched.
+                return segment;
+            }
+            if (decoded === ".." || decoded.includes("/")) {
+                throw new Error("Invalid path provided");
+            }
+            return decoded;
+        })
+        .join("/");
+}
+
+/**
+ * Maps the path of a URL (percent-encoded) to the storage path.
+ */
+export function mapPathUsingUrl(url: URL): string {
+    return mapPathUsingDomainWithPrefix(decodeStoragePath(url.pathname), url.hostname);
+}
+
 export function mapPathUsingDomainWithPrefix(filePath: string, domain: string): string {
     if (PATH_PREFIX) {
         if (filePath.startsWith(PATH_PREFIX)) {

--- a/map-storage/src/Services/VerifyJwt.ts
+++ b/map-storage/src/Services/VerifyJwt.ts
@@ -7,7 +7,7 @@ import type { AreaData } from "@workadventure/map-editor";
 import { WAMFileFormat } from "@workadventure/map-editor";
 import { fileSystem } from "../fileSystem";
 import { PATH_PREFIX, SECRET_KEY } from "../Enum/EnvironmentVariable";
-import { mapPathUsingDomainWithPrefix } from "./PathMapper";
+import { mapPathUsingUrl } from "./PathMapper";
 
 const AuthTokenData = z.object({
     wamUrl: z.string().url(),
@@ -59,7 +59,7 @@ export async function verifyJWT(req: Request, res: Response, next: NextFunction)
 
 async function verifyWam(jwt: AuthTokenData, url: string): Promise<void> {
     const parsedUrl = new URL(jwt.wamUrl);
-    const mapPath = mapPathUsingDomainWithPrefix(parsedUrl.pathname, parsedUrl.hostname);
+    const mapPath = mapPathUsingUrl(parsedUrl);
 
     const test = await getAndCheckWamFile(mapPath, url);
 

--- a/map-storage/src/Services/tests/PathMapper.test.ts
+++ b/map-storage/src/Services/tests/PathMapper.test.ts
@@ -41,6 +41,9 @@ describe("decodeStoragePath", () => {
 
     it("rejects a segment that decodes to a path separator", () => {
         expect(() => decodeStoragePath("/foo%2Fbar/my-map.wam")).toThrow("Invalid path provided");
+        // path.normalize() treats a backslash as a separator on Windows.
+        expect(() => decodeStoragePath("/foo%5Cbar/my-map.wam")).toThrow("Invalid path provided");
+        expect(() => decodeStoragePath("/%2E%2E%5Cother/my-map.wam")).toThrow("Invalid path provided");
     });
 
     it("rejects directory traversal, encoded or not", () => {

--- a/map-storage/src/Services/tests/PathMapper.test.ts
+++ b/map-storage/src/Services/tests/PathMapper.test.ts
@@ -1,0 +1,100 @@
+import path from "path";
+import { describe, expect, it, vi } from "vitest";
+
+const env = vi.hoisted(() => ({ PATH_PREFIX: "", USE_DOMAIN_NAME_IN_PATH: true }));
+vi.mock("../../Enum/EnvironmentVariable", () => env);
+
+const { decodeStoragePath, mapPathUsingDomain, mapPathUsingUrl } = await import("../PathMapper");
+
+const DOMAIN = "example.map-storage.workadventu.re";
+
+describe("decodeStoragePath", () => {
+    it("decodes percent-encoded spaces", () => {
+        // Storage keys are literal, URLs are percent-encoded. This is the mismatch that made every
+        // map edition fail for maps stored in a directory whose name contains a space.
+        expect(decodeStoragePath("/My%20maps/my-map.wam")).toBe("/My maps/my-map.wam");
+    });
+
+    it("decodes non-ASCII characters", () => {
+        expect(decodeStoragePath("/Salle%20des%20f%C3%AAtes/my-map.wam")).toBe("/Salle des fêtes/my-map.wam");
+    });
+
+    it("leaves an already literal path untouched", () => {
+        expect(decodeStoragePath("/My maps/my-map.wam")).toBe("/My maps/my-map.wam");
+    });
+
+    it("keeps a plus sign literal", () => {
+        // "+" only means "space" in a query string, never in a path segment.
+        expect(decodeStoragePath("/my+maps/my-map.wam")).toBe("/my+maps/my-map.wam");
+    });
+
+    it("keeps a segment that is not valid percent-encoding as-is", () => {
+        // A literal "%" in a file name is not an escape sequence: the segment is already the key.
+        expect(decodeStoragePath("/100%/my-map.wam")).toBe("/100%/my-map.wam");
+        expect(decodeStoragePath("/50%off/my-map.wam")).toBe("/50%off/my-map.wam");
+    });
+
+    it("preserves the leading slash and empty segments", () => {
+        expect(decodeStoragePath("/")).toBe("/");
+        expect(decodeStoragePath("/my-map.wam")).toBe("/my-map.wam");
+    });
+
+    it("rejects a segment that decodes to a path separator", () => {
+        expect(() => decodeStoragePath("/foo%2Fbar/my-map.wam")).toThrow("Invalid path provided");
+    });
+
+    it("rejects directory traversal, encoded or not", () => {
+        expect(() => decodeStoragePath("/foo/%2E%2E/my-map.wam")).toThrow("Invalid path provided");
+        expect(() => decodeStoragePath("/foo/../my-map.wam")).toThrow("Invalid path provided");
+        expect(() => decodeStoragePath("/foo/%2E%2E%2F%2E%2E/my-map.wam")).toThrow("Invalid path provided");
+    });
+});
+
+describe("mapPathUsingUrl", () => {
+    it("builds the storage key of a map stored in a directory containing spaces", () => {
+        const url = new URL(`https://${DOMAIN}/My%20maps/my-map.wam`);
+
+        expect(mapPathUsingUrl(url)).toBe(`${DOMAIN}/My maps/my-map.wam`);
+    });
+
+    it("builds the same key as the upload path did for the same map", () => {
+        // The regression: the ZIP upload writes `path.join(directory, zipEntry.path)` literally,
+        // while the map edition path derives its key from a URL. Both must resolve to one key,
+        // otherwise editions read (and write) an object that does not exist.
+        const directory = "/My maps";
+        const zipEntryPath = "my-map.wam";
+
+        const uploadKey = mapPathUsingDomain(path.join(directory, zipEntryPath), DOMAIN);
+        const editionKey = mapPathUsingUrl(new URL(`https://${DOMAIN}${directory}/${zipEntryPath}`));
+
+        expect(editionKey).toBe(uploadKey);
+    });
+
+    it("leaves a key without special characters unchanged", () => {
+        const url = new URL(`https://${DOMAIN}/my-map.wam`);
+
+        expect(mapPathUsingUrl(url)).toBe(`${DOMAIN}/my-map.wam`);
+    });
+
+    it("strips the path prefix when one is configured", () => {
+        env.PATH_PREFIX = "/prefix";
+        try {
+            const url = new URL(`https://${DOMAIN}/prefix/My%20maps/my-map.wam`);
+
+            expect(mapPathUsingUrl(url)).toBe(`${DOMAIN}/My maps/my-map.wam`);
+        } finally {
+            env.PATH_PREFIX = "";
+        }
+    });
+
+    it("omits the domain when USE_DOMAIN_NAME_IN_PATH is disabled", () => {
+        env.USE_DOMAIN_NAME_IN_PATH = false;
+        try {
+            const url = new URL(`https://${DOMAIN}/My%20maps/my-map.wam`);
+
+            expect(mapPathUsingUrl(url)).toBe("My maps/my-map.wam");
+        } finally {
+            env.USE_DOMAIN_NAME_IN_PATH = true;
+        }
+    });
+});

--- a/map-storage/src/Upload/UploadController.ts
+++ b/map-storage/src/Upload/UploadController.ts
@@ -20,7 +20,7 @@ import * as Sentry from "@sentry/node";
 import bodyParser from "body-parser";
 import type { ITiledMap } from "@workadventure/tiled-map-type-guard";
 import axios from "axios";
-import { mapPath } from "../Services/PathMapper";
+import { decodeStoragePath, mapPath } from "../Services/PathMapper";
 import { ENTITY_COLLECTION_URLS, MAX_UNCOMPRESSED_SIZE, WAM_TEMPLATE_URL } from "../Enum/EnvironmentVariable";
 import { passportAuthenticator } from "../Services/Authentication";
 import { uploadDetector } from "../Services/UploadDetector";
@@ -288,10 +288,18 @@ export class UploadController {
                     // Get the uploaded file
                     const file = req.file;
 
-                    const filePath = req.path;
-
-                    if (filePath.includes("..")) {
+                    if (req.path.includes("..")) {
                         // Attempt to override filesystem. That' a hack!
+                        res.status(400).send("Invalid path");
+                        return;
+                    }
+
+                    // `req.path` is percent-encoded while storage keys are literal (the ZIP upload
+                    // writes the entry names as-is), so decode to write under the same key.
+                    let filePath: string;
+                    try {
+                        filePath = decodeStoragePath(req.path);
+                    } catch {
                         res.status(400).send("Invalid path");
                         return;
                     }
@@ -413,10 +421,18 @@ export class UploadController {
          */
         this.app.patch(/.*\.wam$/, passportAuthenticator, (req, res, next) => {
             (async () => {
-                const filePath = req.path;
-
-                if (filePath.includes("..")) {
+                if (req.path.includes("..")) {
                     // Attempt to override filesystem. That' a hack!
+                    res.status(400).send("Invalid path");
+                    return;
+                }
+
+                // `req.path` is percent-encoded while storage keys are literal, so decode to patch
+                // the file that was actually written at upload time.
+                let filePath: string;
+                try {
+                    filePath = decodeStoragePath(req.path);
+                } catch {
                     res.status(400).send("Invalid path");
                     return;
                 }
@@ -678,10 +694,16 @@ export class UploadController {
     private deleteFile() {
         this.app.delete("/{*splat}", passportAuthenticator, (req, res, next) => {
             (async () => {
-                const filePath = req.path;
-
-                if (filePath.includes("..")) {
+                if (req.path.includes("..")) {
                     // Attempt to override filesystem. That' a hack!
+                    res.status(400).send("Invalid path");
+                    return;
+                }
+
+                let filePath: string;
+                try {
+                    filePath = decodeStoragePath(req.path);
+                } catch {
                     res.status(400).send("Invalid path");
                     return;
                 }

--- a/map-storage/src/index.ts
+++ b/map-storage/src/index.ts
@@ -13,7 +13,7 @@ import { proxyFiles } from "./FileFetcher/FileFetcher";
 import { UploadController } from "./Upload/UploadController";
 import { fileSystem } from "./fileSystem";
 import { passportStrategies } from "./Services/Authentication";
-import { mapPathUsingDomain } from "./Services/PathMapper";
+import { decodeStoragePath, mapPathUsingDomain } from "./Services/PathMapper";
 import { ValidatorController } from "./Upload/ValidatorController";
 import {
     SENTRY_DSN,
@@ -103,14 +103,19 @@ for (const passportStrategy of passportStrategies) {
 app.use(passport.initialize());
 
 app.get(/.*\.wam$/, (req, res, next) => {
-    const wamPath = req.path;
     const domain = req.hostname;
-    if (wamPath.includes("..") || domain.includes("..")) {
+    if (req.path.includes("..") || domain.includes("..")) {
         res.status(400).send("Invalid request");
         return;
     }
-    const key = mapPathUsingDomain(wamPath, domain);
-
+    // `req.path` is percent-encoded while storage keys are literal, so it has to be decoded.
+    let key: string;
+    try {
+        key = mapPathUsingDomain(decodeStoragePath(req.path), domain);
+    } catch {
+        res.status(400).send("Invalid request");
+        return;
+    }
     res.setHeader("Content-Type", "application/json");
     // Let's disable any kind of cache (we allow for a 5 seconds cache just to avoid spamming the server and
     // to allow a CDN to take over the load). 5 seconds is ok, because it is lower than the 30 seconds of

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -19,6 +19,7 @@ import { localUserStore } from "../../../Connection/LocalUserStore";
 import LL from "../../../../i18n/i18n-svelte";
 import { gameManager } from "../GameManager";
 import { isInsidePersonalAreaStore, personalAreaDataStore } from "../../../Stores/PersonalDeskStore";
+import { warningMessageStore } from "../../../Stores/ErrorStore";
 import { AreaEditorTool } from "./Tools/AreaEditorTool";
 import type { MapEditorTool } from "./Tools/MapEditorTool";
 import { FloorEditorTool } from "./Tools/FloorEditorTool";
@@ -333,16 +334,18 @@ export class MapEditorModeManager {
         connection.editMapCommandMessageStream.subscribe((editMapCommandMessage) => {
             limit(async () => {
                 if (editMapCommandMessage.editMapMessage?.message?.$case === "errorCommandMessage") {
-                    logger(
-                        "ErrorCommandMessage received",
-                        editMapCommandMessage.editMapMessage?.message.errorCommandMessage,
-                    );
+                    const reason = editMapCommandMessage.editMapMessage.message.errorCommandMessage.reason;
+                    logger("ErrorCommandMessage received", reason);
                     const command = this.pendingCommands.find(
                         (command) => command.commandId === editMapCommandMessage.id,
                     );
                     if (command) {
-                        logger("removing command of pendingList : ", editMapCommandMessage.id);
-                        this.pendingCommands.splice(this.pendingCommands.indexOf(command), 1);
+                        // The server refused the command, so the optimistic local state is now wrong.
+                        // Roll back every pending command: the ones the server did accept come back
+                        // through this same stream and are re-applied as remote commands.
+                        Sentry.captureException(new Error(`Map edition command rejected by the server: ${reason}`));
+                        await this.revertPendingCommands();
+                        warningMessageStore.addWarningMessage(get(LL).mapEditor.map.editionFailed());
                     }
                     return;
                 }

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -343,7 +343,9 @@ export class MapEditorModeManager {
                         // The server refused the command, so the optimistic local state is now wrong.
                         // Roll back every pending command: the ones the server did accept come back
                         // through this same stream and are re-applied as remote commands.
-                        Sentry.captureException(new Error(`Map edition command rejected by the server: ${reason}`));
+                        // Nothing is reported here: map-storage already logged the cause with its
+                        // original stack, and a refusal is also the expected answer to a command the
+                        // user was not allowed to run.
                         await this.revertPendingCommands();
                         warningMessageStore.addWarningMessage(get(LL).mapEditor.map.editionFailed());
                     }

--- a/play/src/i18n/ar-SA/mapEditor.ts
+++ b/play/src/i18n/ar-SA/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "تم حذف هذه الخريطة",
         deletePromptSubtitle: "تم قطع اتصالك بهذه الغرفة.",
         deletePromptDetails: "لن تؤدي إعادة التحميل إلى استعادة هذه الخريطة لأنها لم تعد موجودة.",
+        editionFailed: "تعذر حفظ التغيير الذي أجريته، وتم التراجع عنه.",
     },
     sideBar: {
         areaEditor: "تحرير المنطقة", // Fläche bearbeiten

--- a/play/src/i18n/ca-ES/mapEditor.ts
+++ b/play/src/i18n/ca-ES/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "Aquest mapa s'ha suprimit",
         deletePromptSubtitle: "Se t'ha desconnectat d'aquesta sala.",
         deletePromptDetails: "Actualitzar no restaurarà aquest mapa perquè ja no existeix.",
+        editionFailed: "No s'ha pogut desar el teu canvi i s'ha desfet.",
     },
     sideBar: {
         areaEditor: "Eina d'edició d'àrees",

--- a/play/src/i18n/de-DE/mapEditor.ts
+++ b/play/src/i18n/de-DE/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "Diese Karte wurde gelöscht",
         deletePromptSubtitle: "Du wurdest von diesem Raum getrennt.",
         deletePromptDetails: "Ein Neuladen stellt diese Karte nicht wieder her, da sie nicht mehr existiert.",
+        editionFailed: "Deine Änderung konnte nicht gespeichert werden und wurde rückgängig gemacht.",
     },
     sideBar: {
         areaEditor: "Fläche bearbeiten",

--- a/play/src/i18n/dsb-DE/mapEditor.ts
+++ b/play/src/i18n/dsb-DE/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "Toś ta kórta jo se wulašowała",
         deletePromptSubtitle: "Sy se wót togo rumoja źělił.",
         deletePromptDetails: "Aktualizěrowanje toś tu kórtu njewótnowi, dokulaž wěcej njeeksistěrujo.",
+        editionFailed: "Twója změna njejo se dała składowaś a jo se anulěrowała.",
     },
     sideBar: {
         areaEditor: "Areal wobźěłaś",

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -6,6 +6,7 @@ const mapEditor: BaseTranslation = {
         deletePrompt: "This map has been deleted",
         deletePromptSubtitle: "You have been disconnected from this room.",
         deletePromptDetails: "Refreshing will not restore this map because it no longer exists.",
+        editionFailed: "Your change could not be saved and has been undone.",
     },
     sideBar: {
         areaEditor: "Area editor tool",

--- a/play/src/i18n/es-ES/mapEditor.ts
+++ b/play/src/i18n/es-ES/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "Este mapa ha sido eliminado",
         deletePromptSubtitle: "Te has desconectado de esta sala.",
         deletePromptDetails: "Actualizar no restaurará este mapa porque ya no existe.",
+        editionFailed: "No se ha podido guardar tu cambio y se ha deshecho.",
     },
     sideBar: {
         areaEditor: "Herramienta de edición de zonas",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "Cette carte a été supprimée",
         deletePromptSubtitle: "Vous avez été déconnecté de cette salle.",
         deletePromptDetails: "Actualiser ne restaurera pas cette carte, car elle n'existe plus.",
+        editionFailed: "Votre modification n'a pas pu être enregistrée et a été annulée.",
     },
     sideBar: {
         areaEditor: "Outil d'édition de zone",

--- a/play/src/i18n/hsb-DE/mapEditor.ts
+++ b/play/src/i18n/hsb-DE/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "Tuta karta bu zhašana",
         deletePromptSubtitle: "Zwisk z tutym rumnosću je so přetorhnył.",
         deletePromptDetails: "Wobnowjenje tutu kartu njewobnowi, dokelž hižo njeeksistuje.",
+        editionFailed: "Twoja změna njeda so składować a bu cofnjena.",
     },
     sideBar: {
         areaEditor: "Płoninu wobdźěłać",

--- a/play/src/i18n/it-IT/mapEditor.ts
+++ b/play/src/i18n/it-IT/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "Questa mappa è stata eliminata",
         deletePromptSubtitle: "Sei stato disconnesso da questa stanza.",
         deletePromptDetails: "L'aggiornamento non ripristinerà questa mappa perché non esiste più.",
+        editionFailed: "Non è stato possibile salvare la tua modifica ed è stata annullata.",
     },
     sideBar: {
         areaEditor: "Strumento di modifica dell'area",

--- a/play/src/i18n/ja-JP/mapEditor.ts
+++ b/play/src/i18n/ja-JP/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "このマップは削除されました",
         deletePromptSubtitle: "このルームから切断されました。",
         deletePromptDetails: "このマップはもう存在しないため、再読み込みしても復元されません。",
+        editionFailed: "変更を保存できなかったため、元に戻されました。",
     },
     sideBar: {
         areaEditor: "エリアエディターツール",

--- a/play/src/i18n/ko-KR/mapEditor.ts
+++ b/play/src/i18n/ko-KR/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "이 지도는 삭제되었습니다",
         deletePromptSubtitle: "이 방에서 연결이 끊어졌습니다.",
         deletePromptDetails: "이 지도는 더 이상 존재하지 않으므로 새로고침해도 복원되지 않습니다.",
+        editionFailed: "변경 사항을 저장하지 못하여 취소되었습니다.",
     },
     sideBar: {
         areaEditor: "영역 편집 도구",

--- a/play/src/i18n/nl-NL/mapEditor.ts
+++ b/play/src/i18n/nl-NL/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "Deze kaart is verwijderd",
         deletePromptSubtitle: "Je bent losgekoppeld van deze ruimte.",
         deletePromptDetails: "Verversen zal deze kaart niet herstellen omdat deze niet meer bestaat.",
+        editionFailed: "Je wijziging kon niet worden opgeslagen en is ongedaan gemaakt.",
     },
     sideBar: {
         areaEditor: "Gebied editor tool",

--- a/play/src/i18n/pt-BR/mapEditor.ts
+++ b/play/src/i18n/pt-BR/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "Este mapa foi excluído",
         deletePromptSubtitle: "Você foi desconectado desta sala.",
         deletePromptDetails: "Atualizar não restaurará este mapa porque ele não existe mais.",
+        editionFailed: "Não foi possível salvar sua alteração e ela foi desfeita.",
     },
     sideBar: {
         areaEditor: "Ferramenta de editor de área",

--- a/play/src/i18n/zh-CN/mapEditor.ts
+++ b/play/src/i18n/zh-CN/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "此地图已被删除",
         deletePromptSubtitle: "你已与此房间断开连接。",
         deletePromptDetails: "刷新不会恢复此地图，因为它已经不存在了。",
+        editionFailed: "您的更改无法保存，已被撤销。",
     },
     sideBar: {
         areaEditor: "区域编辑器工具",

--- a/play/src/i18n/zh-TW/mapEditor.ts
+++ b/play/src/i18n/zh-TW/mapEditor.ts
@@ -7,6 +7,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         deletePrompt: "此地圖已被刪除",
         deletePromptSubtitle: "你已與此房間中斷連線。",
         deletePromptDetails: "重新整理不會復原此地圖，因為它已經不存在了。",
+        editionFailed: "您的變更無法儲存，已被復原。",
     },
     sideBar: {
         areaEditor: "區域編輯器工具",

--- a/tests/tests/map_storage_upload.spec.ts
+++ b/tests/tests/map_storage_upload.spec.ts
@@ -592,7 +592,7 @@ test.describe("Map-storage Upload API @nomobile", () => {
 
         const listOfMaps2 = await request.get("maps");
         const maps2 = await listOfMaps2.json();
-        expect(maps2["single-map.wam"]).toBeUndefined();
+        expect(maps2["maps"]["single-map.wam"]).toBeUndefined();
     });
 
     test("special characters support", async ({ request }) => {
@@ -642,10 +642,83 @@ test.describe("Map-storage Upload API @nomobile", () => {
         });
         expect(patch.ok()).toBeTruthy();
 
+        // Assert the patch landed on the file the GET route resolves to. A read and a write that
+        // disagree on the storage key both answer 200 while leaving this stale.
+        const accessFileWithEmojiPatched = await request.get(`🍕.wam`);
+        expect(await accessFileWithEmojiPatched.text()).toContain("https://example.com/newmap.tmj");
+
         const deleteFile = await request.delete(`🍕.wam`);
-        expect(deleteFile.ok()).toBeTruthy();
+        expect(deleteFile.status()).toBe(204);
 
         const accessFileWithEmoji3 = await request.get(`🍕.wam`);
-        expect(accessFileWithEmoji3.ok()).toBeFalsy();
+        expect(accessFileWithEmoji3.status()).toBe(404);
     });
+
+    // A storage key is literal: the ZIP upload writes the entry names as-is, so a map in a
+    // directory named "My maps" is stored under a key holding a real space. Every route that
+    // derives its key from a URL sees "My%20maps" instead and has to convert it back.
+    //
+    // The test above cannot catch a failure to do so, because it creates its file with PUT: the
+    // writer and the readers then share whatever spelling the request carried, and agree with each
+    // other while both being wrong. These cases cross that boundary — written by the ZIP upload,
+    // read back through a URL.
+    //
+    // Playwright has no test.each: a loop over the cases is how it parameterizes tests.
+    const directoriesNeedingEncoding = [
+        { name: "a space", directory: "My maps" },
+        { name: "an accent", directory: "Dossier accentué" },
+        // "+" only means "space" in a query string, so it must survive as a literal here.
+        { name: "a plus sign", directory: "plus+dir" },
+        // The widest of the set: four UTF-8 bytes, so four escapes for one character in the URL,
+        // and a surrogate pair once decoded back.
+        { name: "an emoji", directory: "🍕" },
+    ];
+
+    for (const { name, directory } of directoriesNeedingEncoding) {
+        test(`a map in a directory containing ${name} can be read, patched and deleted`, async ({ request }) => {
+            const wamPath = `${directory}/map.wam`;
+
+            createZipFromDirectory("./assets/file1/", "./assets/file1.zip");
+            const upload = await request.post("upload", {
+                multipart: {
+                    file: fs.createReadStream("./assets/file1.zip"),
+                    directory: `/${directory}`,
+                },
+            });
+            expect(upload.ok()).toBeTruthy();
+
+            // The map list is built by listing the storage itself, so this pins the spelling of the
+            // key on disk: literal, never percent-encoded.
+            const listOfMaps = await request.get("maps");
+            expect((await listOfMaps.json())["maps"][wamPath]).toBeDefined();
+
+            // From here on Playwright percent-encodes the path, so every request exercises the
+            // "URL back to storage key" conversion.
+            const beforePatch = await request.get(wamPath);
+            expect(beforePatch.status()).toBe(200);
+
+            const patch = await request.patch(wamPath, {
+                headers: {
+                    "Content-Type": "application/json-patch+json",
+                },
+                data: JSON.stringify([{ op: "replace", path: "/mapUrl", value: "https://example.com/patched.tmj" }]),
+            });
+            expect(patch.status()).toBe(200);
+
+            const afterPatch = await request.get(wamPath);
+            expect(await afterPatch.text()).toContain("https://example.com/patched.tmj");
+
+            const deleted = await request.delete(wamPath);
+            expect(deleted.status()).toBe(204);
+
+            const afterDelete = await request.get(wamPath);
+            expect(afterDelete.status()).toBe(404);
+
+            const listAfterDelete = await request.get("maps");
+            expect((await listAfterDelete.json())["maps"][wamPath]).toBeUndefined();
+
+            // Leave the storage as we found it for the tests sharing this map-storage.
+            expect((await request.delete(directory)).status()).toBe(204);
+        });
+    }
 });


### PR DESCRIPTION
Objects placed with the inline map editor were not persisted: they stayed visible in the session that placed them, disappeared on refresh, and were never visible to anyone else.

## The invariant that was broken

**A storage key is literal.** The ZIP upload writes `path.join(directory, zipEntry.path)` as-is, so a map in a directory named `My maps` is stored under the key `My maps/my-map.wam` — with a real space.

A URL spelling the same map is percent-encoded: `/My%20maps/my-map.wam`. Anything deriving a key from a URL therefore has to decode it first, and that is what was missing.

| Path | Key derived from | Result |
| --- | --- | --- |
| ZIP upload | `path.join(directory, zipEntry.path)` — literal | `My maps/my-map.wam` ✅ |
| `proxyFiles` | `decodeURIComponent(req.path)` | `My maps/my-map.wam` ✅ |
| **Map edition (gRPC)** | `new URL(mapKey).pathname` — encoded | `My%20maps/my-map.wam` ❌ |
| `GET *.wam`, `PUT`, `PATCH`, `DELETE` | `req.path` — encoded | `My%20maps/my-map.wam` ❌ |

So every edition command looked up a key that does not exist:

```
Edition lock callback failed for key: <domain>/My%20maps/my-map.wam
FileNotFoundError: The specified key does not exist.
    at S3FileSystem.readFileAsString (map-storage/src/Upload/S3FileSystem.ts:360)
    at MapsManager.loadWAMToMemory (map-storage/src/MapsManager.ts:124)
    at MapsManager.getOrLoadWamFile (map-storage/src/MapsManager.ts:110)
    at MapStorageServer.ts:126   <-- handleEditMapCommandWithKeyMessage
```

The map still loaded, which is what made this confusing: `serveStaticFile` calls `next()` on `NoSuchKey`, so a `GET *.wam` that missed fell through to `proxyFiles`, which decodes and found it. The gRPC path has no such second chance, so the map displayed fine while every edit on it was dropped.

## Why nothing was reported to the user

`handleEditMapCommandWithKeyMessage` does return an `errorCommandMessage`, but the front (`MapEditorModeManager`) only logged it to a debug namespace and removed the command from `pendingCommands` **without undoing it**. The optimistic local state was never rolled back, so the object stayed on screen until the next refresh, and nothing was shown.

## The fix

`PathMapper` gains `decodeStoragePath()` and `mapPathUsingUrl()`, and every entry point that starts from a URL now uses them: the three gRPC handlers, `VerifyJwt`, and the `GET *.wam`, `PUT`, `PATCH` and `DELETE` routes. Reads and writes agree on one canonical key.

Decoding is done per segment, so an encoded separator (`%2F`) cannot add a path level; a segment decoding to `..` or `/` is rejected; a segment that is not valid percent-encoding (a literal `%` in a file name) is left as-is rather than throwing.

`handleClearAfterUpload` also gains the try/catch it was missing.

On the front, an `errorCommandMessage` now rolls back the pending commands and raises a warning (new `mapEditor.map.editionFailed` key, en/fr).

## Already-stored files

Only the ZIP upload wrote storage keys, and it writes them literally, so decoding is what puts every
route back in agreement with it. `PUT` and `PATCH` did write the percent-encoded request path
verbatim, so a file created through them — the map-storage UI builds a `.wam` from a hand-typed path
— could sit on an encoded key.

An earlier revision of this PR carried a read fallback for that case. It was dropped: nothing shows
such a file exists, the notion reached all seven production files touched here, and adding a second
key convention is the very shape of the bug being fixed. If a map does turn out to sit on an encoded
key, it 404s and `POST /move` renames it without a deploy — that endpoint takes literal paths from
the request body and is unaffected by any of this.

## Tests

**Unit** — `Services/tests/PathMapper.test.ts`, 13 tests: percent-encoded spaces, non-ASCII, literal `+`, literal `%`, encoded and plain traversal, `PATH_PREFIX`, `USE_DOMAIN_NAME_IN_PATH`, and a regression test on the invariant that broke — *the key derived from a URL must equal the key the upload path writes*. Checked against the pre-fix implementation: both key tests fail and reproduce the encoded key from the logs, while the no-special-character case still passes.

**End to end** — the existing "special characters support" test could not catch this class of bug: it creates its `.wam` with `PUT`, so the writer and every reader share whatever spelling the request carried and agree with each other while both being wrong. It would have passed just as happily with the decoding removed entirely.

Added cases cross that boundary instead — written by the ZIP upload, which stores entry names literally, then read back through a URL, which is percent-encoded. Directories named `My maps`, `Dossier accentué` and `plus+dir` each go through the map list, `GET`, `PATCH` and `DELETE`. The `PATCH` assertion is the one that bites: a read and a write that disagree on the key both answer 200 while leaving the file stale, so the test re-reads the map and checks the patch actually landed.

Two assertions in the existing tests were vacuous and are fixed: one looked up a map key one level above where the map list holds it, so it was undefined whatever happened, and one accepted any non-2xx where it meant 404.

`map-storage`: 28/28 unit tests, typecheck and lint clean.

## Out of scope, but noticed

- map-storage can run with more than one replica. Each pod keeps its own in-memory `WamFile` and rewrites the whole file every 15s with no shared lock, so two `back` pods editing the same room can clobber each other (last writer wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
