### PR TITLE
Pusher: one application for the HTTP routes and the websockets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6333,9 +6333,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -8376,6 +8376,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -10405,6 +10417,12 @@
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "license": "MIT"
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10499,6 +10517,16 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fast-zlib": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-zlib/-/fast-zlib-2.0.1.tgz",
+      "integrity": "sha512-DCoYgNagM2Bt1VIpXpdGnRx4LzqJeYG0oh6Nf/7cWo6elTXkFGMw9CrRCYYUIapYNrozYMoyDRflx9mgT3Awyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/timotejroiko"
       }
     },
     "node_modules/fdir": {
@@ -10776,6 +10804,60 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fulmine.js": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/fulmine.js/-/fulmine.js-5.14.0.tgz",
+      "integrity": "sha512-Xznl3GEity4XSO2yLI8p3uivAxAf+pXB9s/NXaXgELXxojS9IRF6DQhEdj2RrcyvkYlQfvlFwTRjhY2+5LuOOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/express": "^5.0.6",
+        "accepts": "^2.0.0",
+        "acorn": "^8.18.0",
+        "bytes": "^3.1.2",
+        "compressible": "^2.0.18",
+        "content-disposition": "^1.1.0",
+        "cookie": "^0.7.2",
+        "cookie-signature": "^1.2.2",
+        "encodeurl": "^2.0.0",
+        "fast-decode-uri-component": "^1.0.1",
+        "fast-zlib": "^2.0.1",
+        "fresh": "^2.0.0",
+        "iconv-lite": "^0.7.3",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.15.3",
+        "range-parser": "^1.3.0",
+        "statuses": "^2.0.2",
+        "tseep": "^1.3.1",
+        "type-is": "^2.1.0",
+        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.69.0",
+        "vary": "^1.1.2"
+      },
+      "bin": {
+        "fulmine": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@nestjs/platform-express": ">=10"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fulmine.js/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/function-bind": {
@@ -11492,9 +11574,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -15547,12 +15629,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -15699,12 +15782,16 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -16500,14 +16587,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -18477,6 +18564,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tseep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tseep/-/tseep-1.3.1.tgz",
+      "integrity": "sha512-ZPtfk1tQnZVyr7BPtbJ93qaAh2lZuIOpTMjhrYa4XctT8xe7t4SAW9LIxrySDuYMsfNNayE51E/WNGrNVgVicQ==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -20152,6 +20245,7 @@
         "emoji-picker-element": "^1.29.1",
         "express": "^5.2.1",
         "fast-deep-equal": "^3.1.3",
+        "fulmine.js": "^5.14.0",
         "google-protobuf": "^4.0.2",
         "highlight-words": "^2.0.0",
         "highlight.js": "^11.11.1",

--- a/play/package.json
+++ b/play/package.json
@@ -145,6 +145,7 @@
     "emoji-picker-element": "^1.29.1",
     "express": "^5.2.1",
     "fast-deep-equal": "^3.1.3",
+    "fulmine.js": "^5.14.0",
     "google-protobuf": "^4.0.2",
     "highlight-words": "^2.0.0",
     "highlight.js": "^11.11.1",

--- a/play/src/pusher/app.ts
+++ b/play/src/pusher/app.ts
@@ -1,10 +1,8 @@
 import fs from "fs";
-import type { Application } from "express";
-import express from "express";
+import express from "fulmine.js";
 import cookieParser from "cookie-parser";
 import * as Sentry from "@sentry/node";
 import cors from "cors";
-import uWebsockets from "uWebSockets.js";
 import { adminApi } from "./services/AdminApi";
 import { IoSocketController } from "./controllers/IoSocketController";
 import { AuthenticateController } from "./controllers/AuthenticateController";
@@ -20,6 +18,7 @@ import {
     ENABLE_OPENAPI_ENDPOINT,
     PROMETHEUS_PORT,
     GRPC_MAX_MESSAGE_SIZE,
+    PUSHER_HTTP_PORT,
 } from "./enums/EnvironmentVariable";
 import { PingController } from "./controllers/PingController";
 import { CompanionListController } from "./controllers/CompanionListController";
@@ -37,12 +36,12 @@ import { videoQualityAnalyticsQueue } from "./services/VideoQualityAnalyticsQueu
 const VIDEO_QUALITY_ANALYTICS_CAPABILITY = "api/analytics/video-quality-batch";
 
 class App {
-    private readonly app: Application;
-    private readonly websocketApp: uWebsockets.TemplatedApp;
-    private readonly prometheusWebserver: Application | undefined;
+    private readonly app: express.FulmineApplication;
+    private readonly prometheusWebserver: express.FulmineApplication | undefined;
 
     constructor() {
-        this.websocketApp = uWebsockets.App();
+        // One application for both: the websocket routes are registered on it with app.ws(), so
+        // the upgrade is decided by the same request and response objects the HTTP routes get.
         this.app = express();
 
         // LiveKit webhooks must keep the raw body for signature verification in the back; register before express.json().
@@ -89,7 +88,7 @@ class App {
         }
 
         // Socket controllers
-        new IoSocketController(this.websocketApp);
+        new IoSocketController(this.app);
 
         // Http controllers
         new AuthenticateController(this.app);
@@ -212,16 +211,17 @@ class App {
         });
     }
 
+    /**
+     * The same application on a second port, so PUSHER_WS_PORT keeps meaning what it meant and
+     * nothing in front of this service has to be reconfigured. Both ports now serve both the HTTP
+     * routes and the websockets; a deployment that wants one port can point them at the same
+     * number, and this listens once.
+     */
     public listenWebSocket(port: number): Promise<void> {
-        return new Promise((resolve, reject) => {
-            this.websocketApp.listen(port, (token) => {
-                if (token) {
-                    resolve();
-                } else {
-                    reject(new Error(`Error starting WorkAdventure Pusher on port ${port}!`));
-                }
-            });
-        });
+        if (port === PUSHER_HTTP_PORT) {
+            return Promise.resolve();
+        }
+        return this.listenWebServer(port);
     }
 
     public listenPrometheusPort(): Promise<void> {

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -3,7 +3,7 @@ import type { AnswerMessage, CompanionDetail, ErrorApiData, WokaDetail } from "@
 import { apiVersionHash, noUndefined } from "@workadventure/messages";
 import { errors } from "jose";
 import * as Sentry from "@sentry/node";
-import type { TemplatedApp, WebSocket } from "uWebSockets.js";
+import type express from "fulmine.js";
 import { asError } from "catch-unknown";
 import Debug from "debug";
 import { AxiosError } from "axios";
@@ -19,6 +19,7 @@ import {
     SOCKET_IDLE_TIMER,
 } from "../enums/EnvironmentVariable";
 import type { AdminSocketData } from "../models/Websocket/AdminSocketData";
+import { adminDataOf } from "../models/Websocket/AdminSocketData";
 import type { AdminMessageInterface } from "../models/Websocket/Admin/AdminMessages";
 import { isAdminMessageInterface } from "../models/Websocket/Admin/AdminMessages";
 import { adminService } from "../services/AdminService";
@@ -32,7 +33,7 @@ import {
 import { videoQualityAnalyticsQueue } from "../services/VideoQualityAnalyticsQueue";
 import { PusherRoomSocketController } from "../services/PusherRoomSocketController";
 import { AdminWebSocketBackpressureWriter } from "../services/AdminWebSocketBackpressureWriter";
-import type { PusherWebSocket } from "../services/PusherWebSocket";
+import type { PusherWebSocket, SocketRequest } from "../services/PusherWebSocket";
 
 type PendingAnswerMessage = Omit<AnswerMessage, "answer"> & { answer?: AnswerMessage["answer"] };
 
@@ -62,9 +63,9 @@ export type UpgradeFailedData = UpgradeFailedErrorData | UpgradeFailedInvalidDat
 
 export class IoSocketController {
     private readonly roomSocketController: PusherRoomSocketController;
-    private readonly adminSocketWriters = new WeakMap<WebSocket<AdminSocketData>, AdminWebSocketBackpressureWriter>();
+    private readonly adminSocketWriters = new WeakMap<express.FulmineSocket, AdminWebSocketBackpressureWriter>();
 
-    constructor(private readonly app: TemplatedApp) {
+    constructor(private readonly app: express.FulmineApplication) {
         // Global handler for unhandled Promises
         // The listener never needs to be removed, because we are in a singleton that is never destroyed.
         // eslint-disable-next-line listeners/no-missing-remove-event-listener,listeners/no-inline-function-event-listener
@@ -82,34 +83,22 @@ export class IoSocketController {
     }
 
     adminRoomSocket(): void {
-        this.app.ws<AdminSocketData>("/ws/admin/rooms", {
+        this.app.ws("/ws/admin/rooms", {
             maxBackpressure: PUSHER_ADMIN_WS_MAX_BACKPRESSURE_BYTES,
-            upgrade: (res, req, context) => {
-                const websocketKey = req.getHeader("sec-websocket-key");
-                const websocketProtocol = req.getHeader("sec-websocket-protocol");
-                const websocketExtensions = req.getHeader("sec-websocket-extensions");
-
-                res.cork(() => {
-                    res.upgrade<AdminSocketData>(
-                        {
-                            adminConnections: new Map(),
-                            disconnecting: false,
-                            sendMessage: () => {
-                                return;
-                            },
-                        },
-                        websocketKey,
-                        websocketProtocol,
-                        websocketExtensions,
-                        context,
-                    );
-                });
+            upgrade: (req: SocketRequest<AdminSocketData>) => {
+                req.socketData = {
+                    adminConnections: new Map(),
+                    disconnecting: false,
+                    sendMessage: () => {
+                        return;
+                    },
+                };
             },
             open: (ws) => {
                 console.info(
                     "Admin socket connect to client on " + Buffer.from(ws.getRemoteAddressAsText()).toString(),
                 );
-                ws.getUserData().disconnecting = false;
+                adminDataOf(ws).disconnecting = false;
                 const writer = new AdminWebSocketBackpressureWriter(ws, {
                     maxQueuedMessages: 1_000,
                     maxQueuedBytes: PUSHER_ADMIN_WS_MAX_BACKPRESSURE_BYTES,
@@ -122,7 +111,7 @@ export class IoSocketController {
                     },
                 });
                 this.adminSocketWriters.set(ws, writer);
-                ws.getUserData().sendMessage = (message) => {
+                adminDataOf(ws).sendMessage = (message) => {
                     writer.send(message);
                 };
             },
@@ -141,7 +130,7 @@ export class IoSocketController {
                         }
                         Sentry.captureException(`Invalid message received. ${JSON.stringify(message)}`);
                         console.error("Invalid message received.", message);
-                        ws.getUserData().sendMessage(
+                        adminDataOf(ws).sendMessage(
                             JSON.stringify({
                                 type: "Error",
                                 data: {
@@ -161,7 +150,7 @@ export class IoSocketController {
                         data = await jwtTokenManager.verifyAdminSocketToken(token);
                     } catch (e) {
                         console.error("Admin socket access refused for token: " + token, e);
-                        ws.getUserData().sendMessage(
+                        adminDataOf(ws).sendMessage(
                             JSON.stringify({
                                 type: "Error",
                                 data: {
@@ -186,7 +175,7 @@ export class IoSocketController {
                             ).toString()} listening of : \n${JSON.stringify(notAuthorizedRoom)}`;
                             Sentry.captureException(errorMessage);
                             console.error(errorMessage);
-                            ws.getUserData().sendMessage(
+                            adminDataOf(ws).sendMessage(
                                 JSON.stringify({
                                     type: "Error",
                                     data: {
@@ -241,7 +230,7 @@ export class IoSocketController {
             },
             close: (ws) => {
                 try {
-                    ws.getUserData().disconnecting = true;
+                    adminDataOf(ws).disconnecting = true;
                     this.adminSocketWriters.get(ws)?.close("target_closed");
                     this.adminSocketWriters.delete(ws);
                     socketManager.leaveAdminRoom(ws);

--- a/play/src/pusher/models/Websocket/AdminSocketData.ts
+++ b/play/src/pusher/models/Websocket/AdminSocketData.ts
@@ -1,5 +1,7 @@
 import type { AdminPusherToBackMessage, ServerToAdminClientMessage } from "@workadventure/messages";
 import type { ClientDuplexStream } from "@grpc/grpc-js";
+import type express from "fulmine.js";
+import type { Request } from "express";
 
 export type AdminConnection = ClientDuplexStream<AdminPusherToBackMessage, ServerToAdminClientMessage>;
 
@@ -8,3 +10,11 @@ export type AdminSocketData = {
     disconnecting: boolean;
     sendMessage: (message: string) => void;
 };
+
+/** The socket the admin route opens: uWS carries the upgrade's request for its whole life. */
+export type AdminSocket = express.FulmineSocket;
+
+/** What the admin upgrade left on that request. */
+export function adminDataOf(socket: AdminSocket): AdminSocketData {
+    return (socket.req as Request & { socketData: AdminSocketData }).socketData;
+}

--- a/play/src/pusher/services/PusherRoomSocketController.ts
+++ b/play/src/pusher/services/PusherRoomSocketController.ts
@@ -1,4 +1,4 @@
-import type { TemplatedApp, HttpResponse, HttpRequest, us_socket_context_t } from "uWebSockets.js";
+import type express from "fulmine.js";
 import {
     type ClientToServerMessage,
     PusherToFrontWebSocketMessage,
@@ -11,7 +11,7 @@ import { CLIENT_DISCONNECTION_RETENTION_MS } from "../enums/EnvironmentVariable"
 import type { ConnectingSocketData } from "../models/Websocket/SocketData";
 import type { UpgradeFailedData } from "../controllers/IoSocketController";
 import { PusherWebSocket } from "./PusherWebSocket";
-import type { RawSocket } from "./PusherWebSocket";
+import type { RawSocket, SocketRequest } from "./PusherWebSocket";
 import { validateWebsocketQuery } from "./QueryValidator";
 import { getClientIpFromXForwardedFor } from "./ClientIp";
 
@@ -56,6 +56,11 @@ type RoomWsConfig<TQuery extends RoomWsQuery> = {
     close: CloseHandler;
 };
 
+/** What the upgrade hook left on the request, which the socket carries for its whole life. */
+function socketDataOf(ws: express.FulmineSocket): ConnectingSocketData | UpgradeFailedData {
+    return (ws.req as SocketRequest).socketData;
+}
+
 type WebSocketContext = {
     socket?: PusherWebSocket;
     clientLastReceivedNonce?: number;
@@ -66,7 +71,7 @@ export class PusherRoomSocketController {
     private readonly contextByTabKey = new Map<string, WebSocketContext>();
     private readonly contextCleanupTimeoutsByTabKey = new Map<string, ReturnType<typeof setTimeout>>();
 
-    public constructor(private readonly app: TemplatedApp) {}
+    public constructor(private readonly app: express.FulmineApplication) {}
 
     private getOrCreateWrapper(rawSocket: RawSocket): PusherWebSocket {
         const existingWrapper = this.wrappersBySocket.get(rawSocket);
@@ -76,39 +81,6 @@ export class PusherRoomSocketController {
         const wrapper = new PusherWebSocket(rawSocket);
         this.wrappersBySocket.set(rawSocket, wrapper);
         return wrapper;
-    }
-
-    private rejectWithInternalError(
-        res: HttpResponse,
-        req: HttpRequest,
-        context: us_socket_context_t,
-        details: string,
-    ): void {
-        const websocketKey = req.getHeader("sec-websocket-key");
-        const websocketProtocol = req.getHeader("sec-websocket-protocol");
-        const websocketExtensions = req.getHeader("sec-websocket-extensions");
-
-        res.cork(() => {
-            res.upgrade(
-                {
-                    rejected: true,
-                    reason: "error",
-                    error: {
-                        status: "error",
-                        type: "error",
-                        title: "500 Internal Server Error",
-                        subtitle: "Something wrong happened while connecting!",
-                        image: "",
-                        code: "internal_error",
-                        details,
-                    },
-                } satisfies UpgradeFailedData,
-                websocketKey,
-                websocketProtocol,
-                websocketExtensions,
-                context,
-            );
-        });
     }
 
     private parseReconnectNonce(rawValue: string | undefined, key: string): number | undefined {
@@ -144,25 +116,6 @@ export class PusherRoomSocketController {
         return true;
     }
 
-    private upgradeSocket(
-        aborted: boolean,
-        res: HttpResponse,
-        data: ConnectingSocketData | UpgradeFailedData,
-        websocketKey: string,
-        websocketProtocol: string,
-        websocketExtensions: string,
-        context: us_socket_context_t,
-    ) {
-        if (aborted) {
-            // If the response points to nowhere, don't attempt an upgrade
-            return;
-        }
-
-        res.cork(() => {
-            res.upgrade(data, websocketKey, websocketProtocol, websocketExtensions, context);
-        });
-    }
-
     private clearContextCleanup(tabId: string): void {
         const timeout = this.contextCleanupTimeoutsByTabKey.get(tabId);
         if (!timeout) {
@@ -174,30 +127,26 @@ export class PusherRoomSocketController {
     }
 
     public ws<TQuery extends RoomWsQuery>(path: string, config: RoomWsConfig<TQuery>): void {
-        this.app.ws<ConnectingSocketData | UpgradeFailedData>(path, {
+        this.app.ws(path, {
             idleTimeout: config.idleTimeout,
             maxPayloadLength: config.maxPayloadLength,
             maxBackpressure: config.maxBackpressure,
-            upgrade: (res, req, context) => {
-                (async () => {
-                    const upgradeAborted = { aborted: false };
-
-                    res.onAborted(() => {
-                        upgradeAborted.aborted = true;
-                    });
-
-                    const query = validateWebsocketQuery(req, res, context, config.queryValidator);
-                    if (query === undefined) {
+            // The handshake is the framework's: the key, the protocol and the extensions, the cork
+            // and the abort are handled there. What is left here is what this service decides, and
+            // it decides it with the same request and response every HTTP route gets. Leaving
+            // `socketData` unset refuses the socket, so no path can silently leave a client hanging.
+            upgrade: async (req: SocketRequest, res) => {
+                try {
+                    const validated = validateWebsocketQuery(req, config.queryValidator);
+                    if (!validated.success) {
+                        req.socketData = validated.failure;
                         return;
                     }
-
-                    const websocketKey = req.getHeader("sec-websocket-key");
-                    const websocketProtocol = req.getHeader("sec-websocket-protocol");
-                    const websocketExtensions = req.getHeader("sec-websocket-extensions");
-                    const urlSearchParams = new URLSearchParams(req.getQuery());
+                    const query = validated.data;
+                    const websocketProtocol = req.get("sec-websocket-protocol") ?? "";
 
                     const clientLastReceivedNonce = this.parseReconnectNonce(
-                        urlSearchParams.get("lastReceivedNonce") ?? undefined,
+                        typeof req.query.lastReceivedNonce === "string" ? req.query.lastReceivedNonce : undefined,
                         "lastReceivedNonce",
                     );
                     const tabContext = this.contextByTabKey.get(query.tabId);
@@ -207,64 +156,57 @@ export class PusherRoomSocketController {
                         this.canReplaceTransportWithoutUpgrade(query, websocketProtocol, tabContext)
                     ) {
                         tabContext.clientLastReceivedNonce = clientLastReceivedNonce;
-                        this.upgradeSocket(
-                            upgradeAborted.aborted,
-                            res,
-                            { ...tabContext.socket.getUserData() },
-                            websocketKey,
-                            websocketProtocol,
-                            websocketExtensions,
-                            context,
-                        );
+                        req.socketData = { ...tabContext.socket.getUserData() };
                         return;
                     }
-                    const ipAddress = getClientIpFromXForwardedFor(req.getHeader("x-forwarded-for"));
+
                     await config.upgrade({
                         query,
                         request: {
-                            method: req.getMethod(),
-                            url: req.getUrl(),
-                            ipAddress,
-                            locale: req.getHeader("accept-language"),
+                            method: req.method,
+                            url: req.path,
+                            ipAddress: getClientIpFromXForwardedFor(req.get("x-forwarded-for") ?? ""),
+                            locale: req.get("accept-language") ?? "",
                             token: websocketProtocol,
                         },
-                        isAborted: () => upgradeAborted.aborted,
+                        isAborted: () => res.aborted === true,
                         upgrade: (data) => {
                             const tabContext = this.contextByTabKey.get(query.tabId) ?? {};
                             tabContext.clientLastReceivedNonce = clientLastReceivedNonce;
                             this.contextByTabKey.set(query.tabId, tabContext);
-
-                            this.upgradeSocket(
-                                upgradeAborted.aborted,
-                                res,
-                                data,
-                                websocketKey,
-                                websocketProtocol,
-                                websocketExtensions,
-                                context,
-                            );
+                            req.socketData = data;
                         },
                         reject: (data) => {
-                            this.upgradeSocket(
-                                upgradeAborted.aborted,
-                                res,
-                                data,
-                                websocketKey,
-                                websocketProtocol,
-                                websocketExtensions,
-                                context,
-                            );
+                            req.socketData = data;
                         },
                     });
-                })().catch((e) => {
+
+                    if (req.socketData === undefined && res.aborted !== true) {
+                        // neither upgraded nor rejected: refuse rather than open a socket whose
+                        // data nothing set
+                        res.sendStatus(500);
+                    }
+                } catch (e) {
                     Sentry.captureException(e);
                     console.error(e);
-                    this.rejectWithInternalError(res, req, context, asError(e).message);
-                });
+                    req.socketData = {
+                        rejected: true,
+                        reason: "error",
+                        error: {
+                            status: "error",
+                            type: "error",
+                            title: "500 Internal Server Error",
+                            subtitle: "Something wrong happened while connecting!",
+                            image: "",
+                            code: "internal_error",
+                            details: asError(e).message,
+                        },
+                    } satisfies UpgradeFailedData;
+                }
             },
             open: (ws) => {
                 (async () => {
-                    const socketData = ws.getUserData();
+                    const socketData = socketDataOf(ws);
 
                     if (socketData.rejected === true) {
                         const errorMessage = await config.rejectedOpen(socketData);
@@ -327,7 +269,7 @@ export class PusherRoomSocketController {
                 });
             },
             message: (ws, arrayBuffer) => {
-                if (ws.getUserData().rejected === true) {
+                if (socketDataOf(ws).rejected === true) {
                     ws.end(1008, "Connection rejected");
                     return;
                 }
@@ -352,7 +294,7 @@ export class PusherRoomSocketController {
                 });
             },
             drain: (ws) => {
-                if (ws.getUserData().rejected === true) {
+                if (socketDataOf(ws).rejected === true) {
                     return;
                 }
 
@@ -364,7 +306,7 @@ export class PusherRoomSocketController {
                 socket.handleDrain();
             },
             close: (ws, code, message) => {
-                const socketData = ws.getUserData();
+                const socketData = socketDataOf(ws);
                 if (socketData.rejected === true) {
                     return;
                 }

--- a/play/src/pusher/services/PusherWebSocket.ts
+++ b/play/src/pusher/services/PusherWebSocket.ts
@@ -1,4 +1,5 @@
 import type { WebSocket } from "uWebSockets.js";
+import type { Request } from "express";
 import {
     FrontToPusherWebSocketMessage,
     PusherToFrontWebSocketMessage,
@@ -13,7 +14,17 @@ import { NoncedMessageStore } from "../../common/NoncedMessageStore";
 
 import type { SocketData } from "../models/Websocket/SocketData";
 
-export type RawSocket = WebSocket<SocketData>;
+import type { ConnectingSocketData } from "../models/Websocket/SocketData";
+import type { UpgradeFailedData } from "../controllers/IoSocketController";
+
+/**
+ * The request the upgrade hook was given, carrying what this service decided about the socket.
+ * uWS keeps whatever the handshake attached for the life of the connection, and the framework
+ * attaches the request, so this is where the socket data lives now.
+ */
+export type SocketRequest<T = ConnectingSocketData | UpgradeFailedData> = Request & { socketData: T };
+
+export type RawSocket = WebSocket<{ req: SocketRequest<SocketData> }> & { req: SocketRequest<SocketData> };
 
 export class PusherWebSocket {
     private static readonly KEEP_ALIVE_INTERVAL_MS = 25_000;
@@ -42,7 +53,7 @@ export class PusherWebSocket {
     }
 
     public getUserData(): SocketData {
-        return this.socket.getUserData();
+        return this.socket.req.socketData;
     }
 
     public send(message: ServerToClientMessage): ReturnType<RawSocket["send"]> {
@@ -180,7 +191,7 @@ export class PusherWebSocket {
     }
 
     public replaceSocket(newSocket: RawSocket, clientLastReceivedNonce: number): boolean {
-        const socketData = this.socket.getUserData();
+        const socketData = this.socket.req.socketData;
         console.info(
             `Replacing WebSocket transport for user ${socketData.userUuid} on tab ${socketData.tabId} (lastReceivedNonce=${clientLastReceivedNonce})`,
         );
@@ -211,8 +222,8 @@ export class PusherWebSocket {
         }
 
         const previousSocket = this.socket;
-        const previousSocketData = previousSocket.getUserData();
-        const newSocketData = newSocket.getUserData();
+        const previousSocketData = previousSocket.req.socketData;
+        const newSocketData = newSocket.req.socketData;
 
         if (previousSocketData.userUuid !== newSocketData.userUuid) {
             console.warn(

--- a/play/src/pusher/services/QueryValidator.ts
+++ b/play/src/pusher/services/QueryValidator.ts
@@ -1,6 +1,5 @@
 import type { z, ZodObject, ZodRawShape } from "zod";
 import type { Request, Response } from "express";
-import type { HttpRequest, HttpResponse, us_socket_context_t } from "uWebSockets.js";
 import type { UpgradeFailedData } from "../controllers/IoSocketController";
 
 function validateObject<T extends ZodObject<ZodRawShape>>(
@@ -44,53 +43,36 @@ export function validatePostQuery<T extends ZodObject<ZodRawShape>>(
 }
 
 /**
- * Either validates the query and returns the parsed query data (according to the validator passed in parameter)
- * or fills the response with a HTTP 400 message and returns undefined.
+ * The same for a websocket upgrade. The query is the one the request already parsed, so this is
+ * the same validation as above; only the failure differs, because a socket carries its error to
+ * the client over the connection rather than as a 400 nobody would read.
  */
 export function validateWebsocketQuery<T extends ZodObject<ZodRawShape>>(
-    req: HttpRequest,
-    res: HttpResponse,
-    context: us_socket_context_t,
+    req: Request,
     validator: T,
-): z.infer<T> | undefined {
-    const urlSearchParams = new URLSearchParams(req.getQuery());
-    const params: Record<string, string | string[]> = {};
-    for (const key of [...new Set(urlSearchParams.keys())]) {
-        const values = urlSearchParams.getAll(key);
-        params[key] = values.length > 1 ? values : values[0];
-    }
-    const result = validator.safeParse(params);
+): { success: true; data: z.infer<T> } | { success: false; failure: UpgradeFailedData } {
+    const result = validator.safeParse(req.query);
 
     if (result.success) {
-        return result.data;
-    } else {
-        const messages = result.error.issues.map((issue) => "Parameter " + issue.path + ": " + issue.message);
-
-        const websocketKey = req.getHeader("sec-websocket-key");
-        const websocketProtocol = req.getHeader("sec-websocket-protocol");
-        const websocketExtensions = req.getHeader("sec-websocket-extensions");
-
-        res.cork(() => {
-            res.upgrade(
-                {
-                    rejected: true,
-                    reason: "error",
-                    error: {
-                        status: "error",
-                        type: "error",
-                        title: "400 Bad Request",
-                        subtitle: "Something wrong happened while connecting!",
-                        image: "",
-                        code: "WS_BAD_REQUEST",
-                        details: messages.join("\n"),
-                    },
-                } satisfies UpgradeFailedData,
-                websocketKey,
-                websocketProtocol,
-                websocketExtensions,
-                context,
-            );
-        });
-        return undefined;
+        return { success: true, data: result.data };
     }
+
+    const messages = result.error.issues.map((issue) => "Parameter " + issue.path + ": " + issue.message);
+
+    return {
+        success: false,
+        failure: {
+            rejected: true,
+            reason: "error",
+            error: {
+                status: "error",
+                type: "error",
+                title: "400 Bad Request",
+                subtitle: "Something wrong happened while connecting!",
+                image: "",
+                code: "WS_BAD_REQUEST",
+                details: messages.join("\n"),
+            },
+        },
+    };
 }

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -57,7 +57,8 @@ import { PusherRoom } from "../models/PusherRoom";
 import type { SocketData, BackConnection } from "../models/Websocket/SocketData";
 
 import type { GroupDescriptor, UserDescriptor, ZoneEventListener } from "../models/Zone";
-import type { AdminConnection, AdminSocketData } from "../models/Websocket/AdminSocketData";
+import type { AdminConnection, AdminSocket } from "../models/Websocket/AdminSocketData";
+import { adminDataOf } from "../models/Websocket/AdminSocketData";
 import { EMBEDDED_DOMAINS_WHITELIST, GRPC_MAX_MESSAGE_SIZE, SECRET_KEY } from "../enums/EnvironmentVariable";
 import type { SpaceInterface } from "../models/Space";
 import { Space } from "../models/Space";
@@ -76,7 +77,6 @@ import type { PusherWebSocket } from "./PusherWebSocket";
 
 const debug = Debug("socket");
 
-export type AdminSocket = WebSocket<AdminSocketData>;
 export type SocketUpgradeFailed = WebSocket<UpgradeFailedData>;
 
 export class SocketManager implements ZoneEventListener {
@@ -101,7 +101,7 @@ export class SocketManager implements ZoneEventListener {
 
     async handleAdminRoom(client: AdminSocket, roomId: string): Promise<void> {
         const apiClient = await apiClientRepository.getClient(roomId, GRPC_MAX_MESSAGE_SIZE);
-        const socketData = client.getUserData();
+        const socketData = adminDataOf(client);
         const adminRoomStream = apiClient.adminRoom();
         if (!socketData.adminConnections) {
             socketData.adminConnections = new Map<string, AdminConnection>();
@@ -226,7 +226,7 @@ export class SocketManager implements ZoneEventListener {
     }
 
     leaveAdminRoom(socket: AdminSocket): void {
-        for (const adminConnection of socket.getUserData().adminConnections?.values() ?? []) {
+        for (const adminConnection of adminDataOf(socket).adminConnections?.values() ?? []) {
             adminConnection.end();
         }
     }
@@ -547,7 +547,7 @@ export class SocketManager implements ZoneEventListener {
     }
 
     private closeAdminWebsocketConnection(client: AdminSocket, code: number, reason: string): void {
-        client.getUserData().disconnecting = true;
+        adminDataOf(client).disconnecting = true;
         client.end(code, reason);
     }
 

--- a/play/tests/pusher/PusherRoomSocketController.test.ts
+++ b/play/tests/pusher/PusherRoomSocketController.test.ts
@@ -382,7 +382,9 @@ function createSocket(overrides: Partial<SocketData> = {}): RawSocket {
     const endMock = vi.fn();
 
     return {
-        getUserData: vi.fn(() => socketData),
+        // the framework hands the upgrade request to every handler, and this service keeps its
+        // socket data on it
+        req: { socketData },
         send: sendMock,
         sendMock,
         ping: vi.fn(),


### PR DESCRIPTION
CONTRIBUTING asks to check first before a refactor this size, so this is the question with the code attached rather than a merge request: close it if the answer is no.

The pusher runs two servers in one process today, `express()` on `PUSHER_HTTP_PORT` and `uWebSockets.App()` on `PUSHER_WS_PORT`. The upgrade has no request and no response, so the query is parsed and validated a second time in `validateWebsocketQuery`, and the handshake is driven by hand: `sec-websocket-key`, protocol and extensions, `res.cork`, the `onAborted` flag, `rejectWithInternalError`, and the same block again in `adminRoomSocket`.

This swaps express for fulmine.js, a drop-in Express 5 replacement that runs on µWebSockets.js, and registers the websockets on the same app with `app.ws()`. The upgrade hook is handed the same `Request` and `Response` the HTTP routes get, so all of that goes away and the socket data travels on the request instead, reached through `PusherWebSocket.getUserData()` and `adminDataOf()` so the call sites stay as they are. Both ports still listen, on one application, so nothing in front of the service has to be reconfigured.

**I maintain fulmine.js, so weigh the recommendation accordingly.**