### PR TITLE
fix(media): make the audio output selection actually work

### DIFF
--- a/play/src/front/Chat/Components/Room/Message/MessageAudioFile.svelte
+++ b/play/src/front/Chat/Components/Room/Message/MessageAudioFile.svelte
@@ -2,6 +2,7 @@
     import type { Readable } from "svelte/store";
     import type { ChatMessageContent } from "../../../Connection/ChatConnection";
     import LL from "../../../../../i18n/i18n-svelte";
+    import { audioOutput } from "../../../../WebRtc/AudioOutputManager";
 
     interface Props {
         content: Readable<ChatMessageContent>;
@@ -19,7 +20,7 @@
             : $LL.chat.file.attachmentDownloadError()}
     </div>
 {:else if $content.url !== undefined}
-    <audio controls src={$content.url} class="max-w-full min-w-96 block p-2"></audio>
+    <audio use:audioOutput controls src={$content.url} class="max-w-full min-w-96 block p-2"></audio>
 {:else}
     <div class="text-xs text-white/80 px-2 py-2">
         {$content.mediaErrorKind === "decrypt"

--- a/play/src/front/Chat/Components/Room/Message/MessageVideoFile.svelte
+++ b/play/src/front/Chat/Components/Room/Message/MessageVideoFile.svelte
@@ -2,6 +2,7 @@
     import type { Readable } from "svelte/store";
     import type { ChatMessageContent } from "../../../Connection/ChatConnection";
     import LL from "../../../../../i18n/i18n-svelte";
+    import { audioOutput } from "../../../../WebRtc/AudioOutputManager";
 
     interface Props {
         content: Readable<ChatMessageContent>;
@@ -20,7 +21,7 @@
     </div>
 {:else if $content.url !== undefined}
     <!-- svelte-ignore a11y_media_has_caption -->
-    <video controls class="w-full block rounded">
+    <video use:audioOutput controls class="w-full block rounded">
         <source src={$content.url} />
     </video>
 {/if}

--- a/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsPanel.svelte
+++ b/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsPanel.svelte
@@ -20,6 +20,7 @@
     import { cameraPermissionStateStore, microphonePermissionStateStore } from "../../../Stores/MediaStatusStore";
     import { analyticsClient } from "../../../Administration/AnalyticsClient";
     import { localUserStore } from "../../../Connection/LocalUserStore";
+    import { playTestSound } from "../../../WebRtc/AudioOutputManager";
     import { noiseSuppressionEnabledStore, noiseSuppressionStateStore } from "../../../Stores/NoiseSuppressionStore";
     import { handleOpenMenuEvent, settingsSubMenuTargetStore, SubMenusInterface } from "../../../Stores/MenuStore";
     import { LL } from "../../../../i18n/i18n-svelte";
@@ -29,7 +30,7 @@
     import SectionDivider from "./SectionDivider.svelte";
     import SectionTitle from "./SectionTitle.svelte";
     import DeviceListItem from "./DeviceListItem.svelte";
-    import { IconCamera, IconHeadphones, IconMicrophoneOn, IconSettings } from "@wa-icons";
+    import { IconCamera, IconHeadphones, IconMicrophoneOn, IconSettings, IconUnMute } from "@wa-icons";
 
     interface Props {
         oncameraselected?: () => void;
@@ -52,6 +53,10 @@
     function selectSpeaker(deviceId: string) {
         localUserStore.setSpeakerDeviceId(deviceId);
         speakerSelectedStore.set(deviceId);
+    }
+
+    function testSpeaker() {
+        playTestSound($speakerSelectedStore).catch((e) => console.error(e));
     }
 
     function cameraClick(): void {
@@ -286,6 +291,20 @@
                 <IconHeadphones font-size="14" />
                 {$LL.actionbar.subtitle.speaker()}
             </div>
+            {#snippet actions()}
+                {#if $speakerListStore && $speakerListStore.length > 0}
+                    <button
+                        type="button"
+                        data-testid="speaker-test-button"
+                        class="flex h-7 w-7 items-center justify-center rounded text-white/50 hover:bg-white/10 hover:text-white"
+                        aria-label={$LL.actionbar.speaker.test()}
+                        title={$LL.actionbar.speaker.test()}
+                        onclick={testSpeaker}
+                    >
+                        <IconUnMute font-size="14" />
+                    </button>
+                {/if}
+            {/snippet}
         </SectionTitle>
         {#if $speakerSelectedStore != undefined && $speakerListStore && $speakerListStore.length > 0}
             {#each $speakerListStore as speaker, index (index)}

--- a/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsPanel.svelte
+++ b/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsPanel.svelte
@@ -8,6 +8,8 @@
         requestedMicrophoneState,
         speakerListStore,
         speakerSelectedStore,
+        speakerSelectionSupported,
+        usedSpeakerDeviceIdStore,
         silentStore,
         usedCameraDeviceIdStore,
         usedMicrophoneDeviceIdStore,
@@ -58,6 +60,18 @@
     function testSpeaker() {
         playTestSound($speakerSelectedStore).catch((e) => console.error(e));
     }
+
+    // Without microphone permission the browser hands back empty labels, which would render as
+    // blank rows.
+    function speakerLabel(speaker: MediaDeviceInfo, index: number): string {
+        return speaker.label || $LL.actionbar.speaker.unnamedDevice({ index: index + 1 });
+    }
+
+    // The selection is what the user asked for; usedSpeakerDeviceIdStore is what the browser
+    // actually applied. A mismatch means setSinkId was refused and we fell back.
+    let speakerFallbackInUse = $derived(
+        $usedSpeakerDeviceIdStore !== undefined && $usedSpeakerDeviceIdStore !== $speakerSelectedStore,
+    );
 
     function cameraClick(): void {
         if ($silentStore) return;
@@ -306,10 +320,28 @@
                 {/if}
             {/snippet}
         </SectionTitle>
-        {#if $speakerSelectedStore != undefined && $speakerListStore && $speakerListStore.length > 0}
-            {#each $speakerListStore as speaker, index (index)}
+        <!-- Every branch below renders something: an empty section with no explanation was the bug. -->
+        {#if !speakerSelectionSupported}
+            <div class="group flex items-center relative z-10 py-1 px-2 font-sm justify-center">
+                <div class="text-sm italic text-center text-white/55" data-testid="speaker-unsupported">
+                    {$LL.actionbar.speaker.unsupported()}
+                </div>
+            </div>
+        {:else if $speakerListStore === undefined}
+            <div class="group flex items-center relative z-10 py-1 px-2 font-sm justify-center">
+                <div class="text-sm italic text-center text-white/55">{$LL.actionbar.speaker.loading()}</div>
+            </div>
+        {:else if $speakerListStore.length === 0}
+            <div class="group flex items-center relative z-10 py-1 px-2 font-sm justify-center">
+                <div class="text-sm italic text-center">
+                    <p class="text-sm p-0 m-0">{$LL.actionbar.speaker.noDevices()}</p>
+                    <span class="text-xs text-white/55">{$LL.actionbar.speaker.noDevicesDesc()}</span>
+                </div>
+            </div>
+        {:else}
+            {#each $speakerListStore as speaker, index (speaker.deviceId)}
                 <DeviceListItem
-                    label={speaker.label}
+                    label={speakerLabel(speaker, index)}
                     isSelected={$speakerSelectedStore === speaker.deviceId}
                     onclick={() => {
                         analyticsClient.selectSpeaker();
@@ -317,17 +349,11 @@
                     }}
                 />
             {/each}
-        {:else if $speakerListStore !== undefined}
-            <div class="cursor-pointer group flex items-center relative z-10 py-1 px-2 font-sm justify-center">
-                <div class="text-sm italic text-center">
-                    {#if $speakerListStore.length === 0}
-                        <p class="text-sm p-0 m-0">{$LL.actionbar.speaker.noDevices()}</p>
-                        <span class="text-xs text-white/55">{$LL.actionbar.speaker.noDevicesDesc()}</span>
-                    {:else}
-                        {$LL.actionbar.speaker.disabled()}
-                    {/if}
+            {#if speakerFallbackInUse}
+                <div class="px-2 py-1 text-xs text-pop-red" data-testid="speaker-fallback-warning">
+                    {$LL.actionbar.speaker.fallbackInUse()}
                 </div>
-            </div>
+            {/if}
         {/if}
     </div>
 </div>

--- a/play/src/front/Components/AudioManager/AudioPlayer.svelte
+++ b/play/src/front/Components/AudioManager/AudioPlayer.svelte
@@ -17,6 +17,7 @@
     import { warningMessageStore } from "../../Stores/ErrorStore";
     import { activeSecondaryZoneActionBarStore } from "../../Stores/MenuStore";
     import { gameManager } from "../../Phaser/Game/GameManager";
+    import { audioOutput } from "../../WebRtc/AudioOutputManager";
 
     let HTMLAudioPlayer: HTMLAudioElement | undefined;
     let unsubscriberFileStore: Unsubscriber | null = null;
@@ -167,4 +168,4 @@
     }
 </script>
 
-<audio preload="auto" class="audio-manager-audioplayer" bind:this={HTMLAudioPlayer}></audio>
+<audio use:audioOutput preload="auto" class="audio-manager-audioplayer" bind:this={HTMLAudioPlayer}></audio>

--- a/play/src/front/Components/Cowebsites/VideoCowebsiteComponent.svelte
+++ b/play/src/front/Components/Cowebsites/VideoCowebsiteComponent.svelte
@@ -2,6 +2,7 @@
     import { onMount, onDestroy } from "svelte";
     import type { VideoCoWebsite } from "../../WebRtc/CoWebsite/VideoCoWebsite";
     import { screenWakeLock } from "../../Utils/ScreenWakeLock";
+    import { audioOutput } from "../../WebRtc/AudioOutputManager";
 
     interface Props {
         actualCowebsite: VideoCoWebsite;
@@ -65,6 +66,7 @@
 <div class="relative w-full h-full flex items-center justify-center bg-black" class:hidden={!visible}>
     <!-- svelte-ignore a11y_media_has_caption -->
     <video
+        use:audioOutput
         bind:this={videoElement}
         controls
         preload="metadata"

--- a/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
+++ b/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
@@ -20,6 +20,7 @@
     import { myCameraStore, myMicrophoneStore } from "../../Stores/MyMediaStore";
     import { localUserStore } from "../../Connection/LocalUserStore";
     import { gameManager } from "../../Phaser/Game/GameManager";
+    import { playTestSound } from "../../WebRtc/AudioOutputManager";
 
     import bgMap from "../images/map-exemple.png";
     import Button from "../UI/Button.svelte";
@@ -41,7 +42,6 @@
 
     let selectedCamera: string | undefined = $state(undefined);
     let selectedMicrophone: string | undefined = $state(undefined);
-    const sound = new Audio("/resources/objects/webrtc-in.mp3");
 
     let legalStrings: string[] = [];
     if (legals?.termsOfUseUrl) {
@@ -141,7 +141,6 @@
         requestedMicrophoneState.enableMicrophone();
 
         batchGetUserMediaStore.commitChanges();
-        sound.load();
     });
 
     function handleSelectCamera(deviceId: string | undefined) {
@@ -185,8 +184,8 @@
         speakerSelectedStore.set(deviceId);
     }
 
-    function playSoundClick() {
-        sound.play().catch((e) => console.error(e));
+    function playSoundClick(deviceId: string | undefined) {
+        playTestSound(deviceId).catch((e) => console.error(e));
     }
     /* eslint-disable svelte/no-at-html-tags */
 </script>

--- a/play/src/front/Components/EnableCamera/SelectSpeaker.svelte
+++ b/play/src/front/Components/EnableCamera/SelectSpeaker.svelte
@@ -67,7 +67,9 @@
                         </div>
                         <div class="space-y-1 min-w-0">
                             <div class="text-lg bold truncate leading-tight">
-                                {StringUtils.normalizeDeviceName(speaker.label)}
+                                {speaker.label
+                                    ? StringUtils.normalizeDeviceName(speaker.label)
+                                    : $LL.actionbar.speaker.unnamedDevice({ index: index + 1 })}
                             </div>
                             {#if selectedDevice === speaker.deviceId}
                                 <Chip>{$LL.camera.active()}</Chip>

--- a/play/src/front/Components/EnableCamera/SelectSpeaker.svelte
+++ b/play/src/front/Components/EnableCamera/SelectSpeaker.svelte
@@ -38,7 +38,7 @@
 
     <div class="flex items-center justify-center w-full">
         <div class="flex flex-wrap items-center justify-center w-full">
-            {#each deviceList as speaker, index (index)}
+            {#each deviceList as speaker, index (speaker.deviceId)}
                 <!-- svelte-ignore a11y_click_events_have_key_events -->
                 <!-- svelte-ignore a11y_no_static_element_interactions -->
                 <div

--- a/play/src/front/Components/EnableCamera/SelectSpeaker.svelte
+++ b/play/src/front/Components/EnableCamera/SelectSpeaker.svelte
@@ -77,9 +77,22 @@
                         </div>
                     </div>
                     {#if selectedDevice === speaker.deviceId}
-                        <Button variant="secondary" square class="self-end" type="button">
+                        <Button
+                            variant="secondary"
+                            square
+                            class="self-end"
+                            type="button"
+                            aria-label={$LL.actionbar.speaker.test()}
+                            title={$LL.actionbar.speaker.test()}
+                            onclick={(event) => {
+                                // Stop the click from bubbling to the parent card, which would
+                                // re-select the device instead of only testing it.
+                                event.stopPropagation();
+                                event.preventDefault();
+                                onplaysound?.(speaker.deviceId);
+                            }}
+                        >
                             {#snippet icon()}
-                                <!-- TODO HUGO -->
                                 <IconUnMute font-size="20" />
                             {/snippet}
                         </Button>

--- a/play/src/front/Components/Input/SoundSelect.svelte
+++ b/play/src/front/Components/Input/SoundSelect.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import * as Sentry from "@sentry/svelte";
+    import { playNotificationSound } from "../../WebRtc/AudioOutputManager";
     import Button from "../UI/Button.svelte";
     import Select from "./Select.svelte";
 
@@ -29,16 +30,13 @@
         playLabel = "▶",
     }: Props = $props();
 
-    const sound = new Audio();
-
     function playSelectedSound(selectedValue: string = value) {
         const url = getSoundUrl(selectedValue);
         if (!url) {
             return;
         }
-        sound.src = url;
-        sound.volume = volume;
-        sound.play().catch((e) => {
+        // Preview on the selected audio output, so it matches where the sound will actually play.
+        playNotificationSound(url, volume).catch((e) => {
             console.error(e);
             Sentry.captureException(e);
         });

--- a/play/src/front/Components/MapEditor/PropertyEditor/PlayAudioPropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/PlayAudioPropertyEditor.svelte
@@ -5,6 +5,7 @@
     import Input from "../../Input/Input.svelte";
     import InputSwitch from "../../Input/InputSwitch.svelte";
     import { IconFileMusic } from "../../Icons";
+    import { audioOutput } from "../../../WebRtc/AudioOutputManager";
     import PropertyEditorBase from "./PropertyEditorBase.svelte";
 
     interface Props {
@@ -103,7 +104,7 @@
                         <button onclick={stopAudio} class="mt-7 ps-1 pe-0 text-xl"> ⏹️ </button>
                     {/if}
                 </div>
-                <audio class="audio-manager-audioplayer" bind:this={HTMLAudioPlayer}></audio>
+                <audio use:audioOutput class="audio-manager-audioplayer" bind:this={HTMLAudioPlayer}></audio>
             </div>
             <div class="value-input text-danger-800" class:invisible={!errorMessage}>
                 ⚠️ {errorMessage}

--- a/play/src/front/Components/Menu/SettingsSubMenu.svelte
+++ b/play/src/front/Components/Menu/SettingsSubMenu.svelte
@@ -8,6 +8,7 @@
         bubbleSoundStore,
     } from "../../Stores/AudioManagerStore";
     import { HtmlUtils } from "../../WebRtc/HtmlUtils";
+    import { getBubbleSoundUrl } from "../../WebRtc/AudioOutputManager";
     import { LL, locale } from "../../../i18n/i18n-svelte";
     import type { Locales } from "../../../i18n/i18n-types";
     import { displayableLocales, setCurrentLocale } from "../../Utils/locales";
@@ -273,10 +274,6 @@
     function changeVideoQualityStats() {
         localUserStore.setDisplayVideoQualityStats(videoQualityStats);
         displayVideoQualityStore.set(videoQualityStats);
-    }
-
-    function getBubbleSoundUrl(bubbleSound: string): string {
-        return `/resources/objects/webrtc-in-${bubbleSound}.mp3`;
     }
 </script>
 

--- a/play/src/front/Components/UI/AudioPlaying.svelte
+++ b/play/src/front/Components/UI/AudioPlaying.svelte
@@ -3,6 +3,7 @@
     import { onDestroy } from "svelte";
     import { soundPlayingStore } from "../../Stores/SoundPlayingStore";
     import { LL } from "../../../i18n/i18n-svelte";
+    import { audioOutput } from "../../WebRtc/AudioOutputManager";
     import { IconMusic, IconPause, IconPauseFilled, IconPlay, IconPlayFilled } from "@wa-icons";
 
     interface Props {
@@ -59,7 +60,7 @@
 >
     <IconMusic class="top-0 bottom-0 h-8 w-8 m-2" />
     <p>{$LL.audio.message()}</p>
-    <audio bind:this={audio} src={url} onended={soundEnded}>
+    <audio use:audioOutput bind:this={audio} src={url} onended={soundEnded}>
         <track kind="captions" />
     </audio>
     <!-- Button to stop the audio -->

--- a/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
@@ -6,6 +6,7 @@
     import { signalAudioPlaybackBlocked } from "../../../Stores/AudioPlaybackStore";
     import { userActivationManager } from "../../../Stores/UserActivationStore";
     import { audioContextManager } from "../../../WebRtc/AudioContextManager";
+    import { usedSpeakerDeviceIdStore } from "../../../Stores/MediaStore";
 
     interface Props {
         streamStore: Readable<MediaStream | undefined>;
@@ -53,6 +54,10 @@
             debug("Setting output device to ", deviceId);
             await el.setSinkId(deviceId);
             debug("Output device set to ", deviceId);
+            // Report what was actually applied, so the settings UI can tell a selection that took
+            // effect from one the browser refused. This duplicates AudioOutputManager.applySinkId
+            // for now; both collapse into it once this component is migrated onto the manager.
+            usedSpeakerDeviceIdStore.set(deviceId);
             return true;
         } catch (e) {
             if (destroyed) {

--- a/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
@@ -6,7 +6,7 @@
     import { signalAudioPlaybackBlocked } from "../../../Stores/AudioPlaybackStore";
     import { userActivationManager } from "../../../Stores/UserActivationStore";
     import { audioContextManager } from "../../../WebRtc/AudioContextManager";
-    import { usedSpeakerDeviceIdStore } from "../../../Stores/MediaStore";
+    import { applySinkId } from "../../../WebRtc/AudioOutputManager";
 
     interface Props {
         streamStore: Readable<MediaStream | undefined>;
@@ -37,56 +37,18 @@
         }
     });
 
-    let lastRequestedDeviceId: string | undefined;
-
-    async function safeSetSinkId(deviceId: string, el: HTMLAudioElement) {
-        if (destroyed) {
-            return false;
-        }
-        if (lastRequestedDeviceId === deviceId) {
-            return true;
-        }
-        if (typeof el.setSinkId !== "function") {
-            return false;
-        }
-        lastRequestedDeviceId = deviceId;
-        try {
-            debug("Setting output device to ", deviceId);
-            await el.setSinkId(deviceId);
-            debug("Output device set to ", deviceId);
-            // Report what was actually applied, so the settings UI can tell a selection that took
-            // effect from one the browser refused. This duplicates AudioOutputManager.applySinkId
-            // for now; both collapse into it once this component is migrated onto the manager.
-            usedSpeakerDeviceIdStore.set(deviceId);
-            return true;
-        } catch (e) {
-            if (destroyed) {
-                return false;
-            }
-
-            Sentry.captureException(e);
-            if (e instanceof DOMException && e.name === "AbortError") {
-                // An error occurred while setting the sinkId. Let's fall back to default.
-                console.warn("Error setting the audio output device. We fallback to default.");
-
-                try {
-                    lastRequestedDeviceId = "";
-                    await el.setSinkId("");
-                } catch (e) {
-                    console.error("Error resetting the audio output device: ", e);
-                }
-
-                onselectoutputaudiodeviceerror?.();
-                return false;
-            }
-            console.error("Error setting the audio output device: ", e);
-            return false;
+    async function setOutputDevice(deviceId: string, el: HTMLAudioElement): Promise<void> {
+        const outcome = await applySinkId(el, deviceId);
+        // Only a device that vanished is worth reporting: on a browser without the Audio Output
+        // Devices API, resetting the user's selection would throw away a valid preference.
+        if (outcome === "fell-back-to-default" && !destroyed) {
+            onselectoutputaudiodeviceerror?.();
         }
     }
 
     $effect(() => {
         if (outputDeviceId && audioElement) {
-            safeSetSinkId(outputDeviceId, audioElement).catch((e) => {
+            setOutputDevice(outputDeviceId, audioElement).catch((e) => {
                 console.error("Error setting the audio output device: ", e);
                 Sentry.captureException(e);
             });
@@ -232,7 +194,7 @@
         (async () => {
             if (outputDeviceId && audioElement) {
                 // Because of a bug in Chrome, we need to wait for setSinkId to resolve before setting the srcObject.
-                await safeSetSinkId(outputDeviceId, audioElement);
+                await setOutputDevice(outputDeviceId, audioElement);
                 if (destroyed || !audioElement) {
                     return;
                 }

--- a/play/src/front/Components/Video/VideoTags/ScriptingVideo.svelte
+++ b/play/src/front/Components/Video/VideoTags/ScriptingVideo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type { ScriptingVideoStreamable } from "../../../Space/Streamable";
+    import { audioOutput } from "../../../WebRtc/AudioOutputManager";
 
     interface Props {
         style: string;
@@ -23,6 +24,7 @@
 
 <!-- svelte-ignore a11y_media_has_caption -->
 <video
+    use:audioOutput
     {style}
     bind:videoWidth
     bind:videoHeight

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -57,6 +57,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
     private localMicrophoneTrack: LocalAudioTrack | undefined;
     private screenShareUpdateQueue: Promise<void> = Promise.resolve();
     private mediaTrackUpdateQueue: Promise<void> = Promise.resolve();
+    private audioOutputUpdateQueue: Promise<void> = Promise.resolve();
     private unsubscribers: Unsubscriber[] = [];
     private rxjsSubscriptions: Subscription[] = [];
     private unregisterAudioPlaybackRetry: Unsubscriber | undefined;
@@ -191,6 +192,24 @@ export class LiveKitRoom implements LiveKitRoomInterface {
         const width = settings.width || 1280;
         const height = settings.height || 720;
         return selectVideoPreset(height, width, isScreenShare, this.getQualitySetting(isScreenShare));
+    }
+
+    /**
+     * Serialized like the track updates below. The selection can emit twice in a row — the fallback
+     * to a default speaker followed by the restore of the persisted preference on the next
+     * `devicechange` — and two overlapping `switchActiveDevice` calls can settle out of order,
+     * leaving the room on the device the user did not pick.
+     *
+     * An empty string is a meaningful value here: it means "system default".
+     */
+    private queueAudioOutputUpdate(deviceId: string): void {
+        this.audioOutputUpdateQueue = this.audioOutputUpdateQueue
+            .then(() => this.room?.switchActiveDevice("audiooutput", deviceId))
+            .then(() => undefined)
+            .catch((err) => {
+                console.error("An error occurred while switching active device", err);
+                Sentry.captureException(err);
+            });
     }
 
     private queueCameraTrackUpdate(localStream: LocalStreamStoreValue | undefined): void {
@@ -333,12 +352,9 @@ export class LiveKitRoom implements LiveKitRoomInterface {
 
         this.unsubscribers.push(
             this.speakerDeviceIdStore.subscribe((deviceId) => {
-                if (!deviceId) return;
+                if (deviceId === undefined) return;
 
-                this.room?.switchActiveDevice("audiooutput", deviceId).catch((err) => {
-                    console.error("An error occurred while switching active device", err);
-                    Sentry.captureException(err);
-                });
+                this.queueAudioOutputUpdate(deviceId);
             }),
         );
 

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -116,6 +116,7 @@ import {
     requestedMicrophoneState,
     speakerSelectedStore,
 } from "../../Stores/MediaStore";
+import { bindAudioContextOutput } from "../../WebRtc/AudioOutputManager";
 import NoMicrophoneSoundToast from "../../Components/Toasts/NoMicrophoneSoundToast.svelte";
 import { LL, locale } from "../../../i18n/i18n-svelte";
 import { toastStore } from "../../Stores/ToastStoreSingleton";
@@ -507,6 +508,14 @@ export class GameScene extends DirtyScene {
         this.load.audio("meeting-out", "/resources/objects/meeting-out.wav");
 
         this.sound.pauseOnBlur = false;
+
+        // Bubble, meeting and notification sounds go through Phaser's own AudioContext, bypassing
+        // every media element, so they need routing of their own or they always land on the system
+        // default output. Absent when Phaser falls back to its HTML5 audio manager.
+        const phaserAudioContext = (this.sound as Partial<Phaser.Sound.WebAudioSoundManager>).context;
+        if (phaserAudioContext) {
+            this.unsubscribers.push(bindAudioContextOutput(phaserAudioContext));
+        }
 
         this.load.on(Phaser.Loader.Events.FILE_LOAD_ERROR, (file: { src: string }) => {
             // If we happen to be in HTTP and we are trying to load a URL in HTTPS only... (this happens only in dev environments)

--- a/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
+++ b/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
@@ -23,6 +23,7 @@ import LL, { locale } from "../../../i18n/i18n-svelte";
 import { gameManager } from "../../Phaser/Game/GameManager";
 import type { Streamable } from "../Streamable";
 import { deriveSwitchStore } from "../../Stores/InterruptorStore";
+import { playNotificationSound } from "../../WebRtc/AudioOutputManager";
 import { DefaultCommunicationState } from "./DefaultCommunicationState";
 import { CommunicationMessageType } from "./CommunicationMessageType";
 import { WebRTCState } from "./WebRTCState";
@@ -637,33 +638,19 @@ export class SpacePeerManager {
      * by the GameScene.
      */
     private playRecordingStartSound(): void {
-        try {
-            const currentLocale = get(locale);
-            const audioPath = `./static/audio/recording/${currentLocale}_recording-start.mp3`;
-            const audio = new Audio(audioPath);
-            audio.volume = 0.1;
-            audio.play().catch((error) => {
-                console.warn("Error playing recording start sound:", error);
-            });
-        } catch (error) {
-            console.warn("Error initializing recording start sound:", error);
-        }
+        const currentLocale = get(locale);
+        playNotificationSound(`./static/audio/recording/${currentLocale}_recording-start.mp3`, 0.1).catch((error) => {
+            console.warn("Error playing recording start sound:", error);
+        });
     }
 
     /**
      * Plays the recording stop sound based on the current locale.
      */
     private playRecordingStopSound(): void {
-        try {
-            const currentLocale = get(locale);
-            const audioPath = `./static/audio/recording/${currentLocale}_recording-end.mp3`;
-            const audio = new Audio(audioPath);
-            audio.volume = 0.1;
-            audio.play().catch((error) => {
-                console.warn("Error playing recording stop sound:", error);
-            });
-        } catch (error) {
-            console.warn("Error initializing recording stop sound:", error);
-        }
+        const currentLocale = get(locale);
+        playNotificationSound(`./static/audio/recording/${currentLocale}_recording-end.mp3`, 0.1).catch((error) => {
+            console.warn("Error playing recording stop sound:", error);
+        });
     }
 }

--- a/play/src/front/Stores/AudioOutputStore.ts
+++ b/play/src/front/Stores/AudioOutputStore.ts
@@ -1,4 +1,4 @@
-import { writable } from "svelte/store";
+import { get, writable } from "svelte/store";
 import type { Writable } from "svelte/store";
 import { localUserStore } from "../Connection/LocalUserStore";
 import { isIOS, isSafari } from "../WebRtc/DeviceUtils";
@@ -42,3 +42,37 @@ export const usedSpeakerDeviceIdStore: Writable<string | undefined> = writable()
 speakerSelectedStore.subscribe(() => {
     usedSpeakerDeviceIdStore.set(undefined);
 });
+
+/**
+ * Selects the first available output, or the system default when there is none.
+ *
+ * The choice is persisted: the device list subscriber restores the stored preference on every
+ * enumeration, so a fallback that only touched the store would be undone on the next
+ * `devicechange` and re-applied endlessly against a device that keeps failing.
+ */
+export function applyDefaultSpeaker(devices: MediaDeviceInfo[] | undefined): void {
+    const deviceId = devices !== undefined && devices.length > 0 ? devices[0].deviceId : "";
+    localUserStore.setSpeakerDeviceId(deviceId);
+    speakerSelectedStore.set(deviceId);
+}
+
+/**
+ * Keeps the selection pointing at a device that actually exists, called on every enumeration.
+ */
+export function reconcileSpeakerSelection(devices: MediaDeviceInfo[] | undefined): void {
+    if (devices === undefined || !speakerSelectionSupported) {
+        return;
+    }
+    // An empty list is "we cannot see the outputs yet", not "the chosen device is gone": browsers
+    // report no audio output before permission is granted. Falling back here would persist an empty
+    // selection and destroy a perfectly valid stored preference before it ever got a chance.
+    if (devices.length === 0) {
+        return;
+    }
+
+    const selected = get(speakerSelectedStore);
+    if (devices.some((device) => device.deviceId === selected)) {
+        return;
+    }
+    applyDefaultSpeaker(devices);
+}

--- a/play/src/front/Stores/AudioOutputStore.ts
+++ b/play/src/front/Stores/AudioOutputStore.ts
@@ -1,0 +1,44 @@
+import { writable } from "svelte/store";
+import type { Writable } from "svelte/store";
+import { localUserStore } from "../Connection/LocalUserStore";
+import { isIOS, isSafari } from "../WebRtc/DeviceUtils";
+
+/**
+ * The audio output selection, kept in its own leaf module on purpose.
+ *
+ * `AudioOutputManager` needs these stores, and it is reached from `AudioContextManager`, which
+ * `MediaStore` itself pulls in through `SoundMeter`. Living in `MediaStore` would therefore close
+ * an import cycle and leave stores undefined at evaluation time. Everything here must only depend
+ * on leaf modules.
+ */
+
+/**
+ * Whether this browser lets us pick an audio output device at all.
+ *
+ * Livekit does not support audio output device selection on Safari
+ * Code: https://github.com/livekit/client-sdk-js/blob/dbaf7a9b784114728857a447734bc5d5453345b4/src/room/utils.ts#L144C1-L153C2
+ * And it seems there is no plan to support it. Issue: https://github.com/livekit/components-js/issues/1216
+ * Because the audio output selector should work in full-mesh WebRTC AND in Livekit, we have to support the same
+ * features in both modes. So we disable audio output device selection on Safari here.
+ */
+export const speakerSelectionSupported = !isSafari() && !isIOS();
+
+export const speakerSelectedStore = writable<string | undefined>(localUserStore.getSpeakerDeviceId() ?? undefined);
+
+/**
+ * The output device that was actually applied, as reported by `setSinkId`.
+ *
+ * Mirrors `usedCameraDeviceIdStore` / `usedMicrophoneDeviceIdStore`. It stays `undefined` until
+ * something plays, since nothing routes audio before then; once set, a value differing from
+ * `speakerSelectedStore` means the browser refused the selection and fell back.
+ */
+export const usedSpeakerDeviceIdStore: Writable<string | undefined> = writable();
+
+// A freshly picked device has not been applied to anything yet. Without this reset the previous
+// value would linger and read as a mismatch, so the UI would claim the browser refused a device it
+// never even tried.
+// This is a singleton so no need to unsubscribe
+// eslint-disable-next-line svelte/no-ignored-unsubscribe
+speakerSelectedStore.subscribe(() => {
+    usedSpeakerDeviceIdStore.set(undefined);
+});

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -1290,15 +1290,27 @@ export const deviceListStore = readable<MediaDeviceInfo[] | undefined>(undefined
                 devicesNotLoaded.set(false);
             })
             .catch((e) => {
+                // Do not rethrow: this runs in a floating promise chain, so a rethrow would only
+                // surface as an unhandled rejection. Enumerating before any permission is granted
+                // makes this path common enough to matter.
                 console.error(e);
                 devicesNotLoaded.set(false);
-                throw e;
             });
     };
+
+    // Enumerate straight away, without waiting for a successful getUserMedia. Audio *output*
+    // selection needs no permission, so a user who joins with both microphone and camera off (the
+    // default, and unavoidable in a silent zone) would otherwise never get a device list at all.
+    // Labels come back empty until permission is granted; the UI falls back to a generic name.
+    if (navigator.mediaDevices) {
+        queryDeviceList();
+    }
 
     const unsubscribe = localStreamStore.subscribe((streamResult) => {
         if (streamResult && streamResult.type === "success" && streamResult.stream !== undefined) {
             if (deviceListCanBeQueried === false) {
+                // Re-enumerate now that permission was granted: this is the pass that fills in the
+                // device labels.
                 queryDeviceList();
                 deviceListCanBeQueried = true;
             }
@@ -1371,21 +1383,54 @@ export const microphoneButtonHelpContextStore = derived(
     },
 );
 
+/**
+ * Whether this browser lets us pick an audio output device at all.
+ *
+ * Livekit does not support audio output device selection on Safari
+ * Code: https://github.com/livekit/client-sdk-js/blob/dbaf7a9b784114728857a447734bc5d5453345b4/src/room/utils.ts#L144C1-L153C2
+ * And it seems there is no plan to support it. Issue: https://github.com/livekit/components-js/issues/1216
+ * Because the audio output selector should work in full-mesh WebRTC AND in Livekit, we have to support the same
+ * features in both modes. So we disable audio output device selection on Safari here.
+ */
+export const speakerSelectionSupported = !isSafari() && !isIOS();
+
+/**
+ * The audio output devices to choose from.
+ *
+ * `undefined` means "not enumerated yet" and nothing else: an unsupported browser yields an empty
+ * list, not `undefined`. The UI needs to tell those two apart to explain itself instead of
+ * rendering an empty section.
+ */
 export const speakerListStore = derived(deviceListStore, ($deviceListStore) => {
     if ($deviceListStore === undefined) {
         return undefined;
     }
 
-    // Livekit does not support audio output device selection on Safari
-    // Code: https://github.com/livekit/client-sdk-js/blob/dbaf7a9b784114728857a447734bc5d5453345b4/src/room/utils.ts#L144C1-L153C2
-    // And it seems there is no plan to support it. Issue: https://github.com/livekit/components-js/issues/1216
-    // Because the audio output selector should work in full-mesh WebRTC AND in Livekit, we have to support the same
-    // features in both modes. So we disable audio output device selection on Safari here.
-    if (isSafari() || isIOS()) {
-        return;
+    if (!speakerSelectionSupported) {
+        return [];
     }
 
     return removeDuplicateDevices($deviceListStore.filter((device) => device.kind === "audiooutput"));
+});
+
+export const speakerSelectedStore = writable<string | undefined>(localUserStore.getSpeakerDeviceId() ?? undefined);
+
+/**
+ * The output device that was actually applied, as reported by `setSinkId`.
+ *
+ * Mirrors `usedCameraDeviceIdStore` / `usedMicrophoneDeviceIdStore`. It stays `undefined` until
+ * something plays, since nothing routes audio before then; once set, a value differing from
+ * `speakerSelectedStore` means the browser refused the selection and fell back.
+ */
+export const usedSpeakerDeviceIdStore: Writable<string | undefined> = writable();
+
+// A freshly picked device has not been applied to anything yet. Without this reset the previous
+// value would linger and read as a mismatch, so the UI would claim the browser refused a device it
+// never even tried.
+// This is a singleton so no need to unsubscribe
+// eslint-disable-next-line svelte/no-ignored-unsubscribe
+speakerSelectedStore.subscribe(() => {
+    usedSpeakerDeviceIdStore.set(undefined);
 });
 
 export const selectDefaultSpeaker = () => {
@@ -1400,7 +1445,7 @@ export const selectDefaultSpeaker = () => {
 // This is a singleton so no need to unsubscribe
 //eslint-disable-next-line svelte/no-ignored-unsubscribe
 speakerListStore.subscribe((devices) => {
-    if (devices === undefined) {
+    if (devices === undefined || !speakerSelectionSupported) {
         return;
     }
     // if the previous speaker used isn`t defined in the list, apply default speaker
@@ -1410,8 +1455,6 @@ speakerListStore.subscribe((devices) => {
         selectDefaultSpeaker();
     }
 });
-
-export const speakerSelectedStore = writable<string | undefined>(localUserStore.getSpeakerDeviceId() ?? undefined);
 
 let previousMediaDevices: MediaDeviceInfo[] | undefined = undefined;
 

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -1409,17 +1409,24 @@ export const speakerListStore = derived(deviceListStore, ($deviceListStore) => {
 
 export const selectDefaultSpeaker = () => {
     const devices = get(speakerListStore);
-    if (devices !== undefined && devices.length > 0) {
-        speakerSelectedStore.set(devices[0].deviceId);
-    } else {
-        speakerSelectedStore.set("");
-    }
+    const deviceId = devices !== undefined && devices.length > 0 ? devices[0].deviceId : "";
+    // Persist the fallback too. Otherwise the subscriber below restores the previous preference on
+    // the next devicechange, and a device that always fails setSinkId gets re-applied in a loop:
+    // apply, fail, fall back, restore, apply again.
+    localUserStore.setSpeakerDeviceId(deviceId);
+    speakerSelectedStore.set(deviceId);
 };
 
 // This is a singleton so no need to unsubscribe
 //eslint-disable-next-line svelte/no-ignored-unsubscribe
 speakerListStore.subscribe((devices) => {
     if (devices === undefined || !speakerSelectionSupported) {
+        return;
+    }
+    // An empty list is "we cannot see the outputs yet", not "the chosen device is gone": browsers
+    // report no audio output before permission is granted. Falling back here would persist an empty
+    // selection and destroy a perfectly valid stored preference before it ever got a chance.
+    if (devices.length === 0) {
         return;
     }
     // if the previous speaker used isn`t defined in the list, apply default speaker
@@ -1515,29 +1522,6 @@ localStreamStore.subscribe((streamResult) => {
         }
     }
 });
-
-// When the stream is initialized, the new sound constraint is recreated and the first speaker is set.
-// If the user did not select the new speaker, the first new speaker cannot be selected automatically.
-// It is ok to not unsubscribe to this store because it is a singleton.
-// // eslint-disable-next-line svelte/no-ignored-unsubscribe
-/*speakerSelectedStore.subscribe((speaker) => {
-    const oldValue = localUserStore.getSpeakerDeviceId();
-    const currentValue = speaker;
-    const speakerList = get(speakerListStore);
-    const oldDevice =
-        oldValue && speakerList
-            ? speakerList.find((mediaDeviceInfo) => mediaDeviceInfo.deviceId == oldValue)
-            : undefined;
-    if (
-        oldDevice !== undefined &&
-        speakerList !== undefined &&
-        currentValue !== oldDevice.deviceId &&
-        speakerList.find((value) => value.deviceId == oldValue)
-    ) {
-        console.warn("speakerSelectedStore.subscribe", oldValue, currentValue, oldDevice.deviceId);
-        speakerSelectedStore.set(oldDevice.deviceId);
-    }
-});*/
 
 function createVideoQualityStore() {
     const { subscribe, set } = writable<VideoQualitySetting>(localUserStore.getVideoQuality());

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -215,6 +215,15 @@ const userMoved5SecondsAgoStore = readable(false, function start(set) {
  */
 export const devicesNotLoaded = writable(true);
 
+/**
+ * True once devices were enumerated *after* a successful getUserMedia, i.e. with permission.
+ *
+ * Before that, browsers report an empty list rather than the devices they are not allowed to
+ * disclose. Reading that as "this machine has no microphone" is wrong, and it is what made the
+ * microphone button render as permanently disabled on WebKit.
+ */
+export const devicesEnumeratedWithPermission = writable(false);
+
 const deviceChanged10SecondsAgoStore = readable(false, function start(set) {
     let timeout: NodeJS.Timeout | null = null;
 
@@ -1291,20 +1300,25 @@ export const localVoiceIndicatorStore = derived<Readable<number[] | undefined>, 
 export const deviceListStore = readable<MediaDeviceInfo[] | undefined>(undefined, function start(set) {
     let deviceListCanBeQueried = false;
 
-    const queryDeviceList = () => {
+    const queryDeviceList = (withPermission: boolean) => {
         // Note: so far, we are ignoring any failures.
         navigator.mediaDevices
             .enumerateDevices()
             .then((mediaDeviceInfos) => {
                 set(mediaDeviceInfos);
-                devicesNotLoaded.set(false);
+                if (withPermission) {
+                    devicesEnumeratedWithPermission.set(true);
+                    devicesNotLoaded.set(false);
+                }
             })
             .catch((e) => {
                 // Do not rethrow: this runs in a floating promise chain, so a rethrow would only
                 // surface as an unhandled rejection. Enumerating before any permission is granted
                 // makes this path common enough to matter.
                 console.error(e);
-                devicesNotLoaded.set(false);
+                if (withPermission) {
+                    devicesNotLoaded.set(false);
+                }
             });
     };
 
@@ -1313,39 +1327,53 @@ export const deviceListStore = readable<MediaDeviceInfo[] | undefined>(undefined
     // default, and unavoidable in a silent zone) would otherwise never get a device list at all.
     // Labels come back empty until permission is granted; the UI falls back to a generic name.
     if (navigator.mediaDevices) {
-        queryDeviceList();
+        queryDeviceList(false);
     }
 
     const unsubscribe = localStreamStore.subscribe((streamResult) => {
         if (streamResult && streamResult.type === "success" && streamResult.stream !== undefined) {
             if (deviceListCanBeQueried === false) {
                 // Re-enumerate now that permission was granted: this is the pass that fills in the
-                // device labels.
-                queryDeviceList();
+                // device labels, and the only one whose result can be trusted for inputs.
+                queryDeviceList(true);
                 deviceListCanBeQueried = true;
             }
         }
     });
 
+    const onDeviceChange = () => queryDeviceList(deviceListCanBeQueried);
+
     if (navigator.mediaDevices) {
-        navigator.mediaDevices.addEventListener("devicechange", queryDeviceList);
+        navigator.mediaDevices.addEventListener("devicechange", onDeviceChange);
     }
 
     return function stop() {
         unsubscribe();
         if (navigator.mediaDevices) {
-            navigator.mediaDevices.removeEventListener("devicechange", queryDeviceList);
+            navigator.mediaDevices.removeEventListener("devicechange", onDeviceChange);
         }
     };
 });
 
-export const cameraListStore = derived(deviceListStore, ($deviceListStore) => {
-    if ($deviceListStore === undefined) {
-        return undefined;
-    }
+export const cameraListStore = derived(
+    [deviceListStore, devicesEnumeratedWithPermission],
+    ([$deviceListStore, $devicesEnumeratedWithPermission]) => {
+        if ($deviceListStore === undefined) {
+            return undefined;
+        }
 
-    return removeDuplicateDevices($deviceListStore.filter((device) => device.kind === "videoinput"));
-});
+        // Only the enumeration that follows a granted permission says anything meaningful about
+        // inputs: before that the browser hides what it may not disclose, and an empty list would
+        // read as "this machine has no microphone". Several places in the UI rely on `undefined` to
+        // mean "we do not know yet" and pick a disabled control over a permission prompt otherwise.
+        // Audio *outputs* are different, which is why speakerListStore uses the early pass.
+        if (!$devicesEnumeratedWithPermission) {
+            return undefined;
+        }
+
+        return removeDuplicateDevices($deviceListStore.filter((device) => device.kind === "videoinput"));
+    },
+);
 
 /**
  * Context for the camera action-bar tooltip when the camera is off: permission denied vs no usable device.
@@ -1366,13 +1394,25 @@ export const cameraButtonHelpContextStore = derived(
     },
 );
 
-export const microphoneListStore = derived(deviceListStore, ($deviceListStore) => {
-    if ($deviceListStore === undefined) {
-        return undefined;
-    }
+export const microphoneListStore = derived(
+    [deviceListStore, devicesEnumeratedWithPermission],
+    ([$deviceListStore, $devicesEnumeratedWithPermission]) => {
+        if ($deviceListStore === undefined) {
+            return undefined;
+        }
 
-    return removeDuplicateDevices($deviceListStore.filter((device) => device.kind === "audioinput"));
-});
+        // Only the enumeration that follows a granted permission says anything meaningful about
+        // inputs: before that the browser hides what it may not disclose, and an empty list would
+        // read as "this machine has no microphone". Several places in the UI rely on `undefined` to
+        // mean "we do not know yet" and pick a disabled control over a permission prompt otherwise.
+        // Audio *outputs* are different, which is why speakerListStore uses the early pass.
+        if (!$devicesEnumeratedWithPermission) {
+            return undefined;
+        }
+
+        return removeDuplicateDevices($deviceListStore.filter((device) => device.kind === "audioinput"));
+    },
+);
 
 /**
  * Context for the microphone action-bar tooltip when the mic is off: permission denied vs no usable device.

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -6,7 +6,7 @@ import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import * as Sentry from "@sentry/svelte";
 import type { VideoQualitySetting } from "../Connection/LocalUserStore";
 import { localUserStore } from "../Connection/LocalUserStore";
-import { isIOS, isSafari } from "../WebRtc/DeviceUtils";
+import { isIOS } from "../WebRtc/DeviceUtils";
 import { SoundMeter } from "../Phaser/Components/SoundMeter";
 import type { RequestedStatus } from "../Rules/StatusRules/statusRules";
 import { statusChanger } from "../Components/ActionBar/AvailabilityStatus/statusChanger";
@@ -49,8 +49,13 @@ import {
 } from "./LocalStreamTypes";
 import { NoiseSuppressionController } from "./NoiseSuppressionController";
 import { buildMicrophoneAudioConstraints } from "./MicrophoneSettings";
+import { speakerSelectedStore, speakerSelectionSupported } from "./AudioOutputStore";
 import { audioPlaybackStore } from "./AudioPlaybackStore";
 import { browserNotificationStore } from "./BrowserNotificationStore";
+
+// Re-exported so callers keep a single entry point for media stores, while the definitions live in
+// a leaf module that AudioOutputManager can import without closing a cycle.
+export { speakerSelectedStore, speakerSelectionSupported, usedSpeakerDeviceIdStore } from "./AudioOutputStore";
 
 export const inBackgroundSettingsStore = writable<boolean>(false);
 
@@ -1384,17 +1389,6 @@ export const microphoneButtonHelpContextStore = derived(
 );
 
 /**
- * Whether this browser lets us pick an audio output device at all.
- *
- * Livekit does not support audio output device selection on Safari
- * Code: https://github.com/livekit/client-sdk-js/blob/dbaf7a9b784114728857a447734bc5d5453345b4/src/room/utils.ts#L144C1-L153C2
- * And it seems there is no plan to support it. Issue: https://github.com/livekit/components-js/issues/1216
- * Because the audio output selector should work in full-mesh WebRTC AND in Livekit, we have to support the same
- * features in both modes. So we disable audio output device selection on Safari here.
- */
-export const speakerSelectionSupported = !isSafari() && !isIOS();
-
-/**
  * The audio output devices to choose from.
  *
  * `undefined` means "not enumerated yet" and nothing else: an unsupported browser yields an empty
@@ -1411,26 +1405,6 @@ export const speakerListStore = derived(deviceListStore, ($deviceListStore) => {
     }
 
     return removeDuplicateDevices($deviceListStore.filter((device) => device.kind === "audiooutput"));
-});
-
-export const speakerSelectedStore = writable<string | undefined>(localUserStore.getSpeakerDeviceId() ?? undefined);
-
-/**
- * The output device that was actually applied, as reported by `setSinkId`.
- *
- * Mirrors `usedCameraDeviceIdStore` / `usedMicrophoneDeviceIdStore`. It stays `undefined` until
- * something plays, since nothing routes audio before then; once set, a value differing from
- * `speakerSelectedStore` means the browser refused the selection and fell back.
- */
-export const usedSpeakerDeviceIdStore: Writable<string | undefined> = writable();
-
-// A freshly picked device has not been applied to anything yet. Without this reset the previous
-// value would linger and read as a mismatch, so the UI would claim the browser refused a device it
-// never even tried.
-// This is a singleton so no need to unsubscribe
-// eslint-disable-next-line svelte/no-ignored-unsubscribe
-speakerSelectedStore.subscribe(() => {
-    usedSpeakerDeviceIdStore.set(undefined);
 });
 
 export const selectDefaultSpeaker = () => {

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -49,7 +49,12 @@ import {
 } from "./LocalStreamTypes";
 import { NoiseSuppressionController } from "./NoiseSuppressionController";
 import { buildMicrophoneAudioConstraints } from "./MicrophoneSettings";
-import { speakerSelectedStore, speakerSelectionSupported } from "./AudioOutputStore";
+import {
+    applyDefaultSpeaker,
+    reconcileSpeakerSelection,
+    speakerSelectedStore,
+    speakerSelectionSupported,
+} from "./AudioOutputStore";
 import { audioPlaybackStore } from "./AudioPlaybackStore";
 import { browserNotificationStore } from "./BrowserNotificationStore";
 
@@ -1408,33 +1413,13 @@ export const speakerListStore = derived(deviceListStore, ($deviceListStore) => {
 });
 
 export const selectDefaultSpeaker = () => {
-    const devices = get(speakerListStore);
-    const deviceId = devices !== undefined && devices.length > 0 ? devices[0].deviceId : "";
-    // Persist the fallback too. Otherwise the subscriber below restores the previous preference on
-    // the next devicechange, and a device that always fails setSinkId gets re-applied in a loop:
-    // apply, fail, fall back, restore, apply again.
-    localUserStore.setSpeakerDeviceId(deviceId);
-    speakerSelectedStore.set(deviceId);
+    applyDefaultSpeaker(get(speakerListStore));
 };
 
 // This is a singleton so no need to unsubscribe
 //eslint-disable-next-line svelte/no-ignored-unsubscribe
 speakerListStore.subscribe((devices) => {
-    if (devices === undefined || !speakerSelectionSupported) {
-        return;
-    }
-    // An empty list is "we cannot see the outputs yet", not "the chosen device is gone": browsers
-    // report no audio output before permission is granted. Falling back here would persist an empty
-    // selection and destroy a perfectly valid stored preference before it ever got a chance.
-    if (devices.length === 0) {
-        return;
-    }
-    // if the previous speaker used isn`t defined in the list, apply default speaker
-    const previousSpeakerId = get(speakerSelectedStore);
-    const previousAudioOutputDevice = devices.find((device) => device.deviceId === previousSpeakerId);
-    if (previousAudioOutputDevice === undefined) {
-        selectDefaultSpeaker();
-    }
+    reconcileSpeakerSelection(devices);
 });
 
 let previousMediaDevices: MediaDeviceInfo[] | undefined = undefined;

--- a/play/src/front/WebRtc/AudioContextManager.ts
+++ b/play/src/front/WebRtc/AudioContextManager.ts
@@ -1,3 +1,6 @@
+import type { Unsubscriber } from "svelte/store";
+import { bindAudioContextOutput } from "./AudioOutputManager";
+
 export interface AudioContextProbe {
     readonly isPlaybackAvailable: boolean;
     resume: () => Promise<void>;
@@ -13,6 +16,8 @@ export interface AudioContextProbe {
  */
 class AudioContextManager {
     private audioContexts: Map<number, AudioContext> = new Map();
+    /** One per context: keeps it on the user's selected audio output for as long as it lives. */
+    private sinkUnbinders: Map<number, Unsubscriber> = new Map();
     private isShuttingDown = false;
 
     /**
@@ -35,6 +40,10 @@ class AudioContextManager {
             const options = sampleRate ? { sampleRate } : undefined;
             context = new AudioContext(options);
             this.audioContexts.set(key, context);
+            // Everything played through a context — the WebAudio playback fallback, the scripting
+            // API's PCM streams — bypasses media elements, so it needs its own routing to follow
+            // the selected output instead of always landing on the system default.
+            this.sinkUnbinders.set(key, bindAudioContextOutput(context));
             console.debug(
                 `[AudioContextManager] Created new AudioContext with ${
                     sampleRate ? `sample rate ${sampleRate}` : "default sample rate"
@@ -57,6 +66,7 @@ class AudioContextManager {
         if (context && context.state !== "closed") {
             // Remove from map before closing to prevent concurrent access
             this.audioContexts.delete(key);
+            this.unbindSink(key);
             try {
                 await context.close();
                 console.debug(`[AudioContextManager] Closed AudioContext with key ${key}`);
@@ -64,8 +74,14 @@ class AudioContextManager {
                 console.error(`[AudioContextManager] Error closing AudioContext with key ${key}:`, err);
                 // Re-add to map if close failed
                 this.audioContexts.set(key, context);
+                this.sinkUnbinders.set(key, bindAudioContextOutput(context));
             }
         }
+    }
+
+    private unbindSink(key: number): void {
+        this.sinkUnbinders.get(key)?.();
+        this.sinkUnbinders.delete(key);
     }
 
     /**
@@ -89,6 +105,8 @@ class AudioContextManager {
         await Promise.all(closePromises);
         // Clear the map after all contexts are closed
         this.audioContexts.clear();
+        this.sinkUnbinders.forEach((unbind) => unbind());
+        this.sinkUnbinders.clear();
         console.debug("[AudioContextManager] All AudioContexts closed");
     }
 

--- a/play/src/front/WebRtc/AudioOutputManager.ts
+++ b/play/src/front/WebRtc/AudioOutputManager.ts
@@ -2,6 +2,7 @@ import Debug from "debug";
 import * as Sentry from "@sentry/svelte";
 import { get } from "svelte/store";
 import { bubbleSoundStore } from "../Stores/AudioManagerStore";
+import { usedSpeakerDeviceIdStore } from "../Stores/MediaStore";
 
 const debug = Debug("AudioOutput");
 
@@ -38,12 +39,14 @@ export async function applySinkId(el: HTMLMediaElement, deviceId: string | undef
         return false;
     }
     if (el.sinkId === deviceId) {
+        usedSpeakerDeviceIdStore.set(deviceId);
         return true;
     }
 
     try {
         await el.setSinkId(deviceId);
         debug("Audio output set to %s", deviceId);
+        usedSpeakerDeviceIdStore.set(deviceId);
         return true;
     } catch (e) {
         Sentry.captureException(e);
@@ -53,6 +56,7 @@ export async function applySinkId(el: HTMLMediaElement, deviceId: string | undef
             console.warn("Error setting the audio output device. We fallback to default.", e);
             try {
                 await el.setSinkId("");
+                usedSpeakerDeviceIdStore.set("");
             } catch (fallbackError) {
                 console.error("Error resetting the audio output device: ", fallbackError);
             }

--- a/play/src/front/WebRtc/AudioOutputManager.ts
+++ b/play/src/front/WebRtc/AudioOutputManager.ts
@@ -2,8 +2,10 @@ import Debug from "debug";
 import * as Sentry from "@sentry/svelte";
 import { get } from "svelte/store";
 import type { Unsubscriber } from "svelte/store";
-import { bubbleSoundStore } from "../Stores/AudioManagerStore";
-import { speakerSelectedStore, usedSpeakerDeviceIdStore } from "../Stores/MediaStore";
+import { localUserStore } from "../Connection/LocalUserStore";
+// Imported from the leaf store module, not MediaStore: this module is reached from
+// AudioContextManager, which MediaStore pulls in through SoundMeter.
+import { speakerSelectedStore, usedSpeakerDeviceIdStore } from "../Stores/AudioOutputStore";
 
 const debug = Debug("AudioOutput");
 
@@ -193,7 +195,9 @@ async function runTestSound(deviceId: string | undefined): Promise<void> {
     }
     const el = testAudioElement;
 
-    const url = getBubbleSoundUrl(get(bubbleSoundStore));
+    // Read from local storage rather than bubbleSoundStore: that store lives in AudioManagerStore,
+    // which is not a leaf, and both are always written together.
+    const url = getBubbleSoundUrl(localUserStore.getBubbleSound());
     if (testAudioElementUrl !== url) {
         testAudioElementUrl = url;
         el.src = url;

--- a/play/src/front/WebRtc/AudioOutputManager.ts
+++ b/play/src/front/WebRtc/AudioOutputManager.ts
@@ -1,0 +1,111 @@
+import Debug from "debug";
+import * as Sentry from "@sentry/svelte";
+import { get } from "svelte/store";
+import { bubbleSoundStore } from "../Stores/AudioManagerStore";
+
+const debug = Debug("AudioOutput");
+
+/**
+ * Volume used for the "test your audio output" sound. Louder than the in-game bubble sound
+ * (played at 0.2) because the point of the test is to be unambiguously audible.
+ */
+const TEST_SOUND_VOLUME = 0.5;
+
+/**
+ * URL of the sound played when entering a bubble. The file must exist under `public/`:
+ * only the `-ding` and `-wobble` variants do.
+ */
+export function getBubbleSoundUrl(bubbleSound: string): string {
+    return `/resources/objects/webrtc-in-${bubbleSound}.mp3`;
+}
+
+/**
+ * Routes a media element to a given audio output device.
+ *
+ * `deviceId` is an empty string for "system default", which is a meaningful value: it resets an
+ * element that was previously pinned to a specific sink. Only `undefined` means "nothing to do".
+ *
+ * Returns whether the sink is now the requested one. `false` covers the browsers that do not
+ * implement the Audio Output Devices API at all (Firefox before 116, Safari), where callers are
+ * expected to carry on with the system default rather than fail.
+ */
+export async function applySinkId(el: HTMLMediaElement, deviceId: string | undefined): Promise<boolean> {
+    if (deviceId === undefined) {
+        return false;
+    }
+    if (typeof el.setSinkId !== "function") {
+        debug("setSinkId is not supported by this browser, keeping the system default output");
+        return false;
+    }
+    if (el.sinkId === deviceId) {
+        return true;
+    }
+
+    try {
+        await el.setSinkId(deviceId);
+        debug("Audio output set to %s", deviceId);
+        return true;
+    } catch (e) {
+        Sentry.captureException(e);
+        if (e instanceof DOMException && e.name === "AbortError") {
+            // The device went away between enumeration and use. Fall back to the system default so
+            // the caller still produces sound.
+            console.warn("Error setting the audio output device. We fallback to default.", e);
+            try {
+                await el.setSinkId("");
+            } catch (fallbackError) {
+                console.error("Error resetting the audio output device: ", fallbackError);
+            }
+            return false;
+        }
+        console.error("Error setting the audio output device: ", e);
+        return false;
+    }
+}
+
+/**
+ * Single element reused across every test, so that repeated clicks restart the sound instead of
+ * stacking up `<audio>` elements (and overlapping sounds).
+ */
+let testAudioElement: HTMLAudioElement | undefined;
+let testAudioElementUrl: string | undefined;
+/** Serializes overlapping clicks: setSinkId and play() must not interleave across two runs. */
+let testSoundQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Plays a short sound on `deviceId` so the user can check which device they actually selected.
+ *
+ * The sink is applied *before* `play()`: Chrome ignores a sink set on an already-playing element.
+ */
+export function playTestSound(deviceId: string | undefined): Promise<void> {
+    testSoundQueue = testSoundQueue.then(() => runTestSound(deviceId)).catch(() => {});
+    return testSoundQueue;
+}
+
+async function runTestSound(deviceId: string | undefined): Promise<void> {
+    if (!testAudioElement) {
+        testAudioElement = new Audio();
+        testAudioElement.preload = "auto";
+    }
+    const el = testAudioElement;
+
+    const url = getBubbleSoundUrl(get(bubbleSoundStore));
+    if (testAudioElementUrl !== url) {
+        testAudioElementUrl = url;
+        el.src = url;
+    }
+    el.volume = TEST_SOUND_VOLUME;
+
+    await applySinkId(el, deviceId);
+
+    el.pause();
+    el.currentTime = 0;
+    try {
+        await el.play();
+    } catch (e) {
+        // Autoplay policies should not bite here (the sound follows a click), so a failure is worth
+        // reporting rather than swallowing.
+        console.error("Could not play the audio output test sound: ", e);
+        Sentry.captureException(e);
+    }
+}

--- a/play/src/front/WebRtc/AudioOutputManager.ts
+++ b/play/src/front/WebRtc/AudioOutputManager.ts
@@ -1,8 +1,9 @@
 import Debug from "debug";
 import * as Sentry from "@sentry/svelte";
 import { get } from "svelte/store";
+import type { Unsubscriber } from "svelte/store";
 import { bubbleSoundStore } from "../Stores/AudioManagerStore";
-import { usedSpeakerDeviceIdStore } from "../Stores/MediaStore";
+import { speakerSelectedStore, usedSpeakerDeviceIdStore } from "../Stores/MediaStore";
 
 const debug = Debug("AudioOutput");
 
@@ -21,49 +22,150 @@ export function getBubbleSoundUrl(bubbleSound: string): string {
 }
 
 /**
+ * What became of a routing attempt.
+ *
+ * Callers must tell these apart: `fell-back-to-default` means the device is gone and the selection
+ * is worth revisiting, while `unsupported` merely means this browser has no Audio Output Devices
+ * API — dropping the user's preference there would be wrong.
+ */
+export type SinkOutcome = "applied" | "unsupported" | "fell-back-to-default" | "failed";
+
+/**
+ * Serializes routing per target. `setSinkId` is asynchronous, so two calls racing on the same
+ * element can settle in reverse order and leave it on the wrong device.
+ */
+const sinkQueues = new WeakMap<object, Promise<unknown>>();
+
+function enqueue<T>(target: object, task: () => Promise<T>): Promise<T> {
+    const previous = sinkQueues.get(target) ?? Promise.resolve();
+    // Run `task` whether the previous one resolved or rejected: a failure must not wedge the queue.
+    const result = previous.then(task, task);
+    sinkQueues.set(
+        target,
+        result.catch(() => undefined),
+    );
+    return result;
+}
+
+/**
  * Routes a media element to a given audio output device.
  *
  * `deviceId` is an empty string for "system default", which is a meaningful value: it resets an
  * element that was previously pinned to a specific sink. Only `undefined` means "nothing to do".
- *
- * Returns whether the sink is now the requested one. `false` covers the browsers that do not
- * implement the Audio Output Devices API at all (Firefox before 116, Safari), where callers are
- * expected to carry on with the system default rather than fail.
  */
-export async function applySinkId(el: HTMLMediaElement, deviceId: string | undefined): Promise<boolean> {
+export function applySinkId(el: HTMLMediaElement, deviceId: string | undefined): Promise<SinkOutcome> {
     if (deviceId === undefined) {
-        return false;
+        return Promise.resolve("failed");
     }
     if (typeof el.setSinkId !== "function") {
         debug("setSinkId is not supported by this browser, keeping the system default output");
-        return false;
+        return Promise.resolve("unsupported");
     }
-    if (el.sinkId === deviceId) {
-        usedSpeakerDeviceIdStore.set(deviceId);
-        return true;
+    // Bound up front: the narrowing above does not survive into the async closure below.
+    const setSinkId = el.setSinkId.bind(el);
+
+    return enqueue(el, async (): Promise<SinkOutcome> => {
+        if (el.sinkId === deviceId) {
+            usedSpeakerDeviceIdStore.set(deviceId);
+            return "applied";
+        }
+
+        try {
+            await setSinkId(deviceId);
+            debug("Audio output set to %s", deviceId);
+            usedSpeakerDeviceIdStore.set(deviceId);
+            return "applied";
+        } catch (e) {
+            Sentry.captureException(e);
+            if (e instanceof DOMException && e.name === "AbortError") {
+                // The device went away between enumeration and use. Fall back to the system default
+                // so the caller still produces sound.
+                console.warn("Error setting the audio output device. We fallback to default.", e);
+                try {
+                    await setSinkId("");
+                    usedSpeakerDeviceIdStore.set("");
+                } catch (fallbackError) {
+                    console.error("Error resetting the audio output device: ", fallbackError);
+                }
+                return "fell-back-to-default";
+            }
+            console.error("Error setting the audio output device: ", e);
+            return "failed";
+        }
+    });
+}
+
+/**
+ * Keeps a media element on the selected audio output, now and whenever the selection changes.
+ * Returns an unsubscriber the caller must invoke on teardown.
+ */
+export function bindAudioOutput(el: HTMLMediaElement): Unsubscriber {
+    return speakerSelectedStore.subscribe((deviceId) => {
+        applySinkId(el, deviceId).catch((e: unknown) => {
+            console.error("Error routing a media element to the selected audio output: ", e);
+            Sentry.captureException(e);
+        });
+    });
+}
+
+/**
+ * Svelte action form of {@link bindAudioOutput}, for elements declared in a template:
+ * `<audio use:audioOutput>`.
+ */
+export function audioOutput(node: HTMLMediaElement): { destroy: () => void } {
+    const unsubscribe = bindAudioOutput(node);
+    return { destroy: unsubscribe };
+}
+
+/**
+ * Routes an AudioContext to the selected audio output (Chrome 110+), for sound that never goes
+ * through a media element: the Phaser sound manager, the WebAudio playback fallback, and the
+ * scripting API's PCM streams.
+ *
+ * Unlike {@link applySinkId} this does not feed `usedSpeakerDeviceIdStore`: browsers can support
+ * one API and not the other, and the settings UI reports on media elements.
+ */
+export function bindAudioContextOutput(context: AudioContext): Unsubscriber {
+    if (typeof context.setSinkId !== "function") {
+        debug("AudioContext.setSinkId is not supported by this browser, keeping the system default output");
+        return () => {};
     }
 
-    try {
-        await el.setSinkId(deviceId);
-        debug("Audio output set to %s", deviceId);
-        usedSpeakerDeviceIdStore.set(deviceId);
-        return true;
-    } catch (e) {
-        Sentry.captureException(e);
-        if (e instanceof DOMException && e.name === "AbortError") {
-            // The device went away between enumeration and use. Fall back to the system default so
-            // the caller still produces sound.
-            console.warn("Error setting the audio output device. We fallback to default.", e);
-            try {
-                await el.setSinkId("");
-                usedSpeakerDeviceIdStore.set("");
-            } catch (fallbackError) {
-                console.error("Error resetting the audio output device: ", fallbackError);
-            }
-            return false;
+    return speakerSelectedStore.subscribe((deviceId) => {
+        if (deviceId === undefined) {
+            return;
         }
-        console.error("Error setting the audio output device: ", e);
-        return false;
+        enqueue(context, async () => {
+            try {
+                // Reading back the current sink is not portable, so this always re-applies.
+                await context.setSinkId?.(deviceId);
+                debug("AudioContext output set to %s", deviceId);
+            } catch (e) {
+                // Not fatal: the context keeps playing on the previous (or default) device.
+                console.warn("Could not set the AudioContext output device: ", e);
+                Sentry.captureException(e);
+            }
+        }).catch((e: unknown) => Sentry.captureException(e));
+    });
+}
+
+/**
+ * Plays a one-shot sound (notification, announcement) on the selected audio output.
+ *
+ * The sink is applied *before* `play()`: Chrome ignores a sink set on an already-playing element.
+ */
+export async function playNotificationSound(url: string, volume = 1): Promise<void> {
+    const el = new Audio(url);
+    el.volume = volume;
+
+    await applySinkId(el, get(speakerSelectedStore));
+
+    try {
+        await el.play();
+    } catch (e) {
+        // Usually an autoplay policy rejection when no user gesture happened yet. Worth reporting,
+        // but never worth breaking the caller over.
+        console.warn("Could not play sound: ", url, e);
     }
 }
 
@@ -73,13 +175,11 @@ export async function applySinkId(el: HTMLMediaElement, deviceId: string | undef
  */
 let testAudioElement: HTMLAudioElement | undefined;
 let testAudioElementUrl: string | undefined;
-/** Serializes overlapping clicks: setSinkId and play() must not interleave across two runs. */
+/** Serializes overlapping clicks: pause/rewind/play must not interleave across two runs. */
 let testSoundQueue: Promise<void> = Promise.resolve();
 
 /**
  * Plays a short sound on `deviceId` so the user can check which device they actually selected.
- *
- * The sink is applied *before* `play()`: Chrome ignores a sink set on an already-playing element.
  */
 export function playTestSound(deviceId: string | undefined): Promise<void> {
     testSoundQueue = testSoundQueue.then(() => runTestSound(deviceId)).catch(() => {});

--- a/play/src/front/WebRtc/DeviceUtils.ts
+++ b/play/src/front/WebRtc/DeviceUtils.ts
@@ -32,8 +32,19 @@ export function isFirefox(): boolean {
     return window.navigator.userAgent.toLowerCase().indexOf("firefox") !== -1;
 }
 
+/**
+ * Detects Safari without going through `getNavigatorType`, which throws on any user agent that is
+ * none of Firefox / Chrome / Safari (embedded browsers, webviews). This one must never throw: it is
+ * called at module evaluation time (see `speakerSelectionSupported` in MediaStore), where an
+ * exception would take the whole media pipeline down with it.
+ *
+ * Every Chromium browser also carries "Safari" in its user agent, hence the exclusions. On iOS,
+ * Chrome and Firefox are WebKit under the hood and share Safari's limitations, but they are covered
+ * by `isIOS()` rather than here.
+ */
 export function isSafari(): boolean {
-    return getNavigatorType() === NavigatorType.safari;
+    const userAgent = window.navigator.userAgent;
+    return /Safari/i.test(userAgent) && !/Chrome|Chromium|Android|CriOS|FxiOS|EdgiOS|OPiOS/i.test(userAgent);
 }
 
 export function isMac(): boolean {

--- a/play/src/front/webrtc.d.ts
+++ b/play/src/front/webrtc.d.ts
@@ -1,3 +1,9 @@
 declare interface HTMLMediaElement {
     setSinkId?: (sinkId: string) => Promise<void>;
 }
+
+// Audio Output Devices API on AudioContext (Chrome 110+). Absent from the TypeScript DOM lib, and
+// optional because Firefox and Safari do not implement it.
+declare interface AudioContext {
+    setSinkId?: (sinkId: string) => Promise<void>;
+}

--- a/play/src/i18n/ar-SA/actionbar.ts
+++ b/play/src/i18n/ar-SA/actionbar.ts
@@ -52,6 +52,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "تجاهل",
     },
     speaker: {
+        test: "اختبار مخرج الصوت",
         disabled: "مكبر الصوت معطل",
         activate: "قم بتنشيط مكبر الصوت",
         noDevices: "لم يتم العثور على جهاز مكبر صوت",

--- a/play/src/i18n/ar-SA/actionbar.ts
+++ b/play/src/i18n/ar-SA/actionbar.ts
@@ -53,6 +53,10 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "اختبار مخرج الصوت",
+        unnamedDevice: "مخرج الصوت {index}",
+        loading: "جارٍ البحث عن مخارج الصوت…",
+        unsupported: "لا يتيح هذا المتصفح اختيار مخرج الصوت. يُشغَّل الصوت على الجهاز المحدد في إعدادات النظام.",
+        fallbackInUse: "رفض متصفحك هذا الجهاز. يُشغَّل الصوت على الجهاز الافتراضي للنظام.",
         disabled: "مكبر الصوت معطل",
         activate: "قم بتنشيط مكبر الصوت",
         noDevices: "لم يتم العثور على جهاز مكبر صوت",

--- a/play/src/i18n/ca-ES/actionbar.ts
+++ b/play/src/i18n/ca-ES/actionbar.ts
@@ -54,6 +54,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "Ignora",
     },
     speaker: {
+        test: "Prova la sortida d'àudio",
         disabled: "El teu altaveu està desactivat",
         activate: "Activar el teu altaveu",
         noDevices: "No s'ha trobat cap dispositiu d'altaveu",

--- a/play/src/i18n/ca-ES/actionbar.ts
+++ b/play/src/i18n/ca-ES/actionbar.ts
@@ -55,6 +55,12 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "Prova la sortida d'àudio",
+        unnamedDevice: "Sortida d'àudio {index}",
+        loading: "S'estan cercant sortides d'àudio…",
+        unsupported:
+            "Aquest navegador no permet triar la sortida d'àudio. El so es reprodueix al dispositiu seleccionat a la configuració del sistema.",
+        fallbackInUse:
+            "El navegador ha rebutjat aquest dispositiu. El so es reprodueix al dispositiu predeterminat del sistema.",
         disabled: "El teu altaveu està desactivat",
         activate: "Activar el teu altaveu",
         noDevices: "No s'ha trobat cap dispositiu d'altaveu",

--- a/play/src/i18n/de-DE/actionbar.ts
+++ b/play/src/i18n/de-DE/actionbar.ts
@@ -57,6 +57,12 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "Audioausgabe testen",
+        unnamedDevice: "Audioausgabe {index}",
+        loading: "Audioausgaben werden gesucht …",
+        unsupported:
+            "In diesem Browser lässt sich die Audioausgabe nicht auswählen. Der Ton wird über das in den Systemeinstellungen gewählte Gerät wiedergegeben.",
+        fallbackInUse:
+            "Dein Browser hat dieses Gerät abgelehnt. Der Ton wird über das Standardgerät des Systems wiedergegeben.",
         disabled: "Ihr Lautsprecher ist deaktiviert",
         activate: "Lautsprecher aktivieren",
         noDevices: "Kein Lautsprecher gefunden",

--- a/play/src/i18n/de-DE/actionbar.ts
+++ b/play/src/i18n/de-DE/actionbar.ts
@@ -56,6 +56,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "Ignorieren",
     },
     speaker: {
+        test: "Audioausgabe testen",
         disabled: "Ihr Lautsprecher ist deaktiviert",
         activate: "Lautsprecher aktivieren",
         noDevices: "Kein Lautsprecher gefunden",

--- a/play/src/i18n/dsb-DE/actionbar.ts
+++ b/play/src/i18n/dsb-DE/actionbar.ts
@@ -54,6 +54,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "Ignorěrowaś",
     },
     speaker: {
+        test: "Awdiowuchod testowaś",
         disabled: "Waš głośnik jo deaktiwěrowany",
         activate: "Waš głośnik aktiwěrowaś",
         noDevices: "Žedne głośnikowe rědy namakane",

--- a/play/src/i18n/dsb-DE/actionbar.ts
+++ b/play/src/i18n/dsb-DE/actionbar.ts
@@ -55,6 +55,11 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "Awdiowuchod testowaś",
+        unnamedDevice: "Awdiowuchod {index}",
+        loading: "Pyta se za awdiowuchodami …",
+        unsupported:
+            "Toś ten wobglědowak njedopušća wuběrk awdiowuchoda. Zuk se wótgrawa pśez rěd, kótaryž jo w systemowych nastajenjach wubrany.",
+        fallbackInUse: "Twój wobglědowak jo toś ten rěd wótpokazał. Zuk se wótgrawa pśez standardny rěd systema.",
         disabled: "Waš głośnik jo deaktiwěrowany",
         activate: "Waš głośnik aktiwěrowaś",
         noDevices: "Žedne głośnikowe rědy namakane",

--- a/play/src/i18n/en-US/actionbar.ts
+++ b/play/src/i18n/en-US/actionbar.ts
@@ -55,6 +55,7 @@ const actionbar: BaseTranslation = {
     speaker: {
         disabled: "Your speaker is disabled",
         activate: "Activate your speaker",
+        test: "Test audio output",
         noDevices: "No speaker device found",
         noDevicesDesc:
             "Your browser does not list any selectable audio output. Some browsers limit this (for example Safari). Try another browser, reconnect headphones or speakers, check your system sound settings and your computer's configuration (privacy, devices).",

--- a/play/src/i18n/en-US/actionbar.ts
+++ b/play/src/i18n/en-US/actionbar.ts
@@ -56,6 +56,11 @@ const actionbar: BaseTranslation = {
         disabled: "Your speaker is disabled",
         activate: "Activate your speaker",
         test: "Test audio output",
+        unnamedDevice: "Audio output {index}",
+        loading: "Looking for audio outputs…",
+        unsupported:
+            "This browser does not let you choose an audio output. Sound plays on the device selected in your system settings.",
+        fallbackInUse: "Your browser refused this device. Sound is playing on the system default.",
         noDevices: "No speaker device found",
         noDevicesDesc:
             "Your browser does not list any selectable audio output. Some browsers limit this (for example Safari). Try another browser, reconnect headphones or speakers, check your system sound settings and your computer's configuration (privacy, devices).",

--- a/play/src/i18n/es-ES/actionbar.ts
+++ b/play/src/i18n/es-ES/actionbar.ts
@@ -54,6 +54,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "Ignorar",
     },
     speaker: {
+        test: "Probar la salida de audio",
         disabled: "Tu altavoz está desactivado",
         activate: "Activar tu altavoz",
         noDevices: "No se encontró ningún dispositivo de altavoz",

--- a/play/src/i18n/es-ES/actionbar.ts
+++ b/play/src/i18n/es-ES/actionbar.ts
@@ -55,6 +55,12 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "Probar la salida de audio",
+        unnamedDevice: "Salida de audio {index}",
+        loading: "Buscando salidas de audio…",
+        unsupported:
+            "Este navegador no permite elegir la salida de audio. El sonido se reproduce en el dispositivo seleccionado en la configuración del sistema.",
+        fallbackInUse:
+            "Tu navegador ha rechazado este dispositivo. El sonido se reproduce en el dispositivo predeterminado del sistema.",
         disabled: "Tu altavoz está desactivado",
         activate: "Activar tu altavoz",
         noDevices: "No se encontró ningún dispositivo de altavoz",

--- a/play/src/i18n/fr-FR/actionbar.ts
+++ b/play/src/i18n/fr-FR/actionbar.ts
@@ -56,6 +56,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "Ignorer",
     },
     speaker: {
+        test: "Tester la sortie audio",
         disabled: "Votre haut-parleur est désactivé",
         activate: "Activer votre haut-parleur",
         noDevices: "Aucun haut-parleur trouvé",

--- a/play/src/i18n/fr-FR/actionbar.ts
+++ b/play/src/i18n/fr-FR/actionbar.ts
@@ -57,6 +57,12 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "Tester la sortie audio",
+        unnamedDevice: "Sortie audio {index}",
+        loading: "Recherche des sorties audio…",
+        unsupported:
+            "Ce navigateur ne permet pas de choisir la sortie audio. Le son est joué sur le périphérique sélectionné dans les réglages du système.",
+        fallbackInUse:
+            "Votre navigateur a refusé ce périphérique. Le son est joué sur la sortie par défaut du système.",
         disabled: "Votre haut-parleur est désactivé",
         activate: "Activer votre haut-parleur",
         noDevices: "Aucun haut-parleur trouvé",

--- a/play/src/i18n/hsb-DE/actionbar.ts
+++ b/play/src/i18n/hsb-DE/actionbar.ts
@@ -54,6 +54,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "Ignorować",
     },
     speaker: {
+        test: "Awdiowuchod testować",
         disabled: "Waš wótřerěčak je deaktiwowany",
         activate: "Waš wótřerěčak aktiwěrować",
         noDevices: "Žane wótřerěčakowe graty namakane",

--- a/play/src/i18n/hsb-DE/actionbar.ts
+++ b/play/src/i18n/hsb-DE/actionbar.ts
@@ -55,6 +55,11 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "Awdiowuchod testować",
+        unnamedDevice: "Awdiowuchod {index}",
+        loading: "Pyta so za awdiowuchodami …",
+        unsupported:
+            "Tutón wobhladowak njedowoluje wuběr awdiowuchoda. Zynk so přez grat wothrawa, kotryž je w systemowych nastajenjach wubrany.",
+        fallbackInUse: "Twój wobhladowak je tutón grat wotpokazał. Zynk so přez standardny grat systema wothrawa.",
         disabled: "Waš wótřerěčak je deaktiwowany",
         activate: "Waš wótřerěčak aktiwěrować",
         noDevices: "Žane wótřerěčakowe graty namakane",

--- a/play/src/i18n/it-IT/actionbar.ts
+++ b/play/src/i18n/it-IT/actionbar.ts
@@ -54,6 +54,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "Ignora",
     },
     speaker: {
+        test: "Prova l'uscita audio",
         disabled: "Il tuo altoparlante è disabilitato",
         activate: "Attiva il tuo altoparlante",
         noDevices: "Nessun dispositivo altoparlante trovato",

--- a/play/src/i18n/it-IT/actionbar.ts
+++ b/play/src/i18n/it-IT/actionbar.ts
@@ -55,6 +55,12 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "Prova l'uscita audio",
+        unnamedDevice: "Uscita audio {index}",
+        loading: "Ricerca delle uscite audio…",
+        unsupported:
+            "Questo browser non consente di scegliere l'uscita audio. L'audio viene riprodotto sul dispositivo selezionato nelle impostazioni di sistema.",
+        fallbackInUse:
+            "Il browser ha rifiutato questo dispositivo. L'audio viene riprodotto sul dispositivo predefinito del sistema.",
         disabled: "Il tuo altoparlante è disabilitato",
         activate: "Attiva il tuo altoparlante",
         noDevices: "Nessun dispositivo altoparlante trovato",

--- a/play/src/i18n/ja-JP/actionbar.ts
+++ b/play/src/i18n/ja-JP/actionbar.ts
@@ -53,6 +53,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "無視",
     },
     speaker: {
+        test: "音声出力をテスト",
         disabled: "スピーカーが無効になっています",
         activate: "スピーカーを有効にする",
         noDevices: "スピーカーデバイスが見つかりません",

--- a/play/src/i18n/ja-JP/actionbar.ts
+++ b/play/src/i18n/ja-JP/actionbar.ts
@@ -54,6 +54,10 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "音声出力をテスト",
+        unnamedDevice: "音声出力 {index}",
+        loading: "音声出力を検索中…",
+        unsupported: "このブラウザでは音声出力を選択できません。システム設定で選択されたデバイスで再生されます。",
+        fallbackInUse: "ブラウザがこのデバイスを拒否しました。システムの既定のデバイスで再生されています。",
         disabled: "スピーカーが無効になっています",
         activate: "スピーカーを有効にする",
         noDevices: "スピーカーデバイスが見つかりません",

--- a/play/src/i18n/ko-KR/actionbar.ts
+++ b/play/src/i18n/ko-KR/actionbar.ts
@@ -54,6 +54,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "무시",
     },
     speaker: {
+        test: "오디오 출력 테스트",
         disabled: "스피커가 비활성화되어 있습니다",
         activate: "스피커 활성화",
         noDevices: "사용 가능한 스피커 장치를 찾을 수 없습니다",

--- a/play/src/i18n/ko-KR/actionbar.ts
+++ b/play/src/i18n/ko-KR/actionbar.ts
@@ -55,6 +55,11 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "오디오 출력 테스트",
+        unnamedDevice: "오디오 출력 {index}",
+        loading: "오디오 출력을 찾는 중…",
+        unsupported:
+            "이 브라우저에서는 오디오 출력을 선택할 수 없습니다. 시스템 설정에서 선택한 장치로 소리가 재생됩니다.",
+        fallbackInUse: "브라우저가 이 장치를 거부했습니다. 시스템 기본 장치로 소리가 재생됩니다.",
         disabled: "스피커가 비활성화되어 있습니다",
         activate: "스피커 활성화",
         noDevices: "사용 가능한 스피커 장치를 찾을 수 없습니다",

--- a/play/src/i18n/nl-NL/actionbar.ts
+++ b/play/src/i18n/nl-NL/actionbar.ts
@@ -56,6 +56,12 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "Audio-uitvoer testen",
+        unnamedDevice: "Audio-uitvoer {index}",
+        loading: "Audio-uitvoerapparaten zoeken…",
+        unsupported:
+            "In deze browser kun je geen audio-uitvoer kiezen. Het geluid speelt af op het apparaat dat in je systeeminstellingen is geselecteerd.",
+        fallbackInUse:
+            "Je browser heeft dit apparaat geweigerd. Het geluid speelt af op het standaardapparaat van het systeem.",
         disabled: "Je luidspreker is uitgeschakeld",
         activate: "Activeer je luidspreker",
         noDevices: "Geen luidsprekerapparaat gevonden",

--- a/play/src/i18n/nl-NL/actionbar.ts
+++ b/play/src/i18n/nl-NL/actionbar.ts
@@ -55,6 +55,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "Negeren",
     },
     speaker: {
+        test: "Audio-uitvoer testen",
         disabled: "Je luidspreker is uitgeschakeld",
         activate: "Activeer je luidspreker",
         noDevices: "Geen luidsprekerapparaat gevonden",

--- a/play/src/i18n/pt-BR/actionbar.ts
+++ b/play/src/i18n/pt-BR/actionbar.ts
@@ -58,6 +58,7 @@ const actionbar: BaseTranslation = {
         ignore: "Ignorar",
     },
     speaker: {
+        test: "Testar a saída de áudio",
         disabled: "Seu alto-falante está desabilitado",
         activate: "Ativar seu alto-falante",
         noDevices: "Nenhum dispositivo de alto-falante encontrado",

--- a/play/src/i18n/pt-BR/actionbar.ts
+++ b/play/src/i18n/pt-BR/actionbar.ts
@@ -59,6 +59,12 @@ const actionbar: BaseTranslation = {
     },
     speaker: {
         test: "Testar a saída de áudio",
+        unnamedDevice: "Saída de áudio {index}",
+        loading: "Procurando saídas de áudio…",
+        unsupported:
+            "Este navegador não permite escolher a saída de áudio. O som é reproduzido no dispositivo selecionado nas configurações do sistema.",
+        fallbackInUse:
+            "Seu navegador recusou este dispositivo. O som está sendo reproduzido no dispositivo padrão do sistema.",
         disabled: "Seu alto-falante está desabilitado",
         activate: "Ativar seu alto-falante",
         noDevices: "Nenhum dispositivo de alto-falante encontrado",

--- a/play/src/i18n/zh-CN/actionbar.ts
+++ b/play/src/i18n/zh-CN/actionbar.ts
@@ -53,6 +53,10 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "测试音频输出",
+        unnamedDevice: "音频输出 {index}",
+        loading: "正在查找音频输出…",
+        unsupported: "此浏览器不支持选择音频输出。声音将通过系统设置中选定的设备播放。",
+        fallbackInUse: "浏览器拒绝了该设备。声音正通过系统默认设备播放。",
         disabled: "您的扬声器已禁用",
         activate: "激活您的扬声器",
         noDevices: "未找到扬声器设备",

--- a/play/src/i18n/zh-CN/actionbar.ts
+++ b/play/src/i18n/zh-CN/actionbar.ts
@@ -52,6 +52,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "忽略",
     },
     speaker: {
+        test: "测试音频输出",
         disabled: "您的扬声器已禁用",
         activate: "激活您的扬声器",
         noDevices: "未找到扬声器设备",

--- a/play/src/i18n/zh-TW/actionbar.ts
+++ b/play/src/i18n/zh-TW/actionbar.ts
@@ -53,6 +53,10 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     },
     speaker: {
         test: "測試音訊輸出",
+        unnamedDevice: "音訊輸出 {index}",
+        loading: "正在尋找音訊輸出…",
+        unsupported: "此瀏覽器不支援選擇音訊輸出。聲音會透過系統設定中選取的裝置播放。",
+        fallbackInUse: "瀏覽器拒絕了該裝置。聲音正透過系統預設裝置播放。",
         disabled: "您的喇叭已停用",
         activate: "啟用您的喇叭",
         noDevices: "找不到喇叭裝置",

--- a/play/src/i18n/zh-TW/actionbar.ts
+++ b/play/src/i18n/zh-TW/actionbar.ts
@@ -52,6 +52,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ignore: "忽略",
     },
     speaker: {
+        test: "測試音訊輸出",
         disabled: "您的喇叭已停用",
         activate: "啟用您的喇叭",
         noDevices: "找不到喇叭裝置",

--- a/play/tests/front/Stores/AudioOutputStore.test.ts
+++ b/play/tests/front/Stores/AudioOutputStore.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { get } from "svelte/store";
+
+/**
+ * Covers which output device gets picked and, just as importantly, what must never be overwritten.
+ *
+ * The module reads its initial value from local storage at import time, so every test reloads it.
+ */
+
+function audioOutput(deviceId: string, label = `Speaker ${deviceId}`): MediaDeviceInfo {
+    return { deviceId, label, kind: "audiooutput", groupId: "group" } as MediaDeviceInfo;
+}
+
+async function loadStore(storedDeviceId?: string) {
+    if (storedDeviceId !== undefined) {
+        localStorage.setItem("speakerDeviceId", storedDeviceId);
+    }
+    vi.resetModules();
+    return import("../../../src/front/Stores/AudioOutputStore");
+}
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+afterEach(() => {
+    localStorage.clear();
+});
+
+describe("applyDefaultSpeaker", () => {
+    it("picks the first device and persists it", async () => {
+        const stores = await loadStore();
+
+        stores.applyDefaultSpeaker([audioOutput("speaker-a"), audioOutput("speaker-b")]);
+
+        expect(get(stores.speakerSelectedStore)).toBe("speaker-a");
+        // Persisted, otherwise the device list subscriber restores the previous preference on the
+        // next devicechange and the fallback is undone straight away.
+        expect(localStorage.getItem("speakerDeviceId")).toBe("speaker-a");
+    });
+
+    it("falls back to the system default when there is no device", async () => {
+        const stores = await loadStore();
+
+        stores.applyDefaultSpeaker([]);
+
+        expect(get(stores.speakerSelectedStore)).toBe("");
+    });
+});
+
+describe("reconcileSpeakerSelection", () => {
+    it("keeps a selection that still exists", async () => {
+        const stores = await loadStore("speaker-b");
+
+        stores.reconcileSpeakerSelection([audioOutput("speaker-a"), audioOutput("speaker-b")]);
+
+        expect(get(stores.speakerSelectedStore)).toBe("speaker-b");
+    });
+
+    it("falls back when the selected device was unplugged", async () => {
+        const stores = await loadStore("speaker-b");
+
+        stores.reconcileSpeakerSelection([audioOutput("speaker-a")]);
+
+        expect(get(stores.speakerSelectedStore)).toBe("speaker-a");
+        expect(localStorage.getItem("speakerDeviceId")).toBe("speaker-a");
+    });
+
+    it("keeps the stored preference when no output is reported at all", async () => {
+        const stores = await loadStore("speaker-b");
+
+        stores.reconcileSpeakerSelection([]);
+
+        // An empty list means the browser will not tell us about outputs yet, typically because no
+        // permission was granted. Enumeration now happens before any getUserMedia, so treating this
+        // as "the device disappeared" would destroy a valid preference before it was ever used.
+        expect(get(stores.speakerSelectedStore)).toBe("speaker-b");
+        expect(localStorage.getItem("speakerDeviceId")).toBe("speaker-b");
+    });
+
+    it("does nothing while the device list is unknown", async () => {
+        const stores = await loadStore("speaker-b");
+
+        stores.reconcileSpeakerSelection(undefined);
+
+        expect(get(stores.speakerSelectedStore)).toBe("speaker-b");
+    });
+
+    it("restores the preference once its device comes back", async () => {
+        const stores = await loadStore("speaker-b");
+
+        stores.reconcileSpeakerSelection([audioOutput("speaker-a")]);
+        expect(get(stores.speakerSelectedStore)).toBe("speaker-a");
+
+        // Re-selecting by hand is what a user does after plugging the headset back in; the point
+        // here is that reconciling again does not undo it.
+        stores.speakerSelectedStore.set("speaker-b");
+        stores.reconcileSpeakerSelection([audioOutput("speaker-a"), audioOutput("speaker-b")]);
+
+        expect(get(stores.speakerSelectedStore)).toBe("speaker-b");
+    });
+});
+
+describe("usedSpeakerDeviceIdStore", () => {
+    it("is cleared whenever another device is picked", async () => {
+        const stores = await loadStore();
+        stores.usedSpeakerDeviceIdStore.set("speaker-a");
+
+        stores.speakerSelectedStore.set("speaker-b");
+
+        // Nothing has routed audio to the new device yet, so reporting the old one would read as a
+        // mismatch and make the settings panel claim a fallback that never happened.
+        expect(get(stores.usedSpeakerDeviceIdStore)).toBeUndefined();
+    });
+});

--- a/play/tests/front/WebRtc/AudioOutputManager.test.ts
+++ b/play/tests/front/WebRtc/AudioOutputManager.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { get } from "svelte/store";
 import { applySinkId, getBubbleSoundUrl } from "../../../src/front/WebRtc/AudioOutputManager";
+import { speakerSelectedStore, usedSpeakerDeviceIdStore } from "../../../src/front/Stores/MediaStore";
 
 /**
  * jsdom implements neither setSinkId nor play(), so each test builds the element behaviour it needs.
@@ -28,6 +30,39 @@ describe("applySinkId", () => {
 
         await expect(applySinkId(el, "device-1")).resolves.toBe(true);
         expect(setSinkId).toHaveBeenCalledWith("device-1");
+    });
+
+    it("reports the device that was actually applied", async () => {
+        usedSpeakerDeviceIdStore.set(undefined);
+        const { el } = createMediaElement();
+
+        await applySinkId(el, "device-1");
+
+        expect(get(usedSpeakerDeviceIdStore)).toBe("device-1");
+    });
+
+    it("forgets the applied device as soon as another one is picked", () => {
+        usedSpeakerDeviceIdStore.set("device-1");
+
+        speakerSelectedStore.set("device-2");
+
+        // Otherwise the settings panel would compare a stale value against the new selection and
+        // claim a fallback that never happened.
+        expect(get(usedSpeakerDeviceIdStore)).toBeUndefined();
+    });
+
+    it("reports the system default when it had to fall back", async () => {
+        usedSpeakerDeviceIdStore.set(undefined);
+        const failing = vi
+            .fn<(id: string) => Promise<void>>()
+            .mockRejectedValueOnce(new DOMException("device is gone", "AbortError"))
+            .mockResolvedValueOnce(undefined);
+        const { el } = createMediaElement("", failing);
+
+        await applySinkId(el, "device-1");
+
+        // The settings panel compares this to the selection to warn that the browser refused it.
+        expect(get(usedSpeakerDeviceIdStore)).toBe("");
     });
 
     it("applies the empty string, which means 'system default'", async () => {

--- a/play/tests/front/WebRtc/AudioOutputManager.test.ts
+++ b/play/tests/front/WebRtc/AudioOutputManager.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { applySinkId, getBubbleSoundUrl } from "../../../src/front/WebRtc/AudioOutputManager";
+
+/**
+ * jsdom implements neither setSinkId nor play(), so each test builds the element behaviour it needs.
+ * The mock is returned alongside the element: asserting on `el.setSinkId` directly would be an
+ * unbound method reference.
+ */
+function createMediaElement(
+    sinkId = "",
+    setSinkId: Mock<(id: string) => Promise<void>> = vi.fn<(id: string) => Promise<void>>(() => Promise.resolve()),
+): { el: HTMLMediaElement; setSinkId: Mock<(id: string) => Promise<void>> } {
+    return { el: { sinkId, setSinkId } as unknown as HTMLMediaElement, setSinkId };
+}
+
+describe("getBubbleSoundUrl", () => {
+    it("points at files that exist under public/", () => {
+        // Regression guard: the previous test sound was "/resources/objects/webrtc-in.mp3",
+        // which 404s because only the -ding and -wobble variants are shipped.
+        expect(getBubbleSoundUrl("ding")).toBe("/resources/objects/webrtc-in-ding.mp3");
+        expect(getBubbleSoundUrl("wobble")).toBe("/resources/objects/webrtc-in-wobble.mp3");
+    });
+});
+
+describe("applySinkId", () => {
+    it("routes the element to the requested device", async () => {
+        const { el, setSinkId } = createMediaElement();
+
+        await expect(applySinkId(el, "device-1")).resolves.toBe(true);
+        expect(setSinkId).toHaveBeenCalledWith("device-1");
+    });
+
+    it("applies the empty string, which means 'system default'", async () => {
+        const { el, setSinkId } = createMediaElement("device-1");
+
+        await expect(applySinkId(el, "")).resolves.toBe(true);
+        expect(setSinkId).toHaveBeenCalledWith("");
+    });
+
+    it("does nothing when no device is requested", async () => {
+        const { el, setSinkId } = createMediaElement();
+
+        await expect(applySinkId(el, undefined)).resolves.toBe(false);
+        expect(setSinkId).not.toHaveBeenCalled();
+    });
+
+    it("skips the call when the sink is already the right one", async () => {
+        const { el, setSinkId } = createMediaElement("device-1");
+
+        await expect(applySinkId(el, "device-1")).resolves.toBe(true);
+        expect(setSinkId).not.toHaveBeenCalled();
+    });
+
+    it("reports failure instead of throwing on a browser without setSinkId", async () => {
+        const el = { sinkId: undefined } as unknown as HTMLMediaElement;
+
+        await expect(applySinkId(el, "device-1")).resolves.toBe(false);
+    });
+
+    it("falls back to the system default when the device vanished", async () => {
+        const failing = vi
+            .fn<(id: string) => Promise<void>>()
+            .mockRejectedValueOnce(new DOMException("device is gone", "AbortError"))
+            .mockResolvedValueOnce(undefined);
+        const { el, setSinkId } = createMediaElement("", failing);
+
+        await expect(applySinkId(el, "device-1")).resolves.toBe(false);
+        expect(setSinkId).toHaveBeenNthCalledWith(1, "device-1");
+        expect(setSinkId).toHaveBeenNthCalledWith(2, "");
+    });
+});
+
+describe("playTestSound", () => {
+    let play: Mock<() => Promise<void>>;
+    let pause: Mock<() => void>;
+    let setSinkId: Mock<(this: HTMLMediaElement, id: string) => Promise<void>>;
+    /** Records the order of side effects, to assert the sink is set *before* playback starts. */
+    let calls: string[];
+    /** Every URL assigned to the element, to detect a reload on every click. */
+    let assignedSources: string[];
+    let playTestSound: (deviceId: string | undefined) => Promise<void>;
+    let bubbleSoundStore: { set: (value: "ding" | "wobble") => void };
+
+    beforeEach(async () => {
+        calls = [];
+        assignedSources = [];
+
+        play = vi.fn().mockImplementation(() => {
+            calls.push("play");
+            return Promise.resolve();
+        });
+        pause = vi.fn();
+        setSinkId = vi.fn().mockImplementation(function (this: HTMLMediaElement, id: string) {
+            calls.push(`setSinkId:${id}`);
+            // Mirror the browser: reading back sinkId returns what was applied. The manager relies
+            // on this to skip redundant calls.
+            Object.defineProperty(this, "sinkId", { configurable: true, writable: true, value: id });
+            return Promise.resolve();
+        });
+
+        vi.spyOn(window.HTMLMediaElement.prototype, "play").mockImplementation(play);
+        vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(pause);
+        // jsdom exposes neither of these, so define them rather than spy on them.
+        Object.defineProperty(window.HTMLMediaElement.prototype, "setSinkId", {
+            configurable: true,
+            writable: true,
+            value: setSinkId,
+        });
+        Object.defineProperty(window.HTMLMediaElement.prototype, "sinkId", {
+            configurable: true,
+            writable: true,
+            value: "",
+        });
+        Object.defineProperty(window.HTMLMediaElement.prototype, "src", {
+            configurable: true,
+            get(this: HTMLMediaElement & { _src?: string }) {
+                return this._src ?? "";
+            },
+            set(this: HTMLMediaElement & { _src?: string }, value: string) {
+                this._src = value;
+                assignedSources.push(value);
+            },
+        });
+
+        // The manager keeps one element for the lifetime of the module, so reload it between tests
+        // to get a fresh one instead of leaking sink state across cases.
+        vi.resetModules();
+        ({ playTestSound } = await import("../../../src/front/WebRtc/AudioOutputManager"));
+        ({ bubbleSoundStore } = await import("../../../src/front/Stores/AudioManagerStore"));
+    });
+
+    it("sets the sink before starting playback", async () => {
+        await playTestSound("device-1");
+
+        // Chrome ignores a sink set on an already-playing element, hence the strict ordering.
+        expect(calls).toEqual(["setSinkId:device-1", "play"]);
+    });
+
+    it("plays the bubble sound the user configured", async () => {
+        bubbleSoundStore.set("wobble");
+
+        await playTestSound("device-1");
+
+        expect(assignedSources).toEqual(["/resources/objects/webrtc-in-wobble.mp3"]);
+    });
+
+    it("reuses a single element instead of reloading it on every click", async () => {
+        await playTestSound("device-1");
+        await playTestSound("device-1");
+        await playTestSound("device-2");
+
+        expect(play).toHaveBeenCalledTimes(3);
+        // The source is assigned once, and the sink only re-applied when it actually changes.
+        expect(assignedSources).toHaveLength(1);
+        expect(setSinkId).toHaveBeenCalledTimes(2);
+    });
+
+    it("restarts the sound from the beginning on each click", async () => {
+        await playTestSound("device-1");
+        await playTestSound("device-1");
+
+        expect(pause).toHaveBeenCalledTimes(2);
+    });
+
+    it("serializes overlapping clicks", async () => {
+        await Promise.all([playTestSound("device-1"), playTestSound("device-2")]);
+
+        // Never two setSinkId in flight at once: each run completes before the next starts.
+        expect(calls).toEqual(["setSinkId:device-1", "play", "setSinkId:device-2", "play"]);
+    });
+
+    it("does not reject when playback is blocked", async () => {
+        play.mockRejectedValueOnce(new DOMException("blocked", "NotAllowedError"));
+
+        await expect(playTestSound("device-1")).resolves.toBeUndefined();
+    });
+});

--- a/play/tests/front/WebRtc/AudioOutputManager.test.ts
+++ b/play/tests/front/WebRtc/AudioOutputManager.test.ts
@@ -6,7 +6,9 @@ import {
     bindAudioOutput,
     getBubbleSoundUrl,
 } from "../../../src/front/WebRtc/AudioOutputManager";
-import { speakerSelectedStore, usedSpeakerDeviceIdStore } from "../../../src/front/Stores/MediaStore";
+// Imported from the leaf store module, like the manager itself: pulling in MediaStore here would
+// drag along the whole media graph for no reason.
+import { speakerSelectedStore, usedSpeakerDeviceIdStore } from "../../../src/front/Stores/AudioOutputStore";
 
 /**
  * jsdom implements neither setSinkId nor play(), so each test builds the element behaviour it needs.
@@ -192,7 +194,7 @@ describe("playTestSound", () => {
     /** Every URL assigned to the element, to detect a reload on every click. */
     let assignedSources: string[];
     let playTestSound: (deviceId: string | undefined) => Promise<void>;
-    let bubbleSoundStore: { set: (value: "ding" | "wobble") => void };
+    let localUserStore: { setBubbleSound: (value: "ding" | "wobble") => void };
 
     beforeEach(async () => {
         calls = [];
@@ -239,7 +241,7 @@ describe("playTestSound", () => {
         // to get a fresh one instead of leaking sink state across cases.
         vi.resetModules();
         ({ playTestSound } = await import("../../../src/front/WebRtc/AudioOutputManager"));
-        ({ bubbleSoundStore } = await import("../../../src/front/Stores/AudioManagerStore"));
+        ({ localUserStore } = await import("../../../src/front/Connection/LocalUserStore"));
     });
 
     it("sets the sink before starting playback", async () => {
@@ -250,7 +252,7 @@ describe("playTestSound", () => {
     });
 
     it("plays the bubble sound the user configured", async () => {
-        bubbleSoundStore.set("wobble");
+        localUserStore.setBubbleSound("wobble");
 
         await playTestSound("device-1");
 

--- a/play/tests/front/WebRtc/AudioOutputManager.test.ts
+++ b/play/tests/front/WebRtc/AudioOutputManager.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { get } from "svelte/store";
-import { applySinkId, getBubbleSoundUrl } from "../../../src/front/WebRtc/AudioOutputManager";
+import {
+    applySinkId,
+    bindAudioContextOutput,
+    bindAudioOutput,
+    getBubbleSoundUrl,
+} from "../../../src/front/WebRtc/AudioOutputManager";
 import { speakerSelectedStore, usedSpeakerDeviceIdStore } from "../../../src/front/Stores/MediaStore";
 
 /**
@@ -28,7 +33,7 @@ describe("applySinkId", () => {
     it("routes the element to the requested device", async () => {
         const { el, setSinkId } = createMediaElement();
 
-        await expect(applySinkId(el, "device-1")).resolves.toBe(true);
+        await expect(applySinkId(el, "device-1")).resolves.toBe("applied");
         expect(setSinkId).toHaveBeenCalledWith("device-1");
     });
 
@@ -68,28 +73,28 @@ describe("applySinkId", () => {
     it("applies the empty string, which means 'system default'", async () => {
         const { el, setSinkId } = createMediaElement("device-1");
 
-        await expect(applySinkId(el, "")).resolves.toBe(true);
+        await expect(applySinkId(el, "")).resolves.toBe("applied");
         expect(setSinkId).toHaveBeenCalledWith("");
     });
 
     it("does nothing when no device is requested", async () => {
         const { el, setSinkId } = createMediaElement();
 
-        await expect(applySinkId(el, undefined)).resolves.toBe(false);
+        await expect(applySinkId(el, undefined)).resolves.toBe("failed");
         expect(setSinkId).not.toHaveBeenCalled();
     });
 
     it("skips the call when the sink is already the right one", async () => {
         const { el, setSinkId } = createMediaElement("device-1");
 
-        await expect(applySinkId(el, "device-1")).resolves.toBe(true);
+        await expect(applySinkId(el, "device-1")).resolves.toBe("applied");
         expect(setSinkId).not.toHaveBeenCalled();
     });
 
     it("reports failure instead of throwing on a browser without setSinkId", async () => {
         const el = { sinkId: undefined } as unknown as HTMLMediaElement;
 
-        await expect(applySinkId(el, "device-1")).resolves.toBe(false);
+        await expect(applySinkId(el, "device-1")).resolves.toBe("unsupported");
     });
 
     it("falls back to the system default when the device vanished", async () => {
@@ -99,9 +104,82 @@ describe("applySinkId", () => {
             .mockResolvedValueOnce(undefined);
         const { el, setSinkId } = createMediaElement("", failing);
 
-        await expect(applySinkId(el, "device-1")).resolves.toBe(false);
+        await expect(applySinkId(el, "device-1")).resolves.toBe("fell-back-to-default");
         expect(setSinkId).toHaveBeenNthCalledWith(1, "device-1");
         expect(setSinkId).toHaveBeenNthCalledWith(2, "");
+    });
+
+    it("serializes concurrent calls on the same element", async () => {
+        const order: string[] = [];
+        const slow = vi.fn<(id: string) => Promise<void>>().mockImplementation(async (id: string) => {
+            order.push(`start:${id}`);
+            // A longer first call: without serialization the second would settle first and the
+            // element would end up on the wrong device.
+            await new Promise((resolve) => {
+                setTimeout(resolve, id === "device-1" ? 20 : 0);
+            });
+            order.push(`end:${id}`);
+        });
+        const { el } = createMediaElement("", slow);
+
+        await Promise.all([applySinkId(el, "device-1"), applySinkId(el, "device-2")]);
+
+        expect(order).toEqual(["start:device-1", "end:device-1", "start:device-2", "end:device-2"]);
+    });
+
+    it("keeps serving later calls after one rejects", async () => {
+        const failing = vi
+            .fn<(id: string) => Promise<void>>()
+            .mockRejectedValueOnce(new DOMException("nope", "NotFoundError"))
+            .mockResolvedValueOnce(undefined);
+        const { el } = createMediaElement("", failing);
+
+        const first = applySinkId(el, "device-1");
+        const second = applySinkId(el, "device-2");
+
+        await expect(first).resolves.toBe("failed");
+        // A rejected task must not wedge the queue for every element that follows.
+        await expect(second).resolves.toBe("applied");
+    });
+});
+
+describe("bindAudioOutput", () => {
+    it("applies the selection and re-applies it on every change", async () => {
+        speakerSelectedStore.set("device-1");
+        const { el, setSinkId } = createMediaElement();
+
+        const unsubscribe = bindAudioOutput(el);
+        await vi.waitFor(() => expect(setSinkId).toHaveBeenCalledWith("device-1"));
+
+        speakerSelectedStore.set("device-2");
+        await vi.waitFor(() => expect(setSinkId).toHaveBeenCalledWith("device-2"));
+
+        unsubscribe();
+        speakerSelectedStore.set("device-3");
+        await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+        });
+        expect(setSinkId).not.toHaveBeenCalledWith("device-3");
+    });
+});
+
+describe("bindAudioContextOutput", () => {
+    it("routes the context and follows the selection", async () => {
+        speakerSelectedStore.set("device-1");
+        const setSinkId = vi.fn<(id: string) => Promise<void>>(() => Promise.resolve());
+        const context = { setSinkId } as unknown as AudioContext;
+
+        const unsubscribe = bindAudioContextOutput(context);
+        await vi.waitFor(() => expect(setSinkId).toHaveBeenCalledWith("device-1"));
+
+        unsubscribe();
+    });
+
+    it("is a no-op on a browser without AudioContext.setSinkId", () => {
+        const context = {} as unknown as AudioContext;
+
+        // Must not throw: Firefox and Safari have no AudioContext sink selection at all.
+        expect(() => bindAudioContextOutput(context)()).not.toThrow();
     });
 });
 

--- a/play/tests/front/WebRtc/DeviceUtils.test.ts
+++ b/play/tests/front/WebRtc/DeviceUtils.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isSafari } from "../../../src/front/WebRtc/DeviceUtils";
+
+const realUserAgent = window.navigator.userAgent;
+
+function setUserAgent(userAgent: string): void {
+    Object.defineProperty(window.navigator, "userAgent", { configurable: true, value: userAgent });
+}
+
+afterEach(() => {
+    setUserAgent(realUserAgent);
+});
+
+describe("isSafari", () => {
+    it("detects desktop Safari", () => {
+        setUserAgent(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+        );
+
+        expect(isSafari()).toBe(true);
+    });
+
+    it.each([
+        [
+            "Chrome",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+        ],
+        [
+            "Edge",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+        ],
+        ["Firefox", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:124.0) Gecko/20100101 Firefox/124.0"],
+        [
+            "Chrome on iOS",
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/122.0.0.0 Mobile/15E148 Safari/604.1",
+        ],
+    ])("does not mistake %s for Safari", (_name, userAgent) => {
+        setUserAgent(userAgent);
+
+        expect(isSafari()).toBe(false);
+    });
+
+    it("never throws on an unrecognised user agent", () => {
+        // Embedded browsers and webviews match none of Firefox / Chrome / Safari. isSafari runs at
+        // module evaluation time in MediaStore, so throwing here would take the whole media
+        // pipeline down instead of just disabling output selection.
+        setUserAgent("SomeEmbeddedWebview/1.0");
+
+        expect(() => isSafari()).not.toThrow();
+        expect(isSafari()).toBe(false);
+    });
+});

--- a/tests/tests/media_devices.spec.ts
+++ b/tests/tests/media_devices.spec.ts
@@ -120,12 +120,38 @@ test.describe("Media devices @nomobile @nowebkit", () => {
 
         await context.close();
     });
+
+    test("should offer audio outputs even when no microphone or camera stream is obtained", async ({
+        browser,
+        browserName,
+    }) => {
+        test.skip(browserName === "webkit", "WebKit has issues with camera/microphone");
+
+        // Audio output selection needs no permission, but the device list used to be enumerated
+        // only after a successful getUserMedia. A user joining with microphone and camera off — the
+        // default, and unavoidable in a silent zone — was left with an empty section and nothing to
+        // select.
+        const url = publicTestMapUrl("tests/E2E/empty.json", "speaker-without-media-access");
+        const context = await createContextWithMockedMediaDevices(browser, { denyMediaAccess: true });
+        const page = await context.newPage();
+
+        await loginWithMockedMediaDevices(page, url);
+        await openMediaSettings(page);
+
+        await expect(page.getByText("AirPods Speaker")).toBeVisible();
+        await expect(page.getByText("MacBook Speakers")).toBeVisible();
+        await expect(page.getByText("No speaker device found")).toBeHidden();
+
+        await context.close();
+    });
 });
 
 type MockedMediaDevicePreferences = {
     preferredAudioInputDevice?: string;
     preferredVideoInputDevice?: string;
     speakerDeviceId?: string;
+    /** Makes getUserMedia reject, as it does when the user never grants microphone or camera. */
+    denyMediaAccess?: boolean;
 };
 
 async function createContextWithMockedMediaDevices(
@@ -215,6 +241,9 @@ async function createContextWithMockedMediaDevices(
             configurable: true,
             writable: true,
             value: async (constraints: MediaStreamConstraints) => {
+                if (preferences.denyMediaAccess === true) {
+                    throw new DOMException("Permission denied", "NotAllowedError");
+                }
                 const stream = new MediaStream();
 
                 if (constraints.audio !== false && constraints.audio !== undefined) {


### PR DESCRIPTION
## The problem

Changing the audio output device did nothing perceptible. Reproduced on staging (Chrome 151, macOS):

| Measure | Result |
|---|---|
| Audio output section, microphone and camera off | **Empty section** — no device, no message |
| Only media element in the DOM (map ambience) | `sinkId: ""` |
| `setSinkId` on all 6 outputs, in the real page context | 6/6 OK |

The browser was never the problem. Two distinct causes:

1. **Nothing to select.** `deviceListStore` only called `enumerateDevices()` after a successful `getUserMedia`. Joining with microphone and camera off — the default, and unavoidable in a silent zone where enabling the microphone is blocked — left the list empty forever. And `speakerListStore` returning `undefined` meant three different things at once (not enumerated / no device / browser unsupported), which is why the section rendered a title with nothing under it.

2. **Selecting changed nothing audible.** A single component in the whole app applied `setSinkId`: the one carrying peer audio, which only exists while someone is in a bubble. Map ambience, bubble and meeting sounds, new message, recording announcements, chat voice messages, scripting videos and sound previews all played on the system default.

Verified in a two-tab bubble that peer audio *does* follow the selection in full-mesh P2P, so the reports were about everything else.

## What changed

- **Enumerate up front**, without waiting for a stream. Labels come back empty until permission is granted, so the UI falls back to a generic indexed name.
- **Every branch of the section renders something** — loading, no device, unsupported browser — instead of an empty body.
- **A single `AudioOutputManager`** owns routing: a Svelte action for template elements, a helper for one-shot sounds, and `AudioContext` routing for everything that never touches a media element (the Phaser sound manager behind bubble and notification sounds, the WebAudio playback fallback, the scripting API's PCM streams). Calls are serialized per target — `setSinkId` is async and two racing calls could settle in reverse order.
- **Failures are visible.** `usedSpeakerDeviceIdStore` reports what was actually applied, mirroring the camera and microphone stores, and the panel warns when the browser refused the selection.
- **The test button works.** It loaded `/resources/objects/webrtc-in.mp3`, which **404s** — only the `-ding` and `-wobble` variants ship — so it produced no sound at all, on top of ignoring the sink. It now plays the user's configured bubble sound on the selected device, and the same button was added to the in-game panel.
- **Lifecycle fixes**: the fallback is persisted so it stops being undone on the next `devicechange`; `switchActiveDevice` is serialized on the LiveKit room; `isSafari()` no longer throws on unrecognised user agents, which now matters because it runs at MediaStore load time.

## Notable

`isSafari()` used to throw on any user agent that is neither Firefox, Chrome nor Safari. Moving the call to module scope would have taken down the whole media pipeline — camera and microphone included — instead of just disabling output selection, so it was made non-throwing first.

The audio output stores moved to their own leaf module: `AudioOutputManager` needs them and is reached from `AudioContextManager`, which `MediaStore` itself pulls in through `SoundMeter`. `MediaStore` re-exports them, so callers keep one entry point.

## Verification

`i18n:check`, `build`, `build-iframe-api`, `typecheck`, `svelte-check`, `lint`, `pretty-check`, `test` (102 files, 657 tests) all green locally. 21 new unit tests.

**Two things were not verified, worth knowing before merging:**

- **Nothing was checked at runtime.** The tests cover the logic, not sound coming out of the right speaker. The first case to try by hand is the one reproduced on staging: join with microphone and camera off, in a silent zone.
- **The Playwright case added here has never been run** — it needs the full docker stack. It type-checks and lints, and asserts exactly what was observed by hand, but if the e2e job fails that is the first place to look.

**Still open:** the LiveKit path. `switchActiveDevice` was serialized because it is the last plausible suspect, but the problem could never be reproduced there — two tabs stay in full-mesh P2P. If output changes still do nothing in meetings or under megaphone, that is where to measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)