### PR TITLE
fix(matrix): normalize Matrix API URI

### DIFF
--- a/play/src/pusher/enums/EnvironmentVariable.ts
+++ b/play/src/pusher/enums/EnvironmentVariable.ts
@@ -160,7 +160,9 @@ export const GOOGLE_DRIVE_PICKER_API_KEY = env.GOOGLE_DRIVE_PICKER_API_KEY;
 export const GOOGLE_DRIVE_PICKER_APP_ID = env.GOOGLE_DRIVE_PICKER_APP_ID;
 // Matrix
 export const MATRIX_PUBLIC_URI: string | undefined = env.MATRIX_PUBLIC_URI;
-export const MATRIX_API_URI: string | undefined = env.MATRIX_API_URI;
+export const MATRIX_API_URI: string | undefined = env.MATRIX_API_URI
+    ? env.MATRIX_API_URI.replace(/\/+$/, "") + "/"
+    : env.MATRIX_API_URI;
 export const MATRIX_ADMIN_USER: string | undefined = env.MATRIX_ADMIN_USER;
 export const MATRIX_ADMIN_PASSWORD: string | undefined = env.MATRIX_ADMIN_PASSWORD;
 export const MATRIX_DOMAIN: string | undefined = env.MATRIX_DOMAIN;

--- a/play/tests/pusher/EnvironmentVariable.test.ts
+++ b/play/tests/pusher/EnvironmentVariable.test.ts
@@ -35,3 +35,35 @@ describe("OIDC redirect URLs", () => {
         expect(OPID_CLIENT_REDIRECT_LOGOUT_URL).toBe(`${expectedBaseUrl}/logout-callback`);
     });
 });
+
+describe("Matrix API URI", () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    afterEach(() => {
+        vi.doUnmock("../../src/pusher/enums/EnvironmentVariableValidator");
+    });
+
+    it.each([
+        ["http://synapse:8008", "http://synapse:8008/"],
+        ["http://synapse:8008/", "http://synapse:8008/"],
+        ["https://matrix.example.com/internal", "https://matrix.example.com/internal/"],
+        ["https://matrix.example.com/internal///", "https://matrix.example.com/internal/"],
+        ["", ""],
+        [undefined, undefined],
+    ])("should normalize MATRIX_API_URI when it is %s", async (matrixApiUri, expectedMatrixApiUri) => {
+        vi.doMock("../../src/pusher/enums/EnvironmentVariableValidator", () => ({
+            EnvironmentVariables: {
+                safeParse: () => ({
+                    success: true,
+                    data: { MATRIX_API_URI: matrixApiUri },
+                }),
+            },
+        }));
+
+        const { MATRIX_API_URI } = await import("../../src/pusher/enums/EnvironmentVariable");
+
+        expect(MATRIX_API_URI).toBe(expectedMatrixApiUri);
+    });
+});


### PR DESCRIPTION
## Description

Normalize `MATRIX_API_URI` to end with exactly one trailing slash when configured.

This prevents malformed Matrix endpoints such as `http://synapse:8008_matrix/client/r0/login` when self-hosters omit the trailing slash. It preserves the existing behavior for URIs that already end with a slash and for empty or unset configurations.

## Tests

- Added regression coverage for Matrix API URIs with no trailing slash, one or multiple trailing slashes, a path, and empty or unset values
- `npm test -- --run tests/pusher/EnvironmentVariable.test.ts` (14 tests passed)
- `npx prettier --check src/pusher/enums/EnvironmentVariable.ts tests/pusher/EnvironmentVariable.test.ts`
- `npx eslint src/pusher/enums/EnvironmentVariable.ts tests/pusher/EnvironmentVariable.test.ts`