### PR TITLE
perf(tests): stop re-importing Phaser in every vitest setup run

### DIFF
--- a/play/tests/setup/vitest.setup.ts
+++ b/play/tests/setup/vitest.setup.ts
@@ -123,7 +123,7 @@ if (typeof window !== "undefined" && typeof window.matchMedia === "undefined") {
     });
 }
 
-// jsdom does not implement CanvasRenderingContext2D; Phaser expects it during import.
+// jsdom does not implement CanvasRenderingContext2D; Phaser expects it when a test imports it.
 // Provide a minimal stub so canvas feature detection does not crash in tests.
 const createStubContext = () => {
     const data = new Uint8ClampedArray([0, 0, 0, 255]);
@@ -142,5 +142,9 @@ HTMLCanvasElement.prototype.getContext = function getContext() {
     return createStubContext();
 };
 
-const PhaserModule = await import("phaser");
-globalThis.Phaser = PhaserModule.default ?? PhaserModule;
+// Note: do not import Phaser here. Setup files run once per test file and, with `isolate: true`,
+// in a fresh module registry every time, so a global import re-evaluates Phaser's 8.8 MB bundle
+// for each of the ~100 test files. That dominated both the runtime and the peak memory of the
+// suite, and made CI runners exceed their memory limit (SIGKILL / exit 137).
+// Modules that need Phaser import it themselves; the few tests that also need `globalThis.Phaser`
+// set it at the top of their own file (see src/front/Space/tests/*.test.ts).


### PR DESCRIPTION
## Problem

`play/tests/setup/vitest.setup.ts` ended with a top-level import of Phaser:

```ts
const PhaserModule = await import("phaser");
globalThis.Phaser = PhaserModule.default ?? PhaserModule;
```

Setup files run **once per test file**, and with the default `isolate: true` each run gets a fresh module registry — so Phaser 4's 8.8 MB ESM bundle was evaluated once for each of the ~100 test files in `play`.

The speed cost is visible in vitest's own accounting (`setup 788s` cumulative), but the memory cost is what actually breaks CI. Vitest sizes its fork pool from the **host** CPU count rather than the container's memory limit, so on a large runner the pool grows to ~2.7 GB (main Vite process) + ~470 MB per worker. Past a certain runner size the job exceeds the container limit and is SIGKILLed — surfacing as a bare `Killed` / `exit code 137` right after the `RUN v4.1.7` banner, with no test output at all.

This has been failing intermittently on the WorkAdventure SaaS pipeline (`test_play_image`): same commit, passes on a small runner, OOM-killed on a big one.

## Fix

Remove the global import. Nothing needed it:

- modules that use Phaser import it directly;
- the only tests that also want `globalThis.Phaser` (`src/front/Space/tests/*.test.ts`) already set it themselves on line 2 of their own file;
- the sole remaining `Phaser.` occurrence in a file that does not import phaser (`MapEditorModeManager.ts`) is inside a comment.

The canvas stub above is kept — Phaser still probes canvas features when a test imports it.

## Measurements

Measured on a 12-core machine, `npm test` in `play/`, peak RSS sampled across the whole process tree:

|                        | before | after |
| ---------------------- | ------ | ----- |
| peak RSS               | 8.0 GB | **6.0 GB** |
| wall clock             | 123 s  | **~55 s** |
| cumulative setup time  | 788 s  | **5 s** |

Peak breakdown before the change: 2.7 GB in the main vitest/Vite process + 11 workers × ~470 MB.

## Verification

- `npm test` × 3 (default 11 workers): 622 passed / 10 skipped
- `npm test -- --maxWorkers=4` × 2: green both times, ~68 s
- `npm run lint`, `npm run pretty-check`, `npm run typecheck`: clean

One caveat: in 1 of the 3 unbounded runs a single file (`ProximityChatRoomManager.test.ts`) failed on a 10 s `beforeAll` hook timeout; it passes in 3.8 s in isolation. That is **pre-existing** contention flakiness at 11 workers — the same class of timeout shows up on the unpatched tree (`EnvironmentVariable.test.ts` hitting the 5 s `testTimeout`). It does not reproduce at `--maxWorkers=4`.

## Follow-ups (not in this PR)

- Capping the worker count in CI (`vitest --run --maxWorkers=4`) would bound memory regardless of runner size and remove the timeout flakiness above.
- `test.environment` is `jsdom` for the whole suite, including `tests/pusher/` and `tests/room-api/`; moving those to the `node` environment would cut a good part of the ~200 s cumulative environment setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)