### PR TITLE
chore(compose): remove obsolete version declarations

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   reverse-proxy:
     image: traefik:v3.6.1

--- a/contrib/docker/tests/docker-compose.test.yaml
+++ b/contrib/docker/tests/docker-compose.test.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   reverse-proxy:
     networks:

--- a/docker-compose-no-oidc.yaml
+++ b/docker-compose-no-oidc.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   play:
     environment:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   # overrides for e2e tests to be closer to production
   # use with command:

--- a/docker-compose.no-synapse.yaml
+++ b/docker-compose.no-synapse.yaml
@@ -1,4 +1,3 @@
-version: "3.6"
 services:
   # disables the Synapse service
   # use with command:


### PR DESCRIPTION
## Description

Remove the obsolete top-level `version: "3.6"` declarations from the remaining Docker Compose files.

Docker Compose only keeps this field for backward compatibility, always uses the latest Compose Specification, and warns that the field is obsolete. The main `docker-compose.yaml` already omits it. Helm chart versions are not affected.

https://docs.docker.com/reference/compose-file/version-and-name/

## Tests

- `docker compose -f docker-compose.yaml -f docker-compose-no-oidc.yaml config --quiet --no-interpolate`
- `docker compose -f docker-compose.yaml -f docker-compose.e2e.yml config --quiet --no-interpolate`
- `docker compose -f docker-compose.yaml -f docker-compose.no-synapse.yaml config --quiet --no-interpolate`
- `docker compose -f contrib/docker/docker-compose.prod.yaml config --quiet --no-interpolate`
- `docker compose -f contrib/docker/docker-compose.prod.yaml -f contrib/docker/tests/docker-compose.test.yaml config --quiet --no-interpolate`