### PR TITLE
feat(BBBCoWebsite): add speaker-selection policy

### DIFF
--- a/play/src/front/WebRtc/BBBFactory.ts
+++ b/play/src/front/WebRtc/BBBFactory.ts
@@ -13,7 +13,7 @@ class BBBFactory {
         const coWebsite = new BBBCoWebsite(
             new URL(clientURL),
             false,
-            "microphone *; camera *; display-capture *; clipboard-read *; clipboard-write *; screen-wake-lock *;  fullscreen *; geolocation *;",
+            "microphone *; camera *; display-capture *; clipboard-read *; clipboard-write *; screen-wake-lock *;  fullscreen *; geolocation *; speaker-selection *;",
         );
         coWebsites.add(coWebsite);
     }


### PR DESCRIPTION
## Context

Firefox does not expose audio output devices to a cross-origin iframe unless the `speaker-selection` permission is delegated to it. Inside a WorkAdventure BBB meeting that means the BigBlueButton client cannot enumerate or select audio outputs, so participants have no way to switch between speakers and headphones without changing it at the OS level.

## What this adds

`speaker-selection *` in the `allow` policy of the `BBBCoWebsite` created by `BBBFactory`, alongside the permissions already delegated there ([directive reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy/speaker-selection)).

## Notes

- Additive and backwards compatible: browsers ignore `allow` tokens they do not recognise, so the rest of the policy is unaffected where `speaker-selection` is unsupported.
- Verified manually in Firefox with a cross-origin iframe: audio output selection works when the directive is delegated and fails when it is not.