### PR TITLE
fix(play): stop reporting expected connection lifecycle events to Sentry

### DIFF
--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -2183,7 +2183,16 @@ export class RoomConnection implements RoomConnection {
 
         if (!this.isRoomJoined && !force) {
             this.eventBeforeRoomJoinedQueue.push(message);
-            Sentry.captureMessage("RoomConnection: Event before room joined queue: " + message.message?.$case);
+            // Expected startup race: the queue is replayed as soon as roomJoinedMessage arrives, so
+            // nothing is lost. Reporting it as an event cost ~19k Sentry events a month for a case
+            // that is handled by design. A breadcrumb keeps the information in the timeline of a real
+            // error instead, at no quota cost.
+            Sentry.addBreadcrumb({
+                category: "room-connection",
+                level: "info",
+                message: "Event queued before room joined",
+                data: { case: message.message?.$case },
+            });
             return;
         }
 

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -1960,7 +1960,16 @@ export class RoomConnection implements RoomConnection {
             console.warn(
                 "Timeout detected. No ping from the server received. Is your connection down? Closing connection.",
             );
-            Sentry.captureMessage("RoomConnection: Ping timeout - closing connection");
+            // A dead connection is a network condition, not a defect: closing here hands over to the
+            // reconnection flow (cleanupConnection emits serverDisconnected, GameScene waits for the
+            // pusher and rebuilds the scene). Reporting it as an event cost ~25k Sentry events a month
+            // without anyone ever acting on one. A breadcrumb keeps it in the timeline of a real error.
+            Sentry.addBreadcrumb({
+                category: "room-connection",
+                level: "info",
+                message: "Ping timeout - closing connection",
+                data: { manualPingDelayMs: manualPingDelay },
+            });
             this.socket.close();
             this.cleanupConnection(false);
         }, manualPingDelay);


### PR DESCRIPTION
## Problem

Two `Sentry.captureMessage` calls in `RoomConnection` report expected connection lifecycle events. Together they account for **~44 600 Sentry events over 30 days — 12.4% of the whole organisation total**, on a plan capped by event count. Neither has ever been acted upon.

### 1. Events queued before the room is joined — ~19 000 / 30 d

```ts
if (!this.isRoomJoined && !force) {
    this.eventBeforeRoomJoinedQueue.push(message);
    Sentry.captureMessage("RoomConnection: Event before room joined queue: " + message.message?.$case);
    return;
}
```

An expected startup race, not a defect: the message is queued and replayed as soon as `roomJoinedMessage` arrives (`RoomConnection.ts:597`), so nothing is lost. The dominant queued message is `viewportMessage`, sent on every move, so a short join delay produces a burst rather than a single event.

Split across five issues that differ only by room: [PLAY-3YB](https://workadventure-e6.sentry.io/issues/PLAY-3YB), [PLAY-3Y5](https://workadventure-e6.sentry.io/issues/PLAY-3Y5), [PLAY-3Y4](https://workadventure-e6.sentry.io/issues/PLAY-3Y4), [PLAY-3Y7](https://workadventure-e6.sentry.io/issues/PLAY-3Y7), [PLAY-3Z1](https://workadventure-e6.sentry.io/issues/PLAY-3Z1).

### 2. Ping timeout — ~25 500 / 30 d, 15 542 users

[PLAY-20P](https://workadventure-e6.sentry.io/issues/PLAY-20P). A timeout means the connection died: the device slept, the network dropped, the tab was frozen. That is a network condition, and the code already recovers — `cleanupConnection(false)` emits `serverDisconnected`, `GameScene` shows the connection-issue message, waits for the pusher and rebuilds the scene.

## Fix

Replace both events with breadcrumbs. Breadcrumbs are buffered locally and consume **no quota**; they are attached to the next real error, so the information stays available — with more surrounding context than an isolated message — precisely when it becomes useful.

Deliberately **not** changed: the `captureMessage` in `handleSocketClose` ([PLAY-20N](https://workadventure-e6.sentry.io/issues/PLAY-20N)). That one is a genuine bug signal — on a 60-event sample, ~90% are close code `1008`, a deliberate rejection by the pusher, and 82% carry the single reason `Cannot replace socket: previous connection not retained`. It should be fixed, not silenced.

## Known follow-up, not addressed here

This PR only stops the reporting of the ping timeout. The underlying tuning problem is untouched: `manualPingDelay` is 100 s (`RoomConnection.ts:144`) against the back's `PING_INTERVAL` of 80 s (`back/src/RoomManager.ts:53`), leaving 20 s of margin. **Losing a single ping is therefore enough to tear down a healthy connection**, since the next one would arrive at 160 s. The back budgets 70 s for the same phenomenon in reverse (`PONG_TIMEOUT`, with an explicit comment about Chrome background-tab throttling); the front budgets 20.

Raising the delay to ~2.5 x `PING_INTERVAL` deserves its own PR, together with faster wake-from-sleep detection so that a longer delay does not slow down recovery.

## Validation

- `tsc --noEmit` — no error on `RoomConnection.ts`
- `prettier --check` and `eslint` — clean
- No behaviour change: only the reporting calls differ. The queue and its replay, and the timeout's close-and-recover path, are untouched.

## Note

`Sentry.addBreadcrumb` is not used elsewhere in `play` yet. The default Sentry integrations already produce breadcrumbs (console, fetch, DOM), so the buffer is active and these entries join the existing timeline.