### PR TITLE
fix(chat): stop breaking the Matrix session, and recover when it dies

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -811,8 +811,15 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.client.on(UserEvent.Presence, this.handleUserPresence);
         this.client.on(CryptoEvent.VerificationRequestReceived, this.handleVerificationRequestReceived);
         this.client.on(HttpApiEvent.SessionLoggedOut, this.handleSessionLoggedOut);
-        await this.client.store.startup();
 
+        // Crypto first, and only then the sync store. Every sign-in mints a new device id while the rust
+        // crypto store keeps the previous one, so `initRustCrypto()` regularly fails with "the account in
+        // the store doesn't match the account in the constructor" and has to clear the stores before
+        // retrying. Clearing them closes and deletes the sync store's database - and `IndexedDBStore.startup()`
+        // returns early once it has run, so it never reconnects. Starting the store first therefore left it
+        // dead for the rest of the session: every command failed with "the database connection is closing",
+        // the SDK degraded to an in-memory store, and nothing was persisted - so the next page load had no
+        // sync token and paid for a full initial sync all over again.
         try {
             await this.client.initRustCrypto();
         } catch (error) {
@@ -820,6 +827,8 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             await clearMatrixStores(this.client);
             await this.client.initRustCrypto();
         }
+
+        await this.client.store.startup();
 
         await this.client.startClient({
             threadSupport: true,

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -16,6 +16,7 @@ import {
     ClientEvent,
     EventTimeline,
     EventType,
+    HttpApiEvent,
     MatrixError,
     PendingEventOrdering,
     PushRuleActionName,
@@ -51,6 +52,7 @@ import type {
 } from "../ChatConnection";
 import { retargetSelectedRoomIfReplaced, selectedRoomStore } from "../../Stores/SelectRoomStore";
 import { chatNotificationStore } from "../../../Stores/ProximityNotificationStore";
+import { loginTokenErrorStore } from "../../../Stores/ChatStore";
 import { currentPlayerWokaStore } from "../../../Stores/CurrentPlayerWokaStore";
 import LL from "../../../../i18n/i18n-svelte";
 import type { RequestedStatus } from "../../../Rules/StatusRules/statusRules";
@@ -62,6 +64,7 @@ import { matrixSecurity as defaultMatrixSecurity } from "./MatrixSecurity";
 import { MatrixRoomFolder } from "./MatrixRoomFolder";
 import { hasValidViaEntries } from "./MatrixSpaceRelations";
 import { chatUserFactory, mapMatrixPresenceToAvailabilityStatus } from "./MatrixChatUser";
+import { clearMatrixStores } from "./MatrixStoreCleanup";
 import {
     pushLocalWokaAndNameToMatrixProfile,
     syncWokaAvatarToMatrixProfileOnWokaChange,
@@ -93,6 +96,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     private handleAccountDataEvent: (event: MatrixEvent) => void;
     private handleUserPresence: (event: MatrixEvent | undefined, user: User) => void;
     private handleVerificationRequestReceived: (request: VerificationRequest) => void;
+    private handleSessionLoggedOut: (error: MatrixError) => void;
     private directRoomsUnreadAggregateUnsubscriber: Unsubscriber | undefined;
     private statusUnsubscriber: Unsubscriber | undefined;
     private wokaAvatarMatrixSyncUnsubscriber: Unsubscriber | undefined;
@@ -272,6 +276,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.handleAccountDataEvent = this.onAccountDataEvent.bind(this);
         this.handleUserPresence = this.onUserPresenceEvent.bind(this);
         this.handleVerificationRequestReceived = this.onVerificationRequestReceived.bind(this);
+        this.handleSessionLoggedOut = this.onSessionLoggedOut.bind(this);
 
         this.statusUnsubscriber = this.statusStore.subscribe((status: AvailabilityStatus) => {
             this.setPresence(status);
@@ -573,7 +578,10 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             this.attachWokaAvatarMatrixSync();
             this.attachDisplayNameMatrixSync();
         } catch (error) {
-            this.connectionStatus.set("OFFLINE");
+            // "OFFLINE" is what a deliberate stop looks like, and the chat panel renders nothing at all for
+            // it: a failed init would leave the user staring at an empty panel with no hint that anything
+            // went wrong. "ON_ERROR" at least shows the connection error banner.
+            this.connectionStatus.set("ON_ERROR");
             console.error(error);
             Sentry.captureException(error);
         }
@@ -802,12 +810,14 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.client.on(ClientEvent.AccountData, this.handleAccountDataEvent);
         this.client.on(UserEvent.Presence, this.handleUserPresence);
         this.client.on(CryptoEvent.VerificationRequestReceived, this.handleVerificationRequestReceived);
+        this.client.on(HttpApiEvent.SessionLoggedOut, this.handleSessionLoggedOut);
         await this.client.store.startup();
 
         try {
             await this.client.initRustCrypto();
-        } catch {
-            await this.client.clearStores();
+        } catch (error) {
+            console.error("Unable to initialize the Matrix crypto. Clearing the stores before retrying.", error);
+            await clearMatrixStores(this.client);
             await this.client.initRustCrypto();
         }
 
@@ -822,6 +832,22 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         } catch (error) {
             console.error("Failed to wait initial sync:", error);
         }
+    }
+
+    /**
+     * The homeserver rejected our access token with M_UNKNOWN_TOKEN and matrix-js-sdk could not refresh it.
+     *
+     * Nothing in this session can recover from that - the sync loop will keep failing - and the dead
+     * credentials would be replayed on every later page load, so drop them: the next login then starts from
+     * a clean store. The UI switches to the "reconnect" prompt, whose button goes through the OpenID flow,
+     * the only place a fresh Matrix login token is minted.
+     */
+    private onSessionLoggedOut(error: MatrixError): void {
+        console.error("The Matrix session is no longer valid: ", error);
+        Sentry.captureException(error);
+        localUserStore.clearMatrixSession();
+        this.connectionStatus.set("ON_ERROR");
+        loginTokenErrorStore.set(true);
     }
 
     private onVerificationRequestReceived(request: VerificationRequest) {
@@ -2071,6 +2097,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.client?.off(ClientEvent.AccountData, this.handleAccountDataEvent);
         this.client?.off(UserEvent.Presence, this.handleUserPresence);
         this.client?.off(CryptoEvent.VerificationRequestReceived, this.handleVerificationRequestReceived);
+        this.client?.off(HttpApiEvent.SessionLoggedOut, this.handleSessionLoggedOut);
         if (this.directRoomsUnreadAggregateUnsubscriber) {
             this.directRoomsUnreadAggregateUnsubscriber();
             this.directRoomsUnreadAggregateUnsubscriber = undefined;

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -825,6 +825,12 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             threadSupport: true,
             //Detached to prevent using listener on localIdReplaced for each event
             pendingEventOrdering: PendingEventOrdering.Detached,
+            // Without this, the initial sync carries the complete member list of every joined room. A world
+            // creates one Matrix room per area, so a long-standing member of a busy world ends up with a
+            // response the homeserver needs minutes to build - past the 80s the SDK is willing to wait
+            // (BUFFER_PERIOD_MS in matrix-js-sdk's sync.ts), after which it aborts and starts over, forever.
+            // The full member list is now fetched per room, when something actually needs to display it.
+            lazyLoadMembers: true,
         });
 
         try {

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -494,7 +494,15 @@ export class MatrixChatRoom
         }
 
         this.debugInitialization("members");
-        this.membersInitializationPromise = Promise.resolve()
+        // With lazy loading, /sync only carries the heroes, the senders seen in the timeline and
+        // ourselves, so the full list has to be fetched before it can be shown. This is a no-op when
+        // lazy loading is off, and a failure is not worth an empty panel: fall back on whatever the
+        // sync did carry.
+        this.membersInitializationPromise = this.matrixRoom
+            .loadMembersIfNeeded()
+            .catch((error: unknown) => {
+                console.error("Failed to load the full member list of room", this.id, error);
+            })
             .then(() => {
                 this.initializeMembers();
                 this.startHandlingChatRoomInitializedEvents();
@@ -1989,7 +1997,13 @@ export class MatrixChatRoom
             return "direct";
         }
 
-        if (members.length > 2) {
+        // Taken from the room summary rather than from `members.length`: under lazy loading the latter
+        // counts the member events that happen to be loaded, not the people in the room, so a large group
+        // would show up with two loaded members and get filed as a direct message. The counts fall back on
+        // counting members when the server sends no summary, which is what happens without lazy loading.
+        const memberCount = this.matrixRoom.getJoinedMemberCount() + this.matrixRoom.getInvitedMemberCount();
+
+        if (memberCount > 2) {
             return "multiple";
         }
 
@@ -1999,7 +2013,7 @@ export class MatrixChatRoom
             (member) => directRoomsPerUsers && directRoomsPerUsers[member.userId]?.includes(this.id),
         );
 
-        if (isDirectBasedOnRoomData || members.length === 2 || this.isRoomCreatedAsDirect()) {
+        if (isDirectBasedOnRoomData || memberCount === 2 || this.isRoomCreatedAsDirect()) {
             return "direct";
         }
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixClientWrapper.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixClientWrapper.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "buffer";
 
 import type { ICreateClientOpts, MatrixClient, SecretStorage } from "matrix-js-sdk";
-import { createClient, IndexedDBCryptoStore, IndexedDBStore } from "matrix-js-sdk";
+import { createClient, IndexedDBCryptoStore, IndexedDBStore, MatrixError } from "matrix-js-sdk";
 
 import type { SecretStorageKeyDescriptionAesV1 } from "matrix-js-sdk/lib/secret-storage";
 import { VerificationMethod } from "matrix-js-sdk/lib/types";
@@ -9,6 +9,7 @@ import type { LocalUser } from "../../../Connection/LocalUser";
 import AccessSecretStorageDialog from "./AccessSecretStorageDialog.svelte";
 import { matrixSecurity } from "./MatrixSecurity";
 import { customMatrixLogger } from "./CustomMatrixLogger";
+import { clearMatrixStores } from "./MatrixStoreCleanup";
 // Inline worker (bundled as a same-origin blob) that drives matrix-js-sdk's IndexedDB store off the
 // main thread. See matrixIndexedDbWorker.ts for why the entry script and `?worker&inline` are needed.
 import MatrixIndexedDbWorker from "./matrixIndexedDbWorker?worker&inline";
@@ -154,7 +155,7 @@ export class MatrixClientWrapper implements MatrixClientWrapperInterface {
         this.client = this._createClient(matrixCreateClientOpts);
 
         if (oldMatrixUserId !== matrixUserId) {
-            await this.client.clearStores();
+            await clearMatrixStores(this.client);
         }
 
         return this.client;
@@ -241,8 +242,22 @@ export class MatrixClientWrapper implements MatrixClientWrapperInterface {
                 deviceId: device_id,
             };
         } catch (e) {
-            console.error("Invalid login token", e);
-            throw new InvalidLoginTokenError("Invalid login token");
+            if (e instanceof MatrixError) {
+                // The homeserver answered, so the login token has been spent (an m.login.token is single use)
+                // or was rejected outright. Either way it must never be replayed: the branch that exchanges it
+                // runs before the stored access token is even looked at, so keeping a dead token here would
+                // make every later initMatrixClient() fail on it - locking the user out of the chat for good,
+                // even though perfectly valid credentials are sitting in local storage.
+                this.localUserStore.setMatrixLoginToken(null);
+                console.error("Invalid login token", e);
+                throw new InvalidLoginTokenError("Invalid login token");
+            }
+
+            // No answer from the homeserver (network failure, CORS, aborted request): the token was most
+            // likely never seen and stays usable, so keep it for the next attempt and report what really
+            // happened instead of blaming the token.
+            console.error("Unable to exchange the Matrix login token", e);
+            throw e;
         }
     }
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixClientWrapper.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixClientWrapper.ts
@@ -10,6 +10,7 @@ import AccessSecretStorageDialog from "./AccessSecretStorageDialog.svelte";
 import { matrixSecurity } from "./MatrixSecurity";
 import { customMatrixLogger } from "./CustomMatrixLogger";
 import { clearMatrixStores } from "./MatrixStoreCleanup";
+import { initialSyncAwareFetch } from "./MatrixInitialSyncFetch";
 // Inline worker (bundled as a same-origin blob) that drives matrix-js-sdk's IndexedDB store off the
 // main thread. See matrixIndexedDbWorker.ts for why the entry script and `?worker&inline` are needed.
 import MatrixIndexedDbWorker from "./matrixIndexedDbWorker?worker&inline";
@@ -145,6 +146,7 @@ export class MatrixClientWrapper implements MatrixClientWrapperInterface {
                 //VerificationMethod.Reciprocate,
             ],
             timelineSupport: true,
+            fetchFn: initialSyncAwareFetch,
         };
 
         if (this.clientClosed) {

--- a/play/src/front/Chat/Connection/Matrix/MatrixInitialSyncFetch.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixInitialSyncFetch.ts
@@ -1,0 +1,65 @@
+/**
+ * How long an initial `/sync` is allowed to run before we give up on it.
+ *
+ * Still bounded: an unbounded request would reintroduce the wedged-connection problem the SDK's own
+ * deadline guards against. This only has to be longer than the homeserver takes to answer.
+ */
+export const INITIAL_SYNC_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Whether this request is an *initial* `/sync` - the one that returns the whole account, with no
+ * `since` token to start from.
+ *
+ * matrix-js-sdk adds `_cacheBuster` to a sync request precisely when it has no sync token to send
+ * (`getSyncParams` in its sync.ts), so its presence is what marks an initial sync; `since` is checked
+ * as well so the test stays right if that ever changes.
+ */
+function isInitialSyncRequest(url: string): boolean {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+    return (
+        parsed.pathname.endsWith("/sync") &&
+        parsed.searchParams.has("_cacheBuster") &&
+        !parsed.searchParams.has("since")
+    );
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+    if (typeof input === "string") {
+        return input;
+    }
+    if (input instanceof URL) {
+        return input.href;
+    }
+    return input.url;
+}
+
+/**
+ * `fetch` for the Matrix client, giving the initial sync more time than the SDK would.
+ *
+ * matrix-js-sdk caps how long it keeps a `/sync` connection open at the requested `timeout=` plus a
+ * fixed 80s buffer (`BUFFER_PERIOD_MS` in its sync.ts). That buffer is meant to detect a wedged
+ * connection on a long poll, where `timeout=` is 30s and the ceiling therefore lands at 110s. The
+ * initial sync is not a long poll though - it sends `timeout=0` because there is nothing to wait for -
+ * so the ceiling collapses to a flat 80s deadline on a response whose cost grows with the size of the
+ * account. Past that, the SDK aborts and retries from scratch, which produces the exact same request
+ * and the exact same abort: the chat never connects, and signing out makes it worse by clearing the
+ * store and guaranteeing another full initial sync.
+ *
+ * Lazy loading should keep the initial sync well under the SDK's deadline; this is the net for the
+ * accounts that stay above it. The value is not configurable in the SDK, and swapping the abort signal
+ * is the only way to raise it from the outside.
+ *
+ * Trade-off: the SDK can no longer abort this particular request, so `stopClient()` leaves it in
+ * flight. It is harmless - the sync loop has stopped by the time the response lands, and ignores it.
+ */
+export const initialSyncAwareFetch: typeof globalThis.fetch = (input, init) => {
+    if (!isInitialSyncRequest(requestUrl(input))) {
+        return fetch(input, init);
+    }
+    return fetch(input, { ...init, signal: AbortSignal.timeout(INITIAL_SYNC_TIMEOUT_MS) });
+};

--- a/play/src/front/Chat/Connection/Matrix/MatrixStoreCleanup.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixStoreCleanup.ts
@@ -1,0 +1,39 @@
+import * as Sentry from "@sentry/svelte";
+import type { MatrixClient } from "matrix-js-sdk";
+import { raceTimeout } from "../../../Utils/PromiseUtils";
+
+/**
+ * How long we are willing to wait for the Matrix IndexedDB databases to be dropped.
+ *
+ * Deleting them is normally instantaneous; the timeout only exists to bound the pathological case described
+ * in {@link clearMatrixStores}.
+ */
+export const CLEAR_STORES_TIMEOUT_MS = 10_000;
+
+/**
+ * Clears the Matrix stores, giving up rather than waiting forever.
+ *
+ * matrix-js-sdk drops its databases with `indexedDB.deleteDatabase()`, and both call sites - `clearStores()`
+ * for the rust crypto store and `LocalIndexedDBStoreBackend.clearDatabase()` for the sync store - install an
+ * `onblocked` handler that only logs. IndexedDB blocks a deletion for as long as another connection to the
+ * same database is open, and since every WorkAdventure tab opens the very same databases (the sync store is
+ * named "workadventure-matrix" and the rust crypto store uses the SDK's global prefix), a second tab is
+ * enough to keep the request blocked. Neither handler settles the promise in that case, so awaiting it as-is
+ * hangs the caller for good: the connection status stays on its initial "CONNECTING" value and the chat
+ * spins forever with nothing in the UI to say why.
+ *
+ * Failing here is not fatal - a stale store is recoverable, an infinite spinner is not - so the error is
+ * reported and the caller carries on.
+ */
+export async function clearMatrixStores(client: MatrixClient): Promise<void> {
+    try {
+        await raceTimeout(client.clearStores(), CLEAR_STORES_TIMEOUT_MS);
+    } catch (error) {
+        console.error(
+            "Failed to clear the Matrix stores. Another tab holding the same IndexedDB databases open will " +
+                "block the deletion.",
+            error,
+        );
+        Sentry.captureException(error);
+    }
+}

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -351,6 +351,7 @@ describe("MatrixChatConnection", () => {
             expect(mockStartClient).toHaveBeenCalledWith({
                 threadSupport: true,
                 pendingEventOrdering: PendingEventOrdering.Detached,
+                lazyLoadMembers: true,
             });
         });
     });

--- a/play/src/front/Connection/LocalUserStore.ts
+++ b/play/src/front/Connection/LocalUserStore.ts
@@ -951,6 +951,23 @@ class LocalUserStore {
         return localStorage.getItem(matrixLoginToken);
     }
 
+    /**
+     * Forgets everything that identifies the current Matrix session.
+     *
+     * Called on logout, and whenever the homeserver tells us the session is dead: credentials left behind
+     * are replayed on the next page load, and MatrixClientWrapper only resets its stores when the stored
+     * user id differs from the one it just logged in with - so a leftover user id would restore the broken
+     * session instead of starting over. The device id is deliberately kept: it is stored per user and the
+     * next login overwrites it with the one the homeserver hands out.
+     */
+    clearMatrixSession() {
+        this.setMatrixLoginToken(null);
+        this.setMatrixUserId(null);
+        this.setMatrixAccessToken(null);
+        this.setMatrixRefreshToken(null);
+        this.setMatrixAccessTokenExpireDate(null);
+    }
+
     //TODO : Remove duplicate code (getMatrixUserId) and change matrix id to chatID in localStorage
     getChatId(): string | null {
         return localStorage.getItem(matrixUserId);

--- a/play/src/front/Phaser/Game/GameManager.ts
+++ b/play/src/front/Phaser/Game/GameManager.ts
@@ -21,7 +21,7 @@ import { LoginSceneName } from "../Login/LoginScene";
 import { PwaInstallSceneName } from "../Login/PwaInstallScene";
 import { SelectCharacterSceneName } from "../Login/SelectCharacterScene";
 import { EmptySceneName } from "../Login/EmptyScene";
-import { gameSceneIsLoadedStore, waitForGameSceneStore } from "../../Stores/GameSceneStore";
+import { gameSceneIsLoadedStore, gameSceneStore } from "../../Stores/GameSceneStore";
 import { myCameraStore } from "../../Stores/MyMediaStore";
 import { SelectCompanionSceneName } from "../Login/SelectCompanionScene";
 import { errorScreenStore } from "../../Stores/ErrorScreenStore";
@@ -395,6 +395,18 @@ export class GameManager {
         return this.matrixServerUrl;
     }
 
+    /**
+     * Whether the room the player is currently in allows the chat.
+     *
+     * `gameSceneStore` holds the running scene only once it finished loading. During the very first load the
+     * scene is still starting up - it is the one asking for the chat connection - so we fall back on the
+     * start room, which is precisely the room that scene is loading.
+     */
+    private async isChatEnabledOnCurrentRoom(): Promise<boolean> {
+        const room = get(gameSceneStore)?.room ?? (await this.currentStartedRoomPromise);
+        return room.isChatEnabled;
+    }
+
     public async getChatConnection(): Promise<ChatConnectionInterface> {
         if (this.chatConnectionPromise) {
             return this.chatConnectionPromise;
@@ -402,45 +414,35 @@ export class GameManager {
 
         const matrixServerUrl = this.getMatrixServerUrl() ?? MATRIX_PUBLIC_URI;
 
-        if (matrixServerUrl && get(userIsConnected)) {
-            this.matrixClientWrapper = new MatrixClientWrapper(matrixServerUrl, localUserStore);
-
-            const matrixClientPromise = this.matrixClientWrapper.initMatrixClient();
-
-            matrixClientPromise.catch((e) => {
-                if (e instanceof InvalidLoginTokenError) {
-                    loginTokenErrorStore.set(true);
-                }
-            });
-
-            const matrixChatConnection = new MatrixChatConnection(matrixClientPromise, availabilityStatusStore);
-            this._chatConnection = matrixChatConnection;
-
-            this.chatConnectionPromise = matrixChatConnection.init().then(() => matrixChatConnection);
-            isMatrixChatEnabledStore.set(true);
-
-            try {
-                const gameScene = await waitForGameSceneStore();
-
-                if (gameScene.room.isChatEnabled) {
-                    return this.chatConnectionPromise;
-                }
-            } catch (e) {
-                console.error(e);
-                Sentry.captureException(e);
-            }
-
-            matrixChatConnection.destroy().catch((e) => {
-                console.error(e);
-                Sentry.captureException(e);
-            });
-            return new VoidChatConnection();
-        } else {
+        // The chat setting is checked *before* the client is built, on purpose. Opening a Matrix session on a
+        // room where the chat is disabled used to mean a full connection and initial sync, immediately
+        // followed by destroy() - which is a real /logout. The homeserver then revoked the access token that
+        // is still stored locally, so every later room with the chat enabled restored that dead token and got
+        // nothing but M_UNKNOWN_TOKEN. Not opening the session at all leaves nothing to tear down.
+        if (!matrixServerUrl || !get(userIsConnected) || !(await this.isChatEnabledOnCurrentRoom())) {
             // No matrix connection? Let's fill the gap with a "void" object
             this._chatConnection = new VoidChatConnection();
             isMatrixChatEnabledStore.set(false);
             return this._chatConnection;
         }
+
+        this.matrixClientWrapper = new MatrixClientWrapper(matrixServerUrl, localUserStore);
+
+        const matrixClientPromise = this.matrixClientWrapper.initMatrixClient();
+
+        matrixClientPromise.catch((e) => {
+            if (e instanceof InvalidLoginTokenError) {
+                loginTokenErrorStore.set(true);
+            }
+        });
+
+        const matrixChatConnection = new MatrixChatConnection(matrixClientPromise, availabilityStatusStore);
+        this._chatConnection = matrixChatConnection;
+
+        this.chatConnectionPromise = matrixChatConnection.init().then(() => matrixChatConnection);
+        isMatrixChatEnabledStore.set(true);
+
+        return this.chatConnectionPromise;
     }
     get chatConnection(): ChatConnectionInterface {
         if (!this._chatConnection) {
@@ -480,10 +482,7 @@ export class GameManager {
     }
 
     private clearChatDataFromLocalStorage(): void {
-        localUserStore.setMatrixLoginToken(null);
-        localUserStore.setMatrixUserId(null);
-        localUserStore.setMatrixAccessToken(null);
-        localUserStore.setMatrixRefreshToken(null);
+        localUserStore.clearMatrixSession();
     }
 
     public async loadWokaData(): Promise<WokaData> {

--- a/play/src/front/Phaser/Game/GameManager.ts
+++ b/play/src/front/Phaser/Game/GameManager.ts
@@ -454,20 +454,28 @@ export class GameManager {
      * Currently, this logs out from the Matrix client.
      */
     public async logout(): Promise<void> {
-        if (this._chatConnection) {
-            try {
-                this._chatConnection.clearListener();
-                await this._chatConnection.destroy();
-                if (this.chatVisibilitySubscription) {
-                    this.chatVisibilitySubscription();
-                }
-                this.clearChatDataFromLocalStorage();
-                this._chatConnection = undefined;
-                this.chatConnectionPromise = undefined;
-            } catch (e) {
-                console.error("Chat connection not closed properly : ", e);
-                Sentry.captureException(e);
+        if (!this._chatConnection) {
+            return;
+        }
+
+        try {
+            this._chatConnection.clearListener();
+            await this._chatConnection.destroy();
+        } catch (e) {
+            // destroy() ends up calling POST /logout, which fails with a 401 when the Matrix session is
+            // already dead - exactly when the local cleanup below matters most. It must therefore run in
+            // every case: leaving the Matrix user id behind makes MatrixClientWrapper skip its
+            // clearStores() branch on the next login, restoring the broken session (stale sync token and
+            // crypto store) instead of starting over.
+            console.error("Chat connection not closed properly : ", e);
+            Sentry.captureException(e);
+        } finally {
+            if (this.chatVisibilitySubscription) {
+                this.chatVisibilitySubscription();
             }
+            this.clearChatDataFromLocalStorage();
+            this._chatConnection = undefined;
+            this.chatConnectionPromise = undefined;
         }
     }
 

--- a/play/src/front/Phaser/Game/GameManager.ts
+++ b/play/src/front/Phaser/Game/GameManager.ts
@@ -58,6 +58,7 @@ export class GameManager {
     private visitCardUrl: string | null = null;
     private matrixServerUrl: string | undefined = undefined;
     private chatConnectionPromise: Promise<ChatConnectionInterface> | undefined;
+    private pendingChatConnectionPromise: Promise<ChatConnectionInterface> | undefined;
     private matrixClientWrapper: MatrixClientWrapper | undefined;
     private _chatConnection: ChatConnectionInterface | undefined;
     private chatVisibilitySubscription: Unsubscriber | undefined;
@@ -407,11 +408,33 @@ export class GameManager {
         return room.isChatEnabled;
     }
 
-    public async getChatConnection(): Promise<ChatConnectionInterface> {
-        if (this.chatConnectionPromise) {
-            return this.chatConnectionPromise;
+    /**
+     * A Matrix session belongs to the user, not to the caller, so at most one may ever be opened: two
+     * clients in the same tab would fight over the same IndexedDB databases, which matrix-js-sdk warns
+     * leads to data corruption and decryption failures.
+     *
+     * Several callers ask for the connection while a scene starts up - the loading sequence and the world
+     * space join, at least - and deciding whether to open one has to await the room. The in-flight promise
+     * is therefore memoised synchronously: were the memoisation to happen only after that await, every
+     * caller arriving in the meantime would start a client of its own.
+     *
+     * A void connection is deliberately not memoised, so that a room where the chat is disabled does not
+     * settle the question for the rest of the session.
+     */
+    public getChatConnection(): Promise<ChatConnectionInterface> {
+        const alreadyRequested = this.chatConnectionPromise ?? this.pendingChatConnectionPromise;
+        if (alreadyRequested) {
+            return alreadyRequested;
         }
 
+        this.pendingChatConnectionPromise = this.openChatConnection().finally(() => {
+            this.pendingChatConnectionPromise = undefined;
+        });
+
+        return this.pendingChatConnectionPromise;
+    }
+
+    private async openChatConnection(): Promise<ChatConnectionInterface> {
         const matrixServerUrl = this.getMatrixServerUrl() ?? MATRIX_PUBLIC_URI;
 
         // The chat setting is checked *before* the client is built, on purpose. Opening a Matrix session on a
@@ -478,6 +501,7 @@ export class GameManager {
             this.clearChatDataFromLocalStorage();
             this._chatConnection = undefined;
             this.chatConnectionPromise = undefined;
+            this.pendingChatConnectionPromise = undefined;
         }
     }
 


### PR DESCRIPTION
## Problem

Some users lose access to the chat, and it stays lost across reloads. The first version of this PR
made signing out and back in a reliable recovery path again; it did not address what put users in
that state. It now does.

### 1. Entering a room with the chat disabled logged the user out of Matrix

`GameManager.getChatConnection()` built the Matrix client, let it connect and run a full initial
sync, and only then — once `waitForGameSceneStore()` resolved, which cannot happen before the scene
finished loading — called `destroy()` when the room had the chat disabled.

`destroy()` is `client.logout(true)`, a real `POST /logout`. The homeserver revoked the access token,
while the revoked token stayed in local storage: `clearChatDataFromLocalStorage()` only runs on a
deliberate sign-out. Every later room with the chat enabled restored that dead token and got nothing
but `M_UNKNOWN_TOKEN`. Since the Matrix user id was unchanged, `MatrixClientWrapper` also skipped its
`clearStores()` branch, so it looked like a corrupted sync store when it was an authentication
problem.

The cache made it worse. `chatConnectionPromise` kept pointing at the destroyed connection and the
`VoidChatConnection` returned instead was never stored, so every other caller on the page — and every
later map, since map changes are `scene.stop()` / `scene.start()` on the same `gameManager`
singleton — was handed the dead Matrix connection.

**Fix**: read the chat setting before building the client. A room without chat now opens no Matrix
session at all, so there is nothing to tear down. The room to look at follows the running scene when
there is one, and falls back to the start room during the very first load — the scene loading at that
point *is* the start room's.

### 2. A dead session had no way back

Nothing listened to `HttpApiEvent.SessionLoggedOut`, and `onSyncStateChange` never looked at the
errcode. A token the homeserver rejected left the chat on a static "connection error" banner with no
action, forever, and the dead credentials were replayed on every later page load.

**Fix**: drop the credentials as soon as the homeserver disowns them, and switch the UI to the
"reconnect" prompt, whose button goes through the OpenID flow — the only place a fresh Matrix login
token is minted.

### 3. Clearing the stores could hang forever

matrix-js-sdk drops its IndexedDB databases with `deleteDatabase()`, and both call sites —
`MatrixClient.clearStores()` for the rust crypto store, `LocalIndexedDBStoreBackend.clearDatabase()`
for the sync store — install an `onblocked` handler that only logs. IndexedDB blocks a deletion while
another connection to the same database is open, and every tab opens the very same databases: the
sync store is named `workadventure-matrix` (not namespaced per user, unlike the legacy crypto store)
and the rust crypto store uses the SDK's global prefix. Neither handler settles the promise, and both
call sites awaited it directly — the connection status then stays on its initial `CONNECTING` and the
chat spins forever with nothing in the UI to explain it. This is reachable right after a sign-out and
sign-in while a second tab is open.

**Fix**: bound the wait and report it. A stale store is recoverable; an infinite spinner is not.

### 4. A spent login token bricked every later session

The one-shot login token was cleared only after a successful exchange, and every failure — including
a network blip or a CORS error — was reported as an invalid token. That branch runs *before* the
stored access token is even looked at, so a token left behind made every later `initMatrixClient()`
fail on it, even with perfectly valid credentials in local storage.

**Fix**: drop the token as soon as the homeserver has answered (an `m.login.token` is single use),
keep it only when the request never reached it, and stop blaming the token for network errors.

### 5. The initial sync never completed, so the chat never connected

Reported symptom: the chat stays on "connecting". The network tab shows a `/sync` with no `since`,
cancelled after 80 seconds, immediately followed by an identical one.

matrix-js-sdk caps how long it keeps a `/sync` open at the requested `timeout=` plus a fixed 80s
buffer (`BUFFER_PERIOD_MS`, `sync.ts`). That buffer guards against a wedged connection on a long
poll, where `timeout=` is 30s and the ceiling lands at 110s. The initial sync is not a long poll — it
sends `timeout=0`, having nothing to wait for — so the ceiling collapses to a flat 80s deadline on a
response whose cost grows with the size of the account. Past it the SDK aborts and retries from
scratch, producing the same request and the same abort. The sync token is only persisted once a sync
succeeds, so nothing ever accumulates: every reload starts over, and signing out makes it worse by
clearing the store and guaranteeing another full initial sync. Users above the threshold never get in.

Why it takes that long: the SDK's default sync filter sets nothing but unread thread notifications
(`buildDefaultFilter`), so the initial sync carries the complete member list of every joined room. A
world creates one Matrix room per area (`createRoomForArea`), so a long-standing member of a busy
world crosses the threshold while everyone else stays under it.

**Fix**: `lazyLoadMembers: true`. The sync then carries the heroes, the senders seen in the timeline
and ourselves, and the full member list is fetched per room when something needs to display it.

Two consequences handled with it:

- `ensureMembersInitialized()` — already the on-demand, memoised entry point used by the participants
  panel, the manage-participants modal and the room menu — now awaits `loadMembersIfNeeded()` first,
  and falls back on the members the sync did carry if that request fails rather than showing an empty
  panel.
- The direct-vs-group heuristic moved off `members.length`, which under lazy loading counts the member
  events that happen to be loaded rather than the people in the room: a large group would show up with
  two loaded members and be filed as a direct message. It now counts from the room summary, which the
  homeserver sends alongside lazy loading and which falls back to counting members when absent — that
  is, when lazy loading is off, behaviour is unchanged.

Lazy loading should keep the initial sync well under the deadline. For accounts that stay above it
anyway, `fetchFn` swaps the abort signal of the initial sync for a longer one — the deadline is a
module constant in the SDK, so this is the only way to raise it from outside. It stays bounded:
unbounded would reintroduce the wedged-connection problem the deadline exists for. The trade-off is
that the SDK can no longer abort that particular request, so `stopClient()` leaves it in flight; the
sync loop has stopped by the time the response lands and ignores it.

## Also

- An init failure now sets `ON_ERROR` instead of `OFFLINE`, for which the chat panel renders nothing
  at all — the user was left staring at an empty panel.
- `localUserStore.clearMatrixSession()` gathers the session cleanup in one place and clears the access
  token expiry date, which the previous cleanup forgot.

## Not in this PR

- **No cross-tab session lock.** matrix-js-sdk warns that "having multiple `MatrixClient` instances
  connected to the same Indexed DB will cause data corruption and decryption failures", and there is
  no `navigator.locks` guard anywhere in `play`. Deciding what a second tab should do is a product
  call, not a bug fix.
- **No `tokenRefreshFunction`.** The refresh token is handed to the SDK but cannot be used without it
  (`http-api/refresh.ts` bails out with "no refresh token or refresh function"), and the stored expiry
  date is never read. This only bites if the homeserver issues expiring access tokens; nothing in the
  repo configures Synapse that way. Checking whether `matrixAccessTokenExpireDate` exists in an
  affected user's local storage will tell.

## Tests

No new unit tests, as requested. Verified locally in `play/`: `tsc --noEmit` clean, `eslint` and
`prettier --check` clean on the touched files, and `npx vitest run` green — 634 passed / 10 skipped
over 101 files — including `MatrixChatConnection.test.ts`, whose `startClient` options assertion was
updated for `lazyLoadMembers`.
