### PR TITLE
feat(i18n): add the Teams meeting waiting popup strings

### DIFF
--- a/play/src/i18n/ar-SA/externalModule.ts
+++ b/play/src/i18n/ar-SA/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams هو تطبيق Microsoft 365 يساعد فريقك على البقاء متصلًا ومنظمًا. يمكنك الدردشة، الاجتماع، الاتصال، والتعاون في مكان واحد 😍",
         buttonSync: "مزامنة Teams الخاص بي 🚀",
         buttonConnect: "اتصال بـ Teams الخاص بي 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "التكامل",

--- a/play/src/i18n/ca-ES/externalModule.ts
+++ b/play/src/i18n/ca-ES/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams és una aplicació de Microsoft 365 que ajuda el vostre equip a mantenir-se connectat i organitzat. Podeu xatejar, reunir-vos, trucar i col·laborar tot en un sol lloc 😍",
         buttonSync: "Sincronitzar el meu Teams 🚀",
         buttonConnect: "Connectar el meu Teams 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "INTEGRACIÓ",

--- a/play/src/i18n/de-DE/externalModule.ts
+++ b/play/src/i18n/de-DE/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams ist eine Microsoft 365-App, die Ihrem Team hilft, verbunden und organisiert zu bleiben. Sie können chatten, sich treffen, anrufen und an einem Ort zusammenarbeiten 😍",
         buttonSync: "Meine Teams synchronisieren 🚀",
         buttonConnect: "Meine Teams verbinden 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         back: "Back",

--- a/play/src/i18n/dsb-DE/externalModule.ts
+++ b/play/src/i18n/dsb-DE/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams jo Microsoft 365-nałoženje, kótarež wam pomaga, waš team zwězany a organizěrowany źaržaś. Móžośo chatowaś, se stakaś, wołowaś a w jadnem městnje ze sobubuźowaś 😍",
         buttonSync: "Móje Teams synchronizěrowaś 🚀",
         buttonConnect: "Móje Teams zwězaś 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "INTEGRACIJA",

--- a/play/src/i18n/en-US/externalModule.ts
+++ b/play/src/i18n/en-US/externalModule.ts
@@ -16,6 +16,19 @@ const externalModule: BaseTranslation = {
             "Teams is a Microsoft 365 app that helps your team stay connected and organized. You can chat, meet, call, and collaborate all in one place 😍",
         buttonSync: "Sync my Teams 🚀",
         buttonConnect: "Connect my teams 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "INTEGRATION",

--- a/play/src/i18n/es-ES/externalModule.ts
+++ b/play/src/i18n/es-ES/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams es una aplicación de Microsoft 365 que ayuda a tu equipo a mantenerse conectado y organizado. Puedes chatear, reunirte, llamar y colaborar todo en un solo lugar 😍",
         buttonSync: "Sincronizar Teams 🚀",
         buttonConnect: "Conectar Teams 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "INTEGRACIÓN",

--- a/play/src/i18n/fr-FR/externalModule.ts
+++ b/play/src/i18n/fr-FR/externalModule.ts
@@ -17,6 +17,20 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams est une application Microsoft 365 qui aide votre équipe à rester connectée et organisée. Vous pouvez discuter, rencontrer, appeler et collaborer au même endroit 😍",
         buttonSync: "Synchroniser Teams 🚀",
         buttonConnect: "Ouvrir Teams 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "La réunion Teams n’est pas encore créée… c’est en cours 💪",
+            guestExplain:
+                "Veuillez vous connecter à la plateforme pour créer une réunion Teams, ou demandez au propriétaire d’en créer une pour vous 🚀",
+            guestError: "Vous n’êtes pas connecté, vous ne pouvez donc pas créer de réunion Teams 😭",
+            missingScope:
+                "Aucune réunion n’a été créée : votre compte Microsoft n’est pas autorisé à créer des réunions.",
+            missingScopeExplain:
+                "Attendez qu’un participant la crée, ou reconnectez-vous — si votre administrateur vient de l’activer, une reconnexion suffit.",
+            error: "La réunion Teams n’a pas pu être créée.",
+            errorExplain: "Pas d’inquiétude, vous pouvez toujours rejoindre une réunion créée par quelqu’un d’autre 🙏",
+            reconnect: "Reconnecter Teams",
+        },
     },
     discord: {
         integration: "INTÉGRATION",

--- a/play/src/i18n/hsb-DE/externalModule.ts
+++ b/play/src/i18n/hsb-DE/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams je Microsoft 365-nałožka, kotraž wam pomha, waš team zwjazany a organizowany dźeržeć. Móžeće chatować, so stakać, wołać a na jednim městnje sobu dźěłać 😍",
         buttonSync: "Moje Teams synchronizować 🚀",
         buttonConnect: "Moje Teams zwjazać 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "INTEGRACIJA",

--- a/play/src/i18n/it-IT/externalModule.ts
+++ b/play/src/i18n/it-IT/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams è un'app Microsoft 365 che aiuta il tuo team a rimanere connesso e organizzato. Puoi chattare, incontrare, chiamare e collaborare tutto in un unico posto 😍",
         buttonSync: "Sincronizza i miei Teams 🚀",
         buttonConnect: "Connetti i miei Teams 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "INTEGRAZIONE",

--- a/play/src/i18n/ja-JP/externalModule.ts
+++ b/play/src/i18n/ja-JP/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams は、チームが接続を保ち、整理された状態を維持するのに役立つ Microsoft 365 アプリです。チャット、会議、通話、コラボレーションをすべて同じ場所で行えます 😍",
         buttonSync: "Teams を同期 🚀",
         buttonConnect: "Teams に接続 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "統合",

--- a/play/src/i18n/ko-KR/externalModule.ts
+++ b/play/src/i18n/ko-KR/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams는 팀이 연결되고 체계적으로 유지되도록 돕는 Microsoft 365 앱입니다. 한곳에서 채팅, 회의, 통화 및 협업을 할 수 있습니다 😍",
         buttonSync: "Teams 동기화 🚀",
         buttonConnect: "Teams 연결 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "통합",

--- a/play/src/i18n/nl-NL/externalModule.ts
+++ b/play/src/i18n/nl-NL/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams is een Microsoft 365-app die uw team helpt verbonden en georganiseerd te blijven. U kunt chatten, vergaderen, bellen en samenwerken op één plek 😍",
         buttonSync: "Mijn Teams synchroniseren 🚀",
         buttonConnect: "Mijn Teams verbinden 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "INTEGRATIE",

--- a/play/src/i18n/pt-BR/externalModule.ts
+++ b/play/src/i18n/pt-BR/externalModule.ts
@@ -16,6 +16,19 @@ const externalModule: BaseTranslation = {
             "Teams é um aplicativo Microsoft 365 que ajuda sua equipe a se manter conectada e organizada. Você pode conversar, reunir-se, ligar e colaborar tudo em um só lugar 😍",
         buttonSync: "Sincronizar meu Teams 🚀",
         buttonConnect: "Conectar meu teams 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "INTEGRAÇÃO",

--- a/play/src/i18n/zh-CN/externalModule.ts
+++ b/play/src/i18n/zh-CN/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams 是一款 Microsoft 365 应用程序，可帮助您的团队保持联系和组织有序。您可以在一个地方聊天、开会、通话和协作 😍",
         buttonSync: "同步 Teams 🚀",
         buttonConnect: "连接 Teams 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "集成",

--- a/play/src/i18n/zh-TW/externalModule.ts
+++ b/play/src/i18n/zh-TW/externalModule.ts
@@ -17,6 +17,19 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Teams 是一款 Microsoft 365 應用程式，可協助您的團隊保持聯繫並井然有序。您可以在一個地方聊天、開會、通話和協作 😍",
         buttonSync: "同步 Teams 🚀",
         buttonConnect: "連線 Teams 🚀",
+        meetingPopupWaiting: {
+            title: "Teams Microsoft Meetings 🎉",
+            subtitle: "The Teams Meeting is not created yet... is in progress 💪",
+            guestExplain:
+                "Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀",
+            guestError: "You are not connected and cannot create Teams Online Meeting 😭",
+            missingScope: "No meeting was created: your Microsoft account is not allowed to create meetings.",
+            missingScopeExplain:
+                "Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough.",
+            error: "The Teams meeting could not be created.",
+            errorExplain: "No worries, you can still join meetings when someone else creates one 🙏",
+            reconnect: "Reconnect Teams",
+        },
     },
     discord: {
         integration: "整合",


### PR DESCRIPTION
## Context

`TeamsPopupMeetingNotCreated` had all of its text hardcoded in English and only two states: "guest" and a perpetual spinner. A user connected to Microsoft whose token lacks `OnlineMeetings.ReadWrite` got no popup at all — just an "Opening Teams Meeting..." toast that never expires.

The SaaS-side fix (private repo, `external-modules/ms-teams`) gives that popup a `missingScope` state, an `error` state and a reconnect button. This PR adds the strings it needs.

## What this adds

A `meetingPopupWaiting` block under `externalModule.teams`, mirroring the existing `externalModule.google.googleMeetPopupWaiting`:

| key | en-US |
|---|---|
| `title` | Teams Microsoft Meetings 🎉 |
| `subtitle` | The Teams Meeting is not created yet... is in progress 💪 |
| `guestExplain` | Please connect to the platform to create a Teams Online Meeting or ask the owner to create it for you 🚀 |
| `guestError` | You are not connected and cannot create Teams Online Meeting 😭 |
| `missingScope` | No meeting was created: your Microsoft account is not allowed to create meetings. |
| `missingScopeExplain` | Wait for a participant who can create it, or reconnect — if your administrator has just enabled it, reconnecting is enough. |
| `error` | The Teams meeting could not be created. |
| `errorExplain` | No worries, you can still join meetings when someone else creates one 🙏 |
| `reconnect` | Reconnect Teams |

`title`, `subtitle`, `guestExplain` and `guestError` carry over the exact wording that was previously hardcoded in the component — this is a lift into i18n, not a rewrite. The `missingScope` pair is new: unlike Google, the Teams meeting scope is granted by the administrator on the OIDC provider, not ticked by the user, so the guidance is "wait, or reconnect if your admin just enabled it".

## Notes

- ⚠️ The en-US `title` is deliberately byte-identical to the old hardcoded string: `tests/tests/external_modules/teams.spec.ts` asserts `getByRole("heading", { name: "Teams Microsoft Meetings 🎉" })`. The SaaS-side change also adds a `data-testid` so that assertion can be made robust later.
- Added to **all 15 locales** (`i18n:check` is a CI gate). Translated for `en-US` and `fr-FR`; the other 13 carry the English text pending translation.
- Verified with `tsx ./scripts/diff-i18n.ts --check` → *All translations are complete*, plus `tsc`, `eslint` and `svelte-check` against a baseline of the unmodified tree — no new errors or warnings (eslint actually goes from 2 to 1, see the SaaS-side change).