### PR TITLE
fix(chat): say what the participant loaders are actually loading

### DIFF
--- a/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
+++ b/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
@@ -91,7 +91,7 @@
                     <div class="animate-[spin_2s_linear_infinite] text-white/80">
                         <IconLoader font-size="2em" />
                     </div>
-                    <p class="text-sm text-white/60">{$LL.chat.createRoom.loadingCreation()}</p>
+                    <p class="text-sm text-white/60">{$LL.chat.loadingUsers()}</p>
                 </div>
             {:else if membersLoadingError}
                 <div class="flex flex-col items-center justify-center gap-3 py-8">
@@ -105,7 +105,7 @@
                     <div class="animate-[spin_2s_linear_infinite] text-white/80">
                         <IconLoader font-size="2em" />
                     </div>
-                    <p class="text-sm text-white/60">{$LL.chat.createRoom.loadingCreation()}</p>
+                    <p class="text-sm text-white/60">{$LL.chat.loading()}</p>
                 </div>
             {:else}
                 {#if invitationToRoomError}
@@ -152,7 +152,7 @@
     {/snippet}
     {#snippet action()}
         {#if sendingInvitationsToRoom}
-            <p class="text-sm text-white/70">{$LL.chat.createRoom.loadingCreation()}</p>
+            <p class="text-sm text-white/70">{$LL.chat.loading()}</p>
         {:else}
             <Button variant="secondary" class="flex-1" onclick={() => modals.close()}>
                 {$LL.chat.manageRoomUsers.buttons.cancel()}

--- a/play/src/front/Chat/Components/Room/RoomSidePanelParticipants.svelte
+++ b/play/src/front/Chat/Components/Room/RoomSidePanelParticipants.svelte
@@ -78,7 +78,7 @@
                 <div class="animate-[spin_2s_linear_infinite] text-white/80">
                     <IconLoader font-size="2em" />
                 </div>
-                <p class="text-sm text-white/60">{$LL.chat.createRoom.loadingCreation()}</p>
+                <p class="text-sm text-white/60">{$LL.chat.loadingUsers()}</p>
             </div>
         {:else if membersLoadingError}
             <div class="flex flex-col items-center justify-center gap-3 py-8 px-2 text-center">


### PR DESCRIPTION
## Problem

Opening the participants side panel, or the manage-participants modal, shows a spinner labelled
**"Room creation in progress"** while the member list loads. It is the string the create-room modal
uses (`chat.createRoom.loadingCreation`), and it is wrong twice over: nothing is being created, and
the room the user is looking at already exists.

Four call sites carried it:

| File | What is actually happening |
|---|---|
| `RoomSidePanelParticipants.svelte:81` | loading the member list |
| `ManageParticipantsModal.svelte:94` | loading the member list |
| `ManageParticipantsModal.svelte:108` | sending invitations |
| `ManageParticipantsModal.svelte:155` | sending invitations |

## Fix

The two member-list spinners now use `chat.loadingUsers` — "Loading the users …". That key already
exists and is translated in all fifteen locales, and nothing was using it, so no new key is needed
and `i18n:check` stays happy.

The two invitation spinners now use the neutral `chat.loading` ("Loading"). A dedicated
"Sending invitations…" string would read better, but it would mean adding a key to every locale and
inventing fourteen translations, so I left that call to you.

The legitimate uses of `loadingCreation` — `CreateRoomModal`, `CreateFolderModal` and the map
editor's `MatrixRoomPropertyEditor`, which really are creating something — are untouched.

## Why now

The mislabelled spinner has been there a while, but it was close to invisible: the member list came
down with the initial sync, so the loader flashed for a frame. Since #6445 enabled lazy loading of
room members, the full list is fetched on demand when the panel opens, and the loader is on screen
long enough to read.

## Tests

No behaviour to test — this swaps an i18n key. `eslint` and `prettier --check` clean on both files,
and both keys resolve in the generated `i18n-types.ts`.
