### PR TITLE
perf(play): keep sparse tile layers off the GPU tilemap path

### DIFF
--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -27,6 +27,7 @@ import type { ITiledPlace } from "../GameMapPropertiesListener";
 import type { GameScene } from "../GameScene";
 import { EntitiesManager } from "./EntitiesManager";
 import { AreasManager } from "./AreasManager";
+import { getTileLayerStats, isWorthRenderingOnGpu } from "./TilemapGpuLayerEligibility";
 
 import TilemapLayer = Phaser.Tilemaps.TilemapLayer;
 import TilemapGPULayer = Phaser.Tilemaps.TilemapGPULayer;
@@ -39,7 +40,6 @@ type TileAnimationData = {
     animation?: Array<{ duration?: number }>;
 };
 
-const TILED_TILE_FLIP_FLAGS = 0xe0000000;
 const TILE_ANIMATION_REFRESH_FALLBACK_MS = 100;
 
 export type DynamicArea = {
@@ -253,13 +253,13 @@ export class GameMapFrontWrapper {
             return undefined;
         }
 
-        const tileIndices = this.getLayerTileIndices(layer);
-        if (!tileIndices) {
+        const layerStats = getTileLayerStats(layer.data);
+        if (!layerStats || !isWorthRenderingOnGpu(layerStats)) {
             return undefined;
         }
 
         let layerTileset: Tileset | undefined;
-        for (const tileIndex of tileIndices) {
+        for (const tileIndex of layerStats.tileIndices) {
             const tileset = terrains.find((terrain) => terrain.containsTileIndex(tileIndex));
             if (!tileset) {
                 return undefined;
@@ -274,24 +274,6 @@ export class GameMapFrontWrapper {
         }
 
         return layerTileset;
-    }
-
-    private getLayerTileIndices(layer: ITiledMapTileLayer): Set<number> | undefined {
-        if (!Array.isArray(layer.data)) {
-            return undefined;
-        }
-
-        const tileIndices = new Set<number>();
-        for (const tileId of layer.data) {
-            if (typeof tileId !== "number") {
-                return undefined;
-            }
-            const tileIndex = tileId & ~TILED_TILE_FLIP_FLAGS;
-            if (tileIndex > 0) {
-                tileIndices.add(tileIndex);
-            }
-        }
-        return tileIndices;
     }
 
     public getTileAnimationRefreshDelay(): number | undefined {

--- a/play/src/front/Phaser/Game/GameMap/TilemapGpuLayerEligibility.ts
+++ b/play/src/front/Phaser/Game/GameMap/TilemapGpuLayerEligibility.ts
@@ -1,0 +1,79 @@
+const TILED_TILE_FLIP_FLAGS = 0xe0000000;
+
+/**
+ * Minimum ratio of non-empty cells for a layer to be worth rendering on the GPU.
+ *
+ * Down to this ratio we accept the GPU path shading up to about three times the pixels the classic
+ * path would, in exchange for dropping its per-tile CPU work. Below it the trade stops paying: such
+ * a layer holds few enough tiles for batching them to be cheap, so the constant full-viewport pass
+ * buys nothing.
+ */
+const MIN_GPU_LAYER_FILL_RATIO = 0.35;
+
+/**
+ * Minimum number of non-empty cells for a layer to be worth rendering on the GPU, whatever its fill
+ * ratio. A handful of quads never justifies a full-viewport shader pass, even on a small map whose
+ * layers are densely filled.
+ */
+const MIN_GPU_LAYER_FILLED_CELLS = 256;
+
+export type TileLayerStats = {
+    /** The distinct non-empty tile indices used by the layer, flip flags stripped. */
+    tileIndices: Set<number>;
+    /** The number of non-empty cells in the layer. */
+    filledCellCount: number;
+    /** The total number of cells in the layer. */
+    cellCount: number;
+};
+
+/**
+ * Scans a Tiled tile layer's raw data in a single pass.
+ *
+ * Returns undefined when the data cannot be read directly, which is the case for the encoded and
+ * compressed layer formats. Callers should then fall back to the classic renderer.
+ */
+export function getTileLayerStats(data: string | number[]): TileLayerStats | undefined {
+    if (!Array.isArray(data)) {
+        return undefined;
+    }
+
+    const tileIndices = new Set<number>();
+    let filledCellCount = 0;
+    for (const tileId of data) {
+        if (typeof tileId !== "number") {
+            return undefined;
+        }
+        const tileIndex = tileId & ~TILED_TILE_FLIP_FLAGS;
+        if (tileIndex > 0) {
+            tileIndices.add(tileIndex);
+            filledCellCount++;
+        }
+    }
+
+    return { tileIndices, filledCellCount, cellCount: data.length };
+}
+
+/**
+ * Tells whether a tile layer is dense enough to be rendered as a Phaser `TilemapGPULayer`.
+ *
+ * A `TilemapGPULayer` is drawn as a single quad covering the whole layer: a fragment shader resolves
+ * the tile for every pixel the layer covers on screen. Its cost is therefore the on-screen area of
+ * the layer, whatever the layer actually holds. A classic `TilemapLayer` batches one quad per
+ * non-empty visible tile instead, so its cost follows the tile count.
+ *
+ * That makes the GPU layer a win on dense layers, where it shades the same pixels while moving the
+ * per-tile work off the CPU, and a heavy loss on the sparse overlay layers maps are full of: a door
+ * layer holding four tiles still costs a full-viewport shader pass on every frame. Zoomed out on a
+ * 4K screen that is roughly 6 MPixels of shading to draw four tiles, and a map carrying a dozen such
+ * layers saturates an integrated GPU (see https://github.com/workadventure/workadventure/issues/6399).
+ *
+ * Sending sparse layers back to the classic path costs little by construction: few tiles means few
+ * quads to batch.
+ */
+export function isWorthRenderingOnGpu(stats: TileLayerStats): boolean {
+    if (stats.filledCellCount < MIN_GPU_LAYER_FILLED_CELLS) {
+        return false;
+    }
+
+    return stats.filledCellCount >= stats.cellCount * MIN_GPU_LAYER_FILL_RATIO;
+}

--- a/play/tests/front/Phaser/Map/TilemapGpuLayerEligibility.test.ts
+++ b/play/tests/front/Phaser/Map/TilemapGpuLayerEligibility.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+    getTileLayerStats,
+    isWorthRenderingOnGpu,
+} from "../../../../src/front/Phaser/Game/GameMap/TilemapGpuLayerEligibility";
+
+/**
+ * Builds the raw data of a tile layer of `cellCount` cells, of which the first `filledCellCount`
+ * hold `tileId` and the rest are empty.
+ */
+const createLayerData = (cellCount: number, filledCellCount: number, tileId = 42): number[] =>
+    Array.from({ length: cellCount }, (_, index) => (index < filledCellCount ? tileId : 0));
+
+describe("TilemapGpuLayerEligibility", () => {
+    describe("getTileLayerStats", () => {
+        it("should count the non-empty cells and collect their distinct tile indices", () => {
+            const stats = getTileLayerStats([0, 7, 7, 9, 0, 0]);
+
+            expect(stats).toBeDefined();
+            expect(stats?.cellCount).toBe(6);
+            expect(stats?.filledCellCount).toBe(3);
+            expect([...(stats?.tileIndices ?? [])]).toEqual([7, 9]);
+        });
+
+        it("should strip the Tiled flip flags from the tile indices", () => {
+            const horizontallyFlipped = 0x80000000 | 12;
+            const verticallyFlipped = 0x40000000 | 12;
+
+            const stats = getTileLayerStats([horizontallyFlipped, verticallyFlipped]);
+
+            expect([...(stats?.tileIndices ?? [])]).toEqual([12]);
+            expect(stats?.filledCellCount).toBe(2);
+        });
+
+        it("should return undefined for encoded layer data", () => {
+            expect(getTileLayerStats("H4sIAAAAAAAAA2NgGAWjYBSMglEwCkYBAA==")).toBeUndefined();
+        });
+    });
+
+    describe("isWorthRenderingOnGpu", () => {
+        it("should reject a sparse overlay layer covering a whole map", () => {
+            // Regression test for https://github.com/workadventure/workadventure/issues/6399: the
+            // "dampsoft" map carries ten door layers of four tiles each over a 98x70 map. Rendered on
+            // the GPU, each one costs a full-viewport shader pass on every frame.
+            const stats = getTileLayerStats(createLayerData(98 * 70, 4));
+
+            expect(stats && isWorthRenderingOnGpu(stats)).toBe(false);
+        });
+
+        it("should reject a layer that fills a large but minor part of the map", () => {
+            const stats = getTileLayerStats(createLayerData(98 * 70, 1021));
+
+            expect(stats && isWorthRenderingOnGpu(stats)).toBe(false);
+        });
+
+        it("should accept a moderately filled layer such as the walls of an office map", () => {
+            const stats = getTileLayerStats(createLayerData(98 * 70, Math.round(98 * 70 * 0.42)));
+
+            expect(stats && isWorthRenderingOnGpu(stats)).toBe(true);
+        });
+
+        it("should accept a densely filled floor layer", () => {
+            const stats = getTileLayerStats(createLayerData(98 * 70, Math.round(98 * 70 * 0.98)));
+
+            expect(stats && isWorthRenderingOnGpu(stats)).toBe(true);
+        });
+
+        it("should reject a densely filled layer holding too few tiles to be worth a shader pass", () => {
+            const stats = getTileLayerStats(createLayerData(100, 100));
+
+            expect(stats && isWorthRenderingOnGpu(stats)).toBe(false);
+        });
+
+        it("should reject an empty layer", () => {
+            const stats = getTileLayerStats(createLayerData(98 * 70, 0));
+
+            expect(stats && isWorthRenderingOnGpu(stats)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #6399 (partially — see "What this does not fix" below).

## The problem

A Phaser 4 `TilemapGPULayer` is drawn as a **single quad covering the whole layer**, with a fragment shader resolving the tile for every pixel the layer covers on screen. Its cost is the on-screen area of the layer, whatever the layer actually holds. A classic `TilemapLayer` batches one quad per non-empty visible tile instead, so its cost follows the tile count.

Since the Phaser 4 migration we send every single-tileset layer down the GPU path, sparse overlay layers included. On the map from #6399 that means **21 of its 32 visible layers, holding 10031 tiles between them at 6.96% mean occupancy** — among them ten `doors/door_*_closed` layers of **four tiles each**. Zoomed out on a 4K viewport each of those is a ~6.2 MPixel shader pass:

- **~130 million fragments per frame**, of which the ten door layers alone account for 62 M to draw 40 tiles
- Chrome traces from the reporter show the GPU process main thread **84% busy with back-to-back ~110 ms tasks**, renderer main thread idle at 8–12%, ~19 fps zooming and ~6.5 fps moving around
- ~1 Gfrag/s, which is where an Intel iGPU saturates on a shader doing a data fetch, a byte decode, a dependent tileset fetch, `discard` and blending

### This is likely not specific to that map

The map starter kit's optimizer repacks tilesets into 256-tile chunks, and it packs them per layer. That makes layers *more* likely to reference exactly one tileset than in the Tiled source: on this map the optimizer takes single-tileset layers from 17 to 21, and moves the dense `floor` layer (98.5%, 6754 tiles, 132 distinct tiles, all in `Chunk 1`) onto the GPU path where the unoptimized source had it on the classic one. So optimized maps — which is every published map — are systematically more exposed to this than their sources suggest.

## The change

Only take the GPU path when a layer is dense enough for its constant per-frame cost to pay for itself. Two thresholds, both required:

- `MIN_GPU_LAYER_FILL_RATIO = 0.35` — down to this ratio we accept the GPU path shading up to about three times the pixels the classic path would, in exchange for dropping its per-tile CPU work.
- `MIN_GPU_LAYER_FILLED_CELLS = 256` — a handful of quads never justifies a full-viewport shader pass, even on a small densely filled map.

The heuristic errs in the safe direction: sending a sparse layer back to the classic path is cheap by construction, since few tiles means few quads.

The decision lives in a new pure module, `TilemapGpuLayerEligibility.ts`, so it is unit-testable without standing up Phaser. `getTileLayerStats` is the former `getLayerTileIndices` scan, extended to count filled cells in the same pass.

## Effect

On the published build of the map from #6399:

| | GPU layers | fragments/frame |
|---|---|---|
| before | 21 | ~130 M |
| after | **1** (`floor`, 98.5%) | **~6 M** |

**21x less GPU-layer shading per frame.** The one layer that keeps the GPU path is the one it was designed for: dense, 6754 tiles, which is 6754 quads on the classic path. The other 20 layers hand the classic batcher 3277 tiles in total — nothing; Phaser 3 drew all 32 visible layers that way until July.

On our own maps the split lands the same way: `maps/starter` keeps `floor` (100%), `maps/Tuto` keeps `sol-fond-terre-sombre`, `sol-fond-terre-claire` and `sol-herbe` (54–71%), and every sparse decoration and zone layer goes back to the classic batcher.

Side effect worth having: `putTile` refuses tiles from another tileset on GPU layers, and `addTerrain` skips them entirely. Sparse zone layers are exactly where scripts call `setTiles`, so this also un-breaks a scripting-API regression from the migration.

## What this does not fix

This is a mitigation on our side, not the root cause. `TilemapGPULayer` does no culling at all: the quad is the full layer extent regardless of where its tiles are. Clipping the quad to the non-empty bounding box would cut this map's GPU-layer cost by ~8x on its own, and 8x8-tile chunk culling by ~11x, without needing any heuristic. That belongs upstream in Phaser and is being worked on separately.

One other contributor to #6399 is also still open: on a 4K screen the WebGL drawing buffer sits at the full 3840x2105 (32.3 MB, visible in the traces as the exact allocation step size) whenever a zoom is animating or max zoom-out is reached, instead of the ~768x421 canvas `WaScaleManager` normally keeps. That is a 25x fragment multiplier on top of everything else.

## Tests

New `TilemapGpuLayerEligibility.test.ts`, 9 cases, including a regression test pinned to this issue: a four-tile door layer on a 98x70 map must not take the GPU path. Full `play` front suite green (35 files, 202 tests), plus typecheck, eslint and prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)