### PR TITLE
fix(audio): apply the saved output device when a conversation starts

### DIFF
--- a/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onDestroy, onMount } from "svelte";
+    import { onDestroy } from "svelte";
     import Debug from "debug";
     import * as Sentry from "@sentry/svelte";
     import type { Readable } from "svelte/store";
@@ -36,19 +36,30 @@
         }
     });
 
-    let lastRequestedDeviceId: string | undefined;
+    // The sink request currently applied (or in flight) and the element/device it targets. De-duplication is
+    // done on the *promise*, not on the requested device id: callers must be able to await the actual
+    // completion of setSinkId(), which is what the srcObject attach below relies on. Keying on the element
+    // too makes the sink re-apply when the <audio> tag is recreated (see the {#if !$isBlocked} block).
+    let sinkPromise: Promise<boolean> | undefined;
+    let sinkDeviceId: string | undefined;
+    let sinkElement: HTMLAudioElement | undefined;
+
+    function ensureSinkId(deviceId: string, el: HTMLAudioElement): Promise<boolean> {
+        if (!sinkPromise || sinkDeviceId !== deviceId || sinkElement !== el) {
+            sinkDeviceId = deviceId;
+            sinkElement = el;
+            sinkPromise = safeSetSinkId(deviceId, el);
+        }
+        return sinkPromise;
+    }
 
     async function safeSetSinkId(deviceId: string, el: HTMLAudioElement) {
         if (destroyed) {
             return false;
         }
-        if (lastRequestedDeviceId === deviceId) {
-            return true;
-        }
         if (typeof el.setSinkId !== "function") {
             return false;
         }
-        lastRequestedDeviceId = deviceId;
         try {
             debug("Setting output device to ", deviceId);
             await el.setSinkId(deviceId);
@@ -65,8 +76,10 @@
                 console.warn("Error setting the audio output device. We fallback to default.");
 
                 try {
-                    lastRequestedDeviceId = "";
                     await el.setSinkId("");
+                    // The element is back on the default output: forget the failed request so that the same
+                    // device can be requested again later.
+                    sinkDeviceId = "";
                 } catch (e) {
                     console.error("Error resetting the audio output device: ", e);
                 }
@@ -79,9 +92,11 @@
         }
     }
 
+    // Apply the selected output device as soon as the element exists, even before a stream is attached (the
+    // attach below waits for this very request to resolve).
     $effect(() => {
         if (outputDeviceId && audioElement) {
-            safeSetSinkId(outputDeviceId, audioElement).catch((e) => {
+            ensureSinkId(outputDeviceId, audioElement).catch((e) => {
                 console.error("Error setting the audio output device: ", e);
                 Sentry.captureException(e);
             });
@@ -210,35 +225,49 @@
 
     let stream = $derived($streamStore ? $streamStore : undefined);
 
+    function attachStream(el: HTMLAudioElement, mediaStream: MediaStream): void {
+        if (destroyed) {
+            return;
+        }
+        if (el.srcObject !== mediaStream) {
+            el.srcObject = mediaStream;
+        }
+        playAudio();
+    }
+
     // Assign srcObject with $effect.pre (runs *before* the DOM update, matching the Svelte 4 `$:` block this
     // replaced) and then start playback via playAudio(). The explicit play() is what actually restores sound
     // in Brave/Vivaldi — those browsers ignore the `autoplay` attribute for a MediaStream even with correct
     // pre-DOM timing; .pre is kept only for parity with the pre-migration behavior.
+    // Because of a bug in Chrome, the stream must not be attached before setSinkId() has resolved, otherwise
+    // playback stays on the default output device. This is the only place attaching the stream, so that this
+    // ordering cannot be bypassed. Deferring the attach by a microtask does not break the Brave/Vivaldi
+    // play() above: it only needs *sticky* user activation, which is not consumed by the wait.
     $effect.pre(() => {
-        if (audioElement && stream) {
-            if (audioElement.srcObject !== stream) {
-                audioElement.srcObject = stream;
-            }
-            playAudio();
+        const el = audioElement;
+        const currentStream = stream;
+        const deviceId = outputDeviceId;
+        if (!el || !currentStream) {
+            return;
         }
-    });
 
-    onMount(() => {
-        (async () => {
-            if (outputDeviceId && audioElement) {
-                // Because of a bug in Chrome, we need to wait for setSinkId to resolve before setting the srcObject.
-                await safeSetSinkId(outputDeviceId, audioElement);
-                if (destroyed || !audioElement) {
-                    return;
+        if (!deviceId) {
+            attachStream(el, currentStream);
+            return;
+        }
+
+        ensureSinkId(deviceId, el)
+            .then(() => {
+                // Reads inside this callback are not tracked by the effect (it already ran synchronously);
+                // they only guard against the element or the stream having changed while we waited.
+                if (!destroyed && audioElement === el && stream === currentStream) {
+                    attachStream(el, currentStream);
                 }
-                audioElement.srcObject = stream ?? null;
-                audioElement.volume = $volume;
-                playAudio();
-            }
-        })().catch((e) => {
-            console.error(e);
-            Sentry.captureException(e);
-        });
+            })
+            .catch((e: unknown) => {
+                console.error("Error setting the audio output device: ", e);
+                Sentry.captureException(e);
+            });
     });
 
     onDestroy(() => {


### PR DESCRIPTION
Fixes #6403

## Problem

The saved audio output device (speaker) is not applied when a conversation starts: the remote peer's audio always plays on the system default device, even though the correct headset is still selected (and shown as selected) in the media settings. Switching the output device in the settings panel and back routes the audio correctly — proving `setSinkId()` works fine on an already-playing element.

## Root cause

`AudioStream.svelte` knows that Chrome needs `setSinkId()` to resolve **before** `srcObject` is assigned (that is what the `onMount` comment says), but nothing enforced that ordering:

1. **`$effect.pre` attached the stream unconditionally.** It assigned `srcObject` and called `playAudio()` as soon as the element and the stream existed. Being a pre-effect, it ran *before* the `$effect` that requests the sink — so the stream was attached before `setSinkId()` was even called.
2. **The de-duplication short-circuited on the request, not on completion.** `safeSetSinkId()` set `lastRequestedDeviceId` *before* `await el.setSinkId(...)`. Since the `$effect` is created before the `onMount` effect, it always ran first, so the `await safeSetSinkId()` in `onMount` returned immediately with a `setSinkId()` promise still in flight — the intended wait was a no-op in every case, not just occasionally.
3. **The same de-duplication skipped the sink on element recreation.** When the `<audio>` tag is destroyed and recreated (the `{#if !$isBlocked}` block), `safeSetSinkId()` returned early for the already-requested device id and never called `setSinkId()` on the new element, leaving it on the default output.

## Fix

- De-duplicate on the **in-flight promise** (`ensureSinkId()`), keyed on both the device id and the element, so concurrent callers await the same `setSinkId()` completion, and a recreated element gets its own request.
- Make `$effect.pre` the **single place** attaching the stream: when an output device is selected, it waits for that promise before assigning `srcObject` and starting playback (with `destroyed` / element / stream staleness guards). With no device selected, the attach stays synchronous.
- Remove the `onMount` block, which duplicated the attach logic and was the source of the broken ordering.

The extra microtask before the attach does not affect the Brave/Vivaldi explicit `play()` fallback: it only needs *sticky* user activation, which the wait does not consume. The WebAudio fallback and the blocked-playback toast paths are untouched.

## Tests

- `npm run typecheck`, `npm run svelte-check`, `npm run lint`, `npm run pretty-check` in `play/` — all clean.
- Manual check in Chrome still needed: select a non-default speaker, reload, start a conversation bubble, and confirm the remote audio plays on the selected device without touching the settings panel.

## Regression window

Until the Svelte 5 migration the ordering held, by accident but reliably:

- `7c77595` ("Refactoring output device selection") introduced the `await safeSetSinkId()` in `onMount`, citing [crbug 971947](https://bugs.chromium.org/p/chromium/issues/detail?id=971947) — the Chrome bug where `setSinkId()` must resolve before `srcObject` is assigned. In Svelte 4 the reactive attach block ran once at init (when `bind:this` had not yet set `audioElement`, so it did nothing) and only re-ran *after* `onMount`, by which time `srcObject` was already correctly attached. `onMount` was therefore the first caller of `safeSetSinkId()` and its `await` was real.
- `5d199de` (Svelte 5 migration, in v1.32.0) turned that block into an `$effect`. User effects run in creation order, and this one is created before the `onMount` effect — so the attach now happens first, and the `onMount` `await` hits the `lastRequestedDeviceId` early-return instead of waiting.
- `49e22af` (Vivaldi/Brave audio fix) moved the attach to `$effect.pre` and added the explicit `play()`, moving it earlier still.

So the behaviour should have regressed in **v1.32.0**; v1.31.x is expected to be unaffected. That is a useful check for the reporter.
