### PR TITLE
feat(i18n): add Google Meet missing-scope messages

### DIFF
--- a/play/src/i18n/ar-SA/externalModule.ts
+++ b/play/src/i18n/ar-SA/externalModule.ts
@@ -73,6 +73,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "إلغاء",
         isSyncronized: "تمت المزامنة مع Google",
         popupScopeToSyncMeet: "إنشاء اجتماعات عبر الإنترنت",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "جاري فتح Google Meet... 🙏",
         unableJoinMeet: "غير قادر على الانضمام إلى Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -82,6 +83,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             guestExplain: "يرجى تسجيل الدخول إلى المنصة لإنشاء اجتماع Google Meet، أو اطلب من المالك إنشاؤه لك 🚀",
             error: "إعدادات Google Workspace لديك لا تسمح بإنشاء اجتماع Meet.",
             errorExplain: "لا تقلق — ما زال بإمكانك الانضمام إلى الاجتماعات عندما يشارك شخص آخر الرابط 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "تسجيل الخروج",
         popupScopeIsConnectedExplainText: "أنت متصل بالفعل، يرجى النقر على الزر لتسجيل الخروج وإعادة الاتصال.",

--- a/play/src/i18n/ca-ES/externalModule.ts
+++ b/play/src/i18n/ca-ES/externalModule.ts
@@ -76,6 +76,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "Cancel·lar",
         isSyncronized: "Sincronitzat amb Google",
         popupScopeToSyncMeet: "Crear reunions en línia",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "S'està obrint Google Meet... 🙏",
         unableJoinMeet: "No es pot unir a Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -86,6 +87,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
                 "Siusplau, inicieu sessió a la plataforma per crear un Google Meet, o demaneu al propietari que en creï un per a vosaltres 🚀",
             error: "La configuració del vostre Google Workspace no us permet crear un Meet.",
             errorExplain: "No us preocupeu, encara podeu unir-vos a reunions quan algú altre comparteix un enllaç 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "Tancar sessió",
         popupScopeIsConnectedExplainText:

--- a/play/src/i18n/de-DE/externalModule.ts
+++ b/play/src/i18n/de-DE/externalModule.ts
@@ -76,6 +76,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "Abbrechen",
         isSyncronized: "Mit Google synchronisiert",
         popupScopeToSyncMeet: "Online-Meetings erstellen",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Google Meet wird geöffnet... 🙏",
         unableJoinMeet: "Kann nicht an Google Meet teilnehmen 😭",
         googleMeetPopupWaiting: {
@@ -87,6 +88,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             error: "Ihre Google Workspace-Einstellungen erlauben es Ihnen nicht, ein Meet zu erstellen.",
             errorExplain:
                 "Keine Sorge, Sie können sich weiterhin Meetings anschließen, wenn jemand anderes einen Link teilt 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "Abmelden",
         popupScopeIsConnectedExplainText:

--- a/play/src/i18n/dsb-DE/externalModule.ts
+++ b/play/src/i18n/dsb-DE/externalModule.ts
@@ -74,6 +74,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "Pśetergnuś",
         isSyncronized: "Z Google synchronizěrowany",
         popupScopeToSyncMeet: "Online-ześělenja napóraś",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Google Meet se wótwórijo... 🙏",
         unableJoinMeet: "Njamóžośo k Google Meet pśiźoś 😭",
         googleMeetPopupWaiting: {
@@ -84,6 +85,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
                 "Pšosym pśizjawśo se na platformje, aby Google Meet napórał, abo pšosćo wóbsebnika, aby za was jaden napórał 🚀",
             error: "Nastajenja wašogo Google Workspace njedowóluju wam Meet napóraś.",
             errorExplain: "Žedne starosći, móžośo wósebnje na ześělenja pśiźoś, gaž něchten drugi wótkaz źěli 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "Wótzjawiś",
         popupScopeIsConnectedExplainText: "Sćo južo zwězany, klikniśo na tłocašk, aby se wótzjawił a znowego zwězał.",

--- a/play/src/i18n/en-US/externalModule.ts
+++ b/play/src/i18n/en-US/externalModule.ts
@@ -74,6 +74,7 @@ const externalModule: BaseTranslation = {
         popupCancel: "Cancel",
         isSyncronized: "Synchronized with Google",
         popupScopeToSyncMeet: "Create online meetings",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Opening Google Meet... 🙏",
         unableJoinMeet: "Unable to join Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -84,6 +85,9 @@ const externalModule: BaseTranslation = {
                 "Please log in to the platform to create a Google Meet, or ask the owner to create one for you 🚀",
             error: "Your Google Workspace settings don’t allow you to create a Meet.",
             errorExplain: "No worries, you can still join meetings when someone else shares a link 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "Logout",
         popupScopeIsConnectedExplainText:

--- a/play/src/i18n/es-ES/externalModule.ts
+++ b/play/src/i18n/es-ES/externalModule.ts
@@ -76,6 +76,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "Cancelar",
         isSyncronized: "Sincronizado con Google",
         popupScopeToSyncMeet: "Crear reuniones en línea",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Abriendo Google Meet... 🙏",
         unableJoinMeet: "No se puede unir a Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -86,6 +87,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
                 "Por favor inicia sesión en la plataforma para crear un Google Meet, o pide al propietario que cree uno para ti 🚀",
             error: "Tu configuración de Google Workspace no te permite crear un Meet.",
             errorExplain: "No te preocupes, aún puedes unirte a reuniones cuando alguien más comparta un enlace 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "Cerrar sesión",
         popupScopeIsConnectedExplainText:

--- a/play/src/i18n/fr-FR/externalModule.ts
+++ b/play/src/i18n/fr-FR/externalModule.ts
@@ -76,6 +76,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "Annuler",
         isSyncronized: "Synchronisé avec Google",
         popupScopeToSyncMeet: "Créer des réunions en ligne",
+        popupScopeToSyncMeetHelp: "Nécessaire pour créer des réunions dans les zones Google Meet.",
         openingMeet: "Ouverture de Google Meet... 🙏",
         unableJoinMeet: "Impossible de rejoindre Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -87,6 +88,10 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             error: "Les paramètres de votre Google Workspace ne vous permettent pas de créer un Meet.",
             errorExplain:
                 "Pas d'inquiétude, vous pouvez toujours rejoindre une réunion lorsque quelqu'un partage un lien 🙏",
+            missingScope: "Aucune réunion n’a été créée : votre compte Google n’autorise pas la création de réunions.",
+            missingScopeExplain:
+                "Attendez qu’un participant la crée, ou reconnectez-vous en autorisant la création de réunions.",
+            reconnect: "Reconnecter Google",
         },
         popupScopeIsConnectedButton: "Se déconnecter",
         popupScopeIsConnectedExplainText:

--- a/play/src/i18n/hsb-DE/externalModule.ts
+++ b/play/src/i18n/hsb-DE/externalModule.ts
@@ -75,6 +75,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "Přetorhnyć",
         isSyncronized: "Z Google synchronizowany",
         popupScopeToSyncMeet: "Online-zećělenja wutworić",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Google Meet so wočinje... 🙏",
         unableJoinMeet: "Njeda so na Google Meet wobdźělić 😭",
         googleMeetPopupWaiting: {
@@ -85,6 +86,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
                 "Prošu přizjewće so na platformje, zo by Google Meet wutworił, abo prosće wobsedźerja, zo by za was jón wutworil 🚀",
             error: "Nastajenja wašeho Google Workspace wam njedowoluja Meet wutworić.",
             errorExplain: "Žane starosće, móžeće hišće na zećělenja wobdźělić, hdyž něchtó druhi wotkaz dźěli 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "Wotzjewić",
         popupScopeIsConnectedExplainText:

--- a/play/src/i18n/it-IT/externalModule.ts
+++ b/play/src/i18n/it-IT/externalModule.ts
@@ -74,6 +74,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "Annulla",
         isSyncronized: "Sincronizzato con Google",
         popupScopeToSyncMeet: "Crea riunioni online",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Apertura Google Meet... 🙏",
         unableJoinMeet: "Impossibile partecipare a Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -85,6 +86,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             error: "Le impostazioni del tuo Google Workspace non ti consentono di creare un Meet.",
             errorExplain:
                 "Nessun problema, puoi comunque partecipare alle riunioni quando qualcun altro condivide un link 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "Esci",
         popupScopeIsConnectedExplainText: "Sei già connesso, fai clic sul pulsante per disconnetterti e riconnetterti.",

--- a/play/src/i18n/ja-JP/externalModule.ts
+++ b/play/src/i18n/ja-JP/externalModule.ts
@@ -76,6 +76,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "キャンセル",
         isSyncronized: "Google と同期済み",
         popupScopeToSyncMeet: "オンライン会議を作成",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Google Meet を開いています... 🙏",
         unableJoinMeet: "Google Meet に参加できません 😭",
         googleMeetPopupWaiting: {
@@ -86,6 +87,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
                 "Google Meet を作成するには、プラットフォームにログインするか、所有者に作成を依頼してください 🚀",
             error: "Google Workspace の設定により、Meet を作成できません。",
             errorExplain: "心配ありません。他の誰かがリンクを共有した場合でも、会議に参加できます 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "ログアウト",
         popupScopeIsConnectedExplainText:

--- a/play/src/i18n/ko-KR/externalModule.ts
+++ b/play/src/i18n/ko-KR/externalModule.ts
@@ -74,6 +74,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "취소",
         isSyncronized: "Google과 동기화됨",
         popupScopeToSyncMeet: "온라인 회의 만들기",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Google Meet를 여는 중... 🙏",
         unableJoinMeet: "Google Meet에 참가할 수 없습니다 😭",
         googleMeetPopupWaiting: {
@@ -83,6 +84,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             guestExplain: "Google Meet를 만들려면 플랫폼에 로그인하거나 소유자에게 대신 만들어 달라고 요청하세요 🚀",
             error: "Google Workspace 설정에서 Meet를 만들 수 없습니다.",
             errorExplain: "걱정하지 마세요. 다른 사람이 링크를 공유하면 여전히 회의에 참가할 수 있습니다 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "로그아웃",
         popupScopeIsConnectedExplainText: "이미 연결되어 있습니다. 로그아웃하고 다시 연결하려면 버튼을 클릭하세요.",

--- a/play/src/i18n/nl-NL/externalModule.ts
+++ b/play/src/i18n/nl-NL/externalModule.ts
@@ -75,6 +75,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "Annuleren",
         isSyncronized: "Gesynchroniseerd met Google",
         popupScopeToSyncMeet: "Online vergaderingen maken",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Google Meet openen... 🙏",
         unableJoinMeet: "Kan niet deelnemen aan Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -86,6 +87,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             error: "Uw Google Workspace-instellingen staan het maken van een Meet niet toe.",
             errorExplain:
                 "Geen zorgen, u kunt nog steeds deelnemen aan vergaderingen wanneer iemand anders een link deelt 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "Uitloggen",
         popupScopeIsConnectedExplainText:

--- a/play/src/i18n/pt-BR/externalModule.ts
+++ b/play/src/i18n/pt-BR/externalModule.ts
@@ -73,6 +73,7 @@ const externalModule: BaseTranslation = {
         popupCancel: "Cancelar",
         isSyncronized: "Sincronizado com Google",
         popupScopeToSyncMeet: "Criar reuniões online",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "Abrindo Google Meet... 🙏",
         unableJoinMeet: "Não foi possível entrar no Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -84,6 +85,9 @@ const externalModule: BaseTranslation = {
             error: "As configurações do seu Google Workspace não permitem criar um Meet.",
             errorExplain:
                 "Não se preocupe, você ainda pode participar de reuniões quando alguém compartilhar um link 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "Sair",
         popupScopeIsConnectedExplainText: "Você já está conectado, clique no botão para fazer logout e reconectar.",

--- a/play/src/i18n/zh-CN/externalModule.ts
+++ b/play/src/i18n/zh-CN/externalModule.ts
@@ -71,6 +71,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "取消",
         isSyncronized: "已与 Google 同步",
         popupScopeToSyncMeet: "创建在线会议",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "正在打开 Google Meet... 🙏",
         unableJoinMeet: "无法加入 Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -80,6 +81,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             guestExplain: "请登录平台以创建 Google Meet，或要求所有者为您创建一个 🚀",
             error: "您的 Google Workspace 设置不允许您创建 Meet。",
             errorExplain: "别担心，当其他人分享链接时，您仍然可以加入会议 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "注销",
         popupScopeIsConnectedExplainText: "您已连接，请点击按钮注销并重新连接。",

--- a/play/src/i18n/zh-TW/externalModule.ts
+++ b/play/src/i18n/zh-TW/externalModule.ts
@@ -71,6 +71,7 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
         popupCancel: "取消",
         isSyncronized: "已與 Google 同步",
         popupScopeToSyncMeet: "建立線上會議",
+        popupScopeToSyncMeetHelp: "Required to create meetings in Google Meet areas.",
         openingMeet: "正在開啟 Google Meet... 🙏",
         unableJoinMeet: "無法加入 Google Meet 😭",
         googleMeetPopupWaiting: {
@@ -80,6 +81,9 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             guestExplain: "請登入平台以建立 Google Meet，或請擁有者為您建立一個 🚀",
             error: "您的 Google Workspace 設定不允許您建立 Meet。",
             errorExplain: "別擔心，當其他人分享連結時，您仍然可以加入會議 🙏",
+            missingScope: "No meeting was created: your Google account has not granted meeting creation.",
+            missingScopeExplain: "Wait for a participant who can create it, or reconnect and allow meeting creation.",
+            reconnect: "Reconnect Google",
         },
         popupScopeIsConnectedButton: "登出",
         popupScopeIsConnectedExplainText: "您已連線，請點選按鈕登出並重新連線。",


### PR DESCRIPTION
## Context

Entering a Google Meet area without the `meetings.space.*` OAuth scopes currently leaves the user in front of an endless *"Creating your Google Space…"* spinner. The SaaS-side fix (private repo, `external-modules/google`) replaces that spinner with an explicit message and a reconnect button; this PR adds the strings it needs.

## What this adds

Under `externalModule.google.googleMeetPopupWaiting`:

| key | en-US |
|---|---|
| `missingScope` | No meeting was created: your Google account has not granted meeting creation. |
| `missingScopeExplain` | Wait for a participant who can create it, or reconnect and allow meeting creation. |
| `reconnect` | Reconnect Google |

And under `externalModule.google`:

| key | en-US |
|---|---|
| `popupScopeToSyncMeetHelp` | Required to create meetings in Google Meet areas. |

Shown under the "Create online meetings" toggle of the Google connection popup when it is left unchecked — the toggle is off by default, which is what causes the problem in the first place.

## Notes

- Added to **all 15 locales** (`i18n:check` is a CI gate and `DeepPartial` does not make keys optional). Translated for `en-US` and `fr-FR`; the other 13 carry the English text pending translation.
- Verified with `tsx ./scripts/diff-i18n.ts --check` → *All translations are complete*, plus `tsc`, `eslint`, `svelte-check` and `prettier --check` against a baseline of the unmodified tree — no new errors or warnings.