### PR TITLE
fix(map-editor): restrict custom asset deletion to its creator or a map editor

### DIFF
--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -282,6 +282,11 @@ export const EntityRawPrefab = z.object({
     color: z.string(),
     collisionGrid: CollisionGrid.optional(),
     depthOffset: z.number().optional(),
+    // UUID of the user who uploaded this custom entity. Stamped by map-storage from the
+    // authenticated user UUID, never from the client. Undefined on the built-in ("Default")
+    // collections and on custom entities uploaded before this field existed: those can only be
+    // modified or deleted by a user with map edit rights.
+    ownerId: z.string().optional(),
 });
 
 export const EntityPrefabType = z.union([z.literal("Default"), z.literal("Custom")]);

--- a/map-storage/src/MapStorageServer.ts
+++ b/map-storage/src/MapStorageServer.ts
@@ -41,6 +41,8 @@ import { UploadFileMapStorageCommand } from "./Commands/File/UploadFileMapStorag
 import { hookManager } from "./Modules/HookManager";
 import { UpdateEntityMapStorageCommand } from "./Commands/Entity/UpdateEntityMapStorageCommand";
 import { isModifyAreaMessageOnlyClaim } from "./Services/isModifyAreaMessageOnlyClaim";
+import { canUserEditCustomEntity } from "./Services/canUserEditCustomEntity";
+import { CustomEntityCollectionService } from "./Services/CustomEntityCollectionService";
 
 /**
  * List of commands that can be executed even if the user does not have edit rights on the map
@@ -336,6 +338,9 @@ const mapStorageServer: MapStorageServer = {
                     }
                     case "uploadEntityMessage": {
                         const uploadEntityMessage = editMapMessage.uploadEntityMessage;
+                        // The uploader owns the entity. We overwrite whatever the client sent, and we do it on the
+                        // message itself so that the value is persisted, queued and broadcast to every other client.
+                        uploadEntityMessage.ownerId = userUUID;
                         await entitiesManager.executeCommand(
                             new UploadEntityMapStorageCommand(uploadEntityMessage, mapUrl.hostname),
                         );
@@ -343,6 +348,13 @@ const mapStorageServer: MapStorageServer = {
                     }
                     case "modifyCustomEntityMessage": {
                         const modifyCustomEntityMessage = editMapMessage.modifyCustomEntityMessage;
+                        await assertUserCanEditCustomEntity(
+                            mapUrl,
+                            modifyCustomEntityMessage.id,
+                            userUUID,
+                            userCanEdit,
+                            "modify",
+                        );
                         await entitiesManager.executeCommand(
                             new ModifyCustomEntityMapStorageCommand(modifyCustomEntityMessage, mapUrl.hostname),
                         );
@@ -350,6 +362,16 @@ const mapStorageServer: MapStorageServer = {
                     }
                     case "deleteCustomEntityMessage": {
                         const deleteCustomEntityMessage = editMapMessage.deleteCustomEntityMessage;
+                        // This check must happen before the command runs: DeleteCustomEntityCommand.execute()
+                        // mutates the in-memory WAM before touching the collection file, so throwing from
+                        // deeper down would leave map-storage with a corrupted WAM.
+                        await assertUserCanEditCustomEntity(
+                            mapUrl,
+                            deleteCustomEntityMessage.id,
+                            userUUID,
+                            userCanEdit,
+                            "delete",
+                        );
                         await entitiesManager.executeCommand(
                             new DeleteCustomEntityMapStorageCommand(
                                 deleteCustomEntityMessage,
@@ -416,6 +438,31 @@ const mapStorageServer: MapStorageServer = {
         });
     },
 };
+
+/**
+ * Throws unless the user is allowed to modify or delete the given custom entity.
+ *
+ * The thrown error is turned into an errorCommandMessage that is sent back to the sender only, and
+ * the command is neither applied nor broadcast.
+ */
+async function assertUserCanEditCustomEntity(
+    mapUrl: URL,
+    entityId: string,
+    userUUID: string,
+    userCanEdit: boolean,
+    action: "modify" | "delete",
+): Promise<void> {
+    if (userCanEdit) {
+        // Short-circuit so that we do not read the collection file for users who are allowed anyway.
+        return;
+    }
+    const entity = await new CustomEntityCollectionService(mapUrl.hostname).getEntity(entityId);
+    if (!canUserEditCustomEntity(entity, userUUID, userCanEdit)) {
+        throw new Error(
+            `User ${userUUID} is not allowed to ${action} the custom entity ${entityId} on map ${mapUrl.toString()}: only its creator or a user with map edit rights can.`,
+        );
+    }
+}
 
 function getMessageFromError(error: unknown): string {
     if (error instanceof Error) {

--- a/map-storage/src/Services/CustomEntityCollectionService.ts
+++ b/map-storage/src/Services/CustomEntityCollectionService.ts
@@ -48,14 +48,18 @@ export class CustomEntityCollectionService {
         return;
     }
 
+    public async getEntity(id: string): Promise<EntityRawPrefab | undefined> {
+        const customEntityCollection = await this.getCollection();
+        return customEntityCollection.collection.find((entity) => entity.id === id);
+    }
+
     public async modifyEntity(modifyCustomEntityMessage: ModifyCustomEntityMessage) {
         const { id, name, tags, depthOffset } = modifyCustomEntityMessage;
         let collisionGrid = undefined;
         if (modifyCustomEntityMessage.collisionGrid) {
             collisionGrid = CollisionGrid.parse(modifyCustomEntityMessage.collisionGrid);
         }
-        const customEntityCollectionFileContent = await this.readOrCreateEntitiesCollectionFile();
-        const customEntityCollection = EntityCollectionRaw.parse(JSON.parse(customEntityCollectionFileContent));
+        const customEntityCollection = await this.getCollection();
         const indexOfEntityToModify = customEntityCollection.collection.findIndex((entity) => entity.id === id);
         if (indexOfEntityToModify !== -1) {
             const entityToModify = customEntityCollection.collection[indexOfEntityToModify];
@@ -77,8 +81,7 @@ export class CustomEntityCollectionService {
 
     public async deleteEntity(deleteCustomEntityMessage: DeleteCustomEntityMessage) {
         const { id } = deleteCustomEntityMessage;
-        const customEntityCollectionFileContent = await this.readOrCreateEntitiesCollectionFile();
-        const customEntityCollection = EntityCollectionRaw.parse(JSON.parse(customEntityCollectionFileContent));
+        const customEntityCollection = await this.getCollection();
         const customEntityToDelete = customEntityCollection.collection.find((entity) => entity.id === id);
         customEntityCollection.collection = customEntityCollection.collection.filter(
             (customEntity) => customEntity.id !== id,
@@ -110,18 +113,24 @@ export class CustomEntityCollectionService {
         return fileSystem.readFileAsString(entityCollectionFileVirtualPath);
     }
 
+    private async getCollection(): Promise<EntityCollectionRaw> {
+        return EntityCollectionRaw.parse(JSON.parse(await this.readOrCreateEntitiesCollectionFile()));
+    }
+
     private mapEntityFromUploadEntityMessageToEntityRawPrefab(
         uploadEntityMessage: UploadEntityMessage,
     ): EntityRawPrefab {
         return EntityRawPrefab.parse({
             ...uploadEntityMessage,
             direction: mapCustomEntityDirectionToDirection(uploadEntityMessage.direction),
+            // MapStorageServer overwrites ownerId with the authenticated user UUID before we get
+            // here, so this is the server-side value and never what the client sent.
+            ownerId: uploadEntityMessage.ownerId,
         });
     }
 
     private async addEntityInEntityCollectionFile(entityToAddInCollection: EntityRawPrefab) {
-        const customEntityCollectionFileContent = await this.readOrCreateEntitiesCollectionFile();
-        const customEntityCollection = EntityCollectionRaw.parse(JSON.parse(customEntityCollectionFileContent));
+        const customEntityCollection = await this.getCollection();
         customEntityCollection.collection.push(entityToAddInCollection);
         this.lock = this.lock.then(async () => {
             await fileSystem.writeStringAsFile(

--- a/map-storage/src/Services/canUserEditCustomEntity.ts
+++ b/map-storage/src/Services/canUserEditCustomEntity.ts
@@ -1,0 +1,30 @@
+import type { EntityRawPrefab } from "@workadventure/map-editor";
+
+/**
+ * Returns true iff the given user is allowed to modify or delete the given custom entity prefab.
+ *
+ * Users without map edit rights can still reach the map editor (through a zone edit tag or a
+ * personal area) and upload their own custom entities. This check exists so that they cannot
+ * modify or delete the custom entities uploaded by someone else: the custom entity collection is
+ * shared by every map of the domain, so a deletion from one room removes the asset everywhere.
+ *
+ * - `userCanEdit` is true for admin/editor tags, MAP_EDITOR_ALLOWED_USERS, and when
+ *   MAP_EDITOR_ALLOW_ALL_USERS is set. In that last case everybody can edit everything, which is
+ *   the intended behaviour for open self-hosted instances.
+ * - An entity with no `ownerId` was uploaded before ownership was recorded: only a user with map
+ *   edit rights can touch it.
+ * - An unknown entity is refused too, so that a forged command cannot slip through.
+ */
+export function canUserEditCustomEntity(
+    entity: Pick<EntityRawPrefab, "ownerId"> | undefined,
+    userUUID: string | undefined,
+    userCanEdit: boolean,
+): boolean {
+    if (userCanEdit) {
+        return true;
+    }
+    if (!entity?.ownerId || !userUUID) {
+        return false;
+    }
+    return entity.ownerId === userUUID;
+}

--- a/map-storage/src/Services/tests/CustomEntityCollectionService.test.ts
+++ b/map-storage/src/Services/tests/CustomEntityCollectionService.test.ts
@@ -1,0 +1,91 @@
+import { EntityCollectionRaw } from "@workadventure/map-editor";
+import { CustomEntityDirection } from "@workadventure/messages";
+import type { UploadEntityMessage } from "@workadventure/messages";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const files = new Map<string, string>();
+
+// PathMapper pulls in EnvironmentVariable, which validates process.env and exits the process.
+vi.mock("../PathMapper", () => ({
+    mapPathUsingDomainWithPrefix: (filePath: string, domain: string) => `${domain}${filePath}`,
+}));
+
+vi.mock("../../fileSystem", () => ({
+    fileSystem: {
+        exist: (path: string) => Promise.resolve(files.has(path)),
+        readFileAsString: (path: string) => Promise.resolve(files.get(path) ?? ""),
+        writeStringAsFile: (path: string, content: string) => {
+            files.set(path, content);
+            return Promise.resolve();
+        },
+        writeByteArrayAsFile: () => Promise.resolve(),
+        deleteFiles: () => Promise.resolve(),
+    },
+}));
+
+import { CustomEntityCollectionService } from "../CustomEntityCollectionService";
+
+const OWNER_UUID = "998ce839-3dea-4698-8b41-ebbdf7688ad9";
+
+function uploadMessage(overrides: Partial<UploadEntityMessage> = {}): UploadEntityMessage {
+    return {
+        file: new Uint8Array(0),
+        id: "entity-1",
+        name: "My asset",
+        tags: ["Custom"],
+        imagePath: "entity-1-asset.png",
+        direction: CustomEntityDirection.Down,
+        color: "",
+        collisionGrid: undefined,
+        depthOffset: undefined,
+        ownerId: OWNER_UUID,
+        ...overrides,
+    };
+}
+
+async function readCollection(service: CustomEntityCollectionService) {
+    const entity = await service.getEntity("entity-1");
+    expect(entity).toBeDefined();
+    return entity;
+}
+
+describe("CustomEntityCollectionService", () => {
+    beforeEach(() => {
+        files.clear();
+    });
+
+    it("persists the ownerId set on the upload message", async () => {
+        const service = new CustomEntityCollectionService("play.workadventure.localhost");
+
+        await service.uploadEntity(uploadMessage());
+
+        expect((await readCollection(service))?.ownerId).toBe(OWNER_UUID);
+    });
+
+    it("keeps the ownerId when the entity is modified", async () => {
+        const service = new CustomEntityCollectionService("play.workadventure.localhost");
+        await service.uploadEntity(uploadMessage());
+
+        await service.modifyEntity({
+            id: "entity-1",
+            name: "Renamed",
+            tags: ["Other"],
+            collisionGrid: undefined,
+            depthOffset: 12,
+        });
+
+        const entity = await readCollection(service);
+        expect(entity?.name).toBe("Renamed");
+        expect(entity?.ownerId).toBe(OWNER_UUID);
+    });
+
+    it("writes a collection file that still parses without any ownerId", async () => {
+        const service = new CustomEntityCollectionService("play.workadventure.localhost");
+
+        await service.uploadEntity(uploadMessage({ ownerId: undefined }));
+
+        const [content] = [...files.values()];
+        expect(() => EntityCollectionRaw.parse(JSON.parse(content))).not.toThrow();
+        expect((await readCollection(service))?.ownerId).toBeUndefined();
+    });
+});

--- a/map-storage/src/Services/tests/canUserEditCustomEntity.test.ts
+++ b/map-storage/src/Services/tests/canUserEditCustomEntity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { canUserEditCustomEntity } from "../canUserEditCustomEntity";
+
+const OWNER_UUID = "998ce839-3dea-4698-8b41-ebbdf7688ad9";
+const OTHER_UUID = "11111111-2222-3333-4444-555555555555";
+
+describe("canUserEditCustomEntity", () => {
+    describe("user with map edit rights", () => {
+        it("can edit an entity owned by somebody else", () => {
+            expect(canUserEditCustomEntity({ ownerId: OWNER_UUID }, OTHER_UUID, true)).toBe(true);
+        });
+
+        it("can edit a legacy entity with no owner", () => {
+            expect(canUserEditCustomEntity({ ownerId: undefined }, OTHER_UUID, true)).toBe(true);
+        });
+
+        it("is allowed even when the entity cannot be found", () => {
+            expect(canUserEditCustomEntity(undefined, OTHER_UUID, true)).toBe(true);
+        });
+    });
+
+    describe("user without map edit rights", () => {
+        it("can edit their own entity", () => {
+            expect(canUserEditCustomEntity({ ownerId: OWNER_UUID }, OWNER_UUID, false)).toBe(true);
+        });
+
+        it("cannot edit an entity owned by somebody else", () => {
+            expect(canUserEditCustomEntity({ ownerId: OWNER_UUID }, OTHER_UUID, false)).toBe(false);
+        });
+
+        it("cannot edit a legacy entity with no owner", () => {
+            expect(canUserEditCustomEntity({ ownerId: undefined }, OWNER_UUID, false)).toBe(false);
+        });
+
+        it("cannot edit an entity that cannot be found", () => {
+            expect(canUserEditCustomEntity(undefined, OWNER_UUID, false)).toBe(false);
+        });
+
+        it("cannot edit anything when their own uuid is missing", () => {
+            expect(canUserEditCustomEntity({ ownerId: OWNER_UUID }, undefined, false)).toBe(false);
+        });
+
+        it("does not match an empty ownerId with an empty uuid", () => {
+            expect(canUserEditCustomEntity({ ownerId: "" }, "", false)).toBe(false);
+        });
+    });
+});

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -355,6 +355,10 @@ message UploadEntityMessage {
   string color = 7;
   optional google.protobuf.Value collisionGrid = 8;
   optional int32 depthOffset = 9;
+  // UUID of the user who uploaded the entity. Always overwritten by map-storage with the
+  // authenticated user UUID: any value sent by the client is discarded. It is sent back in the
+  // broadcast copy of the command so every client knows who owns the asset.
+  optional string ownerId = 10;
 }
 
 message UploadFileMessage {

--- a/play/src/front/Components/MapEditor/EntityEditor/EntityEditorPicker.svelte
+++ b/play/src/front/Components/MapEditor/EntityEditor/EntityEditorPicker.svelte
@@ -3,6 +3,7 @@
     import { onDestroy } from "svelte";
     import { get } from "svelte/store";
     import { LL } from "../../../../i18n/i18n-svelte";
+    import { localUserStore } from "../../../Connection/LocalUserStore";
     import { gameManager } from "../../../Phaser/Game/GameManager";
     import type { EntityVariant } from "../../../Phaser/Game/MapEditor/Entities/EntityVariant";
     import type { CategoryTag, SelectableTag } from "../../../Stores/MapEditorStore";
@@ -29,6 +30,22 @@
     const entitiesCollectionsManager = gameManager.getCurrentGameScene().getEntitiesCollectionsManager();
     const entitiesPrefabsVariants = entitiesCollectionsManager.getEntitiesPrefabsVariantStore();
     const MOST_USED_CATEGORY_LIMIT = 12;
+
+    // Users who only got the map editor through a zone tag or a personal area may upload their own
+    // custom entities, but must not be able to rename or delete somebody else's: the custom entity
+    // collection is shared by every map of the domain. The server enforces this too.
+    const userCanEditMap = gameManager.getCurrentGameScene().connection?.userCanEdit ?? false;
+    const localUserUuid = localUserStore.getLocalUser()?.uuid;
+
+    function canEditCustomEntity(entityPrefab: EntityPrefab): boolean {
+        if (entityPrefab.type !== "Custom") {
+            return false;
+        }
+        if (userCanEditMap) {
+            return true;
+        }
+        return entityPrefab.ownerId !== undefined && entityPrefab.ownerId === localUserUuid;
+    }
 
     let pickedEntity: EntityPrefab | undefined = $state(undefined);
     let pickedEntityVariant: EntityVariant | undefined = $state(undefined);
@@ -329,7 +346,7 @@
                                 {onPickItem}
                             />
                         </div>
-                        {#if pickedEntity.type === "Custom"}
+                        {#if canEditCustomEntity(pickedEntity)}
                             <Button
                                 variant="secondary"
                                 dataTestId="editEntity"

--- a/play/src/front/Components/MapEditor/EntityEditor/EntityUpload/EntityUpload.svelte
+++ b/play/src/front/Components/MapEditor/EntityEditor/EntityUpload/EntityUpload.svelte
@@ -6,6 +6,7 @@
     import type { EntityPrefab } from "@workadventure/map-editor";
     import { Direction, ENTITY_UPLOAD_SUPPORTED_FORMATS_FRONT } from "@workadventure/map-editor";
     import LL from "../../../../../i18n/i18n-svelte";
+    import { localUserStore } from "../../../../Connection/LocalUserStore";
     import { mapEditorEntityUploadEventStore, selectCategoryStore } from "../../../../Stores/MapEditorStore";
     import CustomEntityEditionForm from "../CustomEntityEditionForm/CustomEntityEditionForm.svelte";
     import { IconCloudUpload } from "@wa-icons";
@@ -76,6 +77,9 @@
                 collisionGrid: customEditedEntity.collisionGrid,
                 depthOffset: customEditedEntity.depthOffset,
                 color: "",
+                // Lets us edit and delete our own upload without waiting for the round trip to
+                // map-storage, which overwrites this with the authenticated user UUID anyway.
+                ownerId: localUserStore.getLocalUser()?.uuid,
             });
         }
     }

--- a/play/src/front/Phaser/Game/MapEditor/EntitiesCollectionsManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/EntitiesCollectionsManager.ts
@@ -95,6 +95,7 @@ export class EntitiesCollectionsManager {
                                 color: entity.color,
                                 collisionGrid: entity.collisionGrid,
                                 type: entity.type,
+                                ownerId: entity.ownerId,
                             });
                             entity.tags.forEach((tag: string) => tagSet.add(tag));
                         });

--- a/tests/tests/map_editor/map_editor_custom_entity_rights.spec.ts
+++ b/tests/tests/map_editor/map_editor_custom_entity_rights.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+import Map from "../utils/map";
+import AreaAccessRights from "../utils/areaAccessRights";
+import EntityEditor from "../utils/map-editor/entityEditor";
+import { resetWamMaps } from "../utils/map-editor/uploader";
+import MapEditor from "../utils/mapeditor";
+import Menu from "../utils/menu";
+import { oidcLogout } from "../utils/oidc";
+import { map_storage_url } from "../utils/urls";
+import { getPage } from "../utils/auth";
+import { isMobile } from "../utils/isMobile";
+
+test.setTimeout(240_000); // Fix Webkit that can take more than 60s
+test.use({
+    baseURL: map_storage_url,
+});
+
+/**
+ * A user without map edit rights can still reach the map editor through a zone write right (or a
+ * personal area) and upload custom entities. These tests pin down that they cannot edit or delete
+ * the custom entities uploaded by somebody else, but can still manage their own.
+ */
+test.describe("Map editor custom entity rights @oidc @nomobile @nowebkit", () => {
+    test.beforeEach("Ignore tests on mobile because map editor not available for mobile devices", ({ page }) => {
+        // Map Editor not available on mobile
+        test.skip(isMobile(page), "Map editor is not available on mobile");
+    });
+
+    test.beforeEach("Ignore tests on webkit because of issue with camera and microphone", ({ browserName }) => {
+        // WebKit has issue with camera
+        test.skip(browserName === "webkit", "WebKit has issues with camera/microphone");
+    });
+
+    test("A member cannot edit or delete a custom entity uploaded by an admin", async ({ browser, request }) => {
+        await resetWamMaps(request);
+        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+
+        // Give members write access on an area, so that they get the map editor without edit rights
+        await Menu.openMapEditor(page);
+        await AreaAccessRights.openAreaEditorAndAddAreaWithRights(page, ["member"], []);
+
+        // Upload a custom entity as the admin
+        await MapEditor.openEntityEditor(page);
+        await EntityEditor.uploadTestAsset(page);
+        await Menu.closeMapEditor(page);
+        await oidcLogout(page);
+        await page.close();
+
+        // The member sees the asset but gets no edit button on it
+        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await page2.getByTestId("cameras-container").waitFor({ state: "detached" });
+        await Menu.openMapEditor(page2);
+        await EntityEditor.selectEntity(page2, 0, EntityEditor.getTestAssetName());
+        await expect(page2.getByTestId("editEntity")).toHaveCount(0);
+    });
+
+    test("A member can delete the custom entity they uploaded themselves", async ({ browser, request }) => {
+        await resetWamMaps(request);
+        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+
+        // Give members write access on an area, so that they get the map editor without edit rights
+        await Menu.openMapEditor(page);
+        await AreaAccessRights.openAreaEditorAndAddAreaWithRights(page, ["member"], []);
+        await Menu.closeMapEditor(page);
+        await oidcLogout(page);
+        await page.close();
+
+        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await page2.getByTestId("cameras-container").waitFor({ state: "detached" });
+        await Menu.openMapEditor(page2);
+        await MapEditor.openEntityEditor(page2);
+        await EntityEditor.uploadTestAsset(page2);
+
+        // Reload so that the collection is re-fetched from map-storage: this proves the owner
+        // survives the round trip through entities.json and not only the optimistic local insert.
+        await page2.reload();
+        await Menu.waitForMapLoad(page2);
+        await Menu.openMapEditor(page2);
+        await EntityEditor.selectEntity(page2, 0, EntityEditor.getTestAssetName());
+
+        await expect(page2.getByTestId("editEntity")).toBeVisible();
+        await EntityEditor.openEditEntityForm(page2);
+        await EntityEditor.removeEntity(page2);
+
+        await expect(page2.getByTestId("entity-item")).toHaveCount(0);
+    });
+});


### PR DESCRIPTION
Fixes #6428.

## The problem

A user who reaches the map editor **partially** — through a zone write tag or a personal desk (`canEdit === false`) — can upload custom assets (intended), but could also **delete and rename the assets uploaded by anybody else** (not intended).

Two things made it worse:

- The custom entity collection is a single file shared by the whole domain (`assets/entities/entities.json`, keyed by hostname), so a deletion from one room removed the asset from **every** map of the world.
- `DeleteCustomEntityFrontCommand` also removes every **placed instance** of the prefab from the map, and its `getUndoCommand()` throws `"Not supported."` — the deletion is irreversible.

### Root cause

`uploadEntityMessage`, `modifyCustomEntityMessage` and `deleteCustomEntityMessage` sit in `COMMANDS_ACCESSIBLE_WITHOUT_CAN_EDIT` (`map-storage/src/MapStorageServer.ts`), so they bypass the global `canEdit` gate — and unlike `createEntityMessage` / `modifyEntityMessage`, which call `entityCommandPermissions.canEdit(...)`, they performed **no check at all**. `EntityRawPrefab` had no notion of an owner, so there was nothing to check against, even though `userUUID` already reaches map-storage in `EditMapCommandWithKeyMessage`.

## The fix

Same pattern as personal desks (`PersonalAreaPropertyData.ownerId` + the server-side `isModifyAreaMessageOnlyClaim` check + a client-side comparison against `localUserStore.getLocalUser()?.uuid`):

1. `EntityRawPrefab` gains an optional `ownerId`.
2. map-storage **overwrites** `ownerId` with the authenticated `userUUID` on upload — a value sent by the client is always discarded.
3. Modify and delete are allowed if the user owns the asset **or** has full map edit rights (`admin`/`editor` tag, `MAP_EDITOR_ALLOWED_USERS`, `MAP_EDITOR_ALLOW_ALL_USERS`). Otherwise the command throws, which becomes an `errorCommandMessage` sent back to the sender only — nothing is applied or broadcast.
4. Assets uploaded before this change carry no owner and are reserved to users with edit rights (fail closed).
5. The front hides the edit pencil for assets the user does not own, which also hides the delete button. Other people's assets stay visible and placeable.

### Two implementation notes worth a reviewer's attention

**Why `ownerId` is on the proto and not only in `entities.json`.** map-storage rebroadcasts the command to the whole room and replays it to late joiners, and every other client re-runs `UploadEntityFrontCommand` to rebuild the prefab locally. Had the front stamped its own UUID there, **every recipient would have declared itself the owner of somebody else's asset**. The field has to travel in the message, filled by the server. It is overwritten before persistence and before rebroadcast — same pattern as `uploadFileMessage.file = new Uint8Array(0)` a few lines below.

**Why the permission check runs before `executeCommand` and not inside the service.** `DeleteCustomEntityCommand.execute()` mutates the in-memory WAM (`deleteCustomEntities`) before touching the collection file, so throwing from deeper down would leave map-storage with a corrupted WAM.

### No migration bump

The field is optional, existing `"1.0"` files stay valid, and `undefined` is meaningful. Also, `entitiesFileMigration.migrate()` only runs on the front — `readOrCreateEntitiesCollectionFile` parses without migrating — so bumping the version would desynchronise the two sides.

### Privacy note

`entities.json` is served unauthenticated, so `ownerId` becomes publicly readable. This is not a new class of exposure: the same identifier is already stored in clear in the publicly-served `.wam` files as `PersonalAreaPropertyData.ownerId`. Worth knowing though: depending on the admin configuration, `userUuid` **can be an email address** (`play/src/pusher/services/AdminApi.ts`, *"it can be an email, an uuid"*). A plain SHA-256 would not help there (a known email is trivially checked); only an HMAC with a server secret would, at the cost of threading a per-user token from map-storage down to the front. Not done here — say the word if you would rather have it.

## Testing

| | |
|---|---|
| `map-storage` | typecheck, lint, pretty-check, 27 tests (12 new) |
| `libs/map-editor` | typecheck, lint, 37 tests |
| `play` | typecheck, svelte-check (0 error / 0 warning), lint, pretty-check, 622 tests |
| `back` | typecheck |

New unit tests cover the authorization predicate (editor / owner / non-owner / legacy asset / unknown entity / missing uuid / empty string) and pin that the upload persists the owner and that a modify preserves it.

**The two end-to-end tests were not run** — they need the docker-compose stack up. They are written on the existing helpers (`AreaAccessRights.openAreaEditorAndAddAreaWithRights`, testids `editEntity` / `removeEntity`), but CI will be their first execution.

## Out of scope

While reading this code I found a separate hole in the **placed entity** commands: `deleteEntityMessage` has no permission check at all, and `modifyEntityMessage` only validates the destination coordinates (all client-supplied) and never the entity's current position, so an entity could be dragged out of an area the user has no rights on. Both are already gated on the front, so they need a forged client. Filed separately rather than widened into this PR, because the clean fix needs a design decision: the server has no `width`/`height` for a placed entity (`WAMEntityData` omits them), so it cannot compute a real center without resolving the prefab.
