### PR TITLE
fix: keep screen awake during meetings on mobile

### DIFF
--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -1133,7 +1133,15 @@ export class ProximityChatRoom implements ChatRoom {
         // Request a screen wake lock so the device does not go to sleep while chatting (proximity or meeting room).
         screenWakeLock
             .requestWakeLock()
-            .then((release) => (this.screenWakeRelease = release))
+            .then((release) => {
+                if (joinSignal.aborted || this._space !== spaceForThisJoin) {
+                    // The join attempt was aborted while we were acquiring the lock. Release it right away,
+                    // the cleanup code already ran and will not do it for us.
+                    release?.().catch((error) => console.error(error));
+                    return;
+                }
+                this.screenWakeRelease = release;
+            })
             .catch((error) => console.error(error));
 
         await this.throwIfAborted(joinSignal, spaceForThisJoin);
@@ -1239,6 +1247,10 @@ export class ProximityChatRoom implements ChatRoom {
         this.scriptingOutputAudioStreamManager = undefined;
         this.scriptingInputAudioStreamManager?.close();
         this.scriptingInputAudioStreamManager = undefined;
+        if (this.screenWakeRelease) {
+            this.screenWakeRelease().catch((error) => console.error(error));
+            this.screenWakeRelease = undefined;
+        }
         this.spaceUsersStore.forward(readable(new Map()));
         this.spaceMetadataStore.set(new Map());
         this.unreadQuestionIdsStore.set(new Set());

--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -1111,10 +1111,6 @@ export class ProximityChatRoom implements ChatRoom {
                 iframeListener.sendJoinProximityMeetingEvent(playersInSpace);
             }
             faviconManager.pushNotificationFavicon();
-            screenWakeLock
-                .requestWakeLock()
-                .then((release) => (this.screenWakeRelease = release))
-                .catch((error) => console.error(error));
 
             // Note: by design, if someone comes talk to us, there should be only one new user in the space.
             // So we know for sure that there is only one new user.
@@ -1133,6 +1129,13 @@ export class ProximityChatRoom implements ChatRoom {
             this.sendMessage(get(LL).chat.timeLine.youJoinedMeetingRoom(), "incoming", false);
             this.soundManager.playMeetingInSound();
         }
+
+        // Request a screen wake lock so the device does not go to sleep while chatting (proximity or meeting room).
+        screenWakeLock
+            .requestWakeLock()
+            .then((release) => (this.screenWakeRelease = release))
+            .catch((error) => console.error(error));
+
         await this.throwIfAborted(joinSignal, spaceForThisJoin);
 
         this.spaceWatcherUserJoinedObserver = this._space.observeUserJoined.subscribe((spaceUser) => {

--- a/play/src/front/Utils/ScreenWakeLock.ts
+++ b/play/src/front/Utils/ScreenWakeLock.ts
@@ -1,3 +1,15 @@
+/**
+ * Logs a wake lock failure, except when the browser refused because the page is hidden.
+ * This happens routinely (someone comes talk to us while the tab is in the background) and the
+ * lock is acquired again on the next "visibilitychange", so it is not worth polluting the console.
+ */
+function logWakeLockError(error: unknown): void {
+    if (error instanceof DOMException && error.name === "NotAllowedError") {
+        return;
+    }
+    console.error(error);
+}
+
 class ScreenWakeLock {
     private isSupported: boolean;
     private wakeLockSentinel: WakeLockSentinel | undefined;
@@ -34,7 +46,7 @@ class ScreenWakeLock {
         if (document.visibilityState !== "visible") {
             return;
         }
-        this.acquire().catch((error) => console.error(error));
+        this.acquire().catch((error) => logWakeLockError(error));
     };
 
     /**
@@ -49,7 +61,7 @@ class ScreenWakeLock {
         this.lockRequestCount++;
         // A failure here (typically a "NotAllowedError" because the document is hidden) is not
         // fatal: the lock will be acquired on the next "visibilitychange" if it is still wanted.
-        await this.acquire().catch((error) => console.error(error));
+        await this.acquire().catch((error) => logWakeLockError(error));
 
         let isReleased = false;
         return async () => {

--- a/play/src/front/Utils/ScreenWakeLock.ts
+++ b/play/src/front/Utils/ScreenWakeLock.ts
@@ -1,7 +1,16 @@
 class ScreenWakeLock {
     private isSupported: boolean;
     private wakeLockSentinel: WakeLockSentinel | undefined;
-    private isLockRequested = false;
+    /**
+     * Number of features currently asking for the screen to stay awake.
+     * The lock is only released when this counter drops back to 0.
+     */
+    private lockRequestCount = 0;
+    /**
+     * The acquisition currently in flight, if any, so that 2 concurrent requests do not end up
+     * creating 2 sentinels (only one of which we would be able to release).
+     */
+    private acquisition: Promise<void> | undefined;
 
     constructor() {
         if ("wakeLock" in navigator) {
@@ -12,33 +21,79 @@ class ScreenWakeLock {
         }
 
         if (this.isSupported) {
+            // The Screen Wake Lock API automatically releases the lock when the document becomes
+            // hidden, so we need to acquire it again when the user comes back to the tab/app.
+            // This class is a singleton living for the whole lifetime of the page, so the listener
+            // is never removed.
+            // eslint-disable-next-line listeners/no-missing-remove-event-listener
             document.addEventListener("visibilitychange", this.onVisibilityChange);
         }
     }
 
     private onVisibilityChange = (): void => {
-        if (this.isLockRequested && document.visibilityState === "visible" && !this.wakeLockSentinel) {
-            navigator.wakeLock
-                .request("screen")
-                .then((sentinel) => (this.wakeLockSentinel = sentinel))
-                .catch((error) => console.error(error));
+        if (document.visibilityState !== "visible") {
+            return;
         }
+        this.acquire().catch((error) => console.error(error));
     };
 
-    async requestWakeLock() {
+    /**
+     * Asks for the screen to stay awake. Returns a function releasing this particular request.
+     * The screen only goes back to sleep when every caller released its own request.
+     */
+    async requestWakeLock(): Promise<(() => Promise<void>) | undefined> {
         if (!this.isSupported) {
             return;
         }
 
-        this.isLockRequested = true;
+        this.lockRequestCount++;
+        // A failure here (typically a "NotAllowedError" because the document is hidden) is not
+        // fatal: the lock will be acquired on the next "visibilitychange" if it is still wanted.
+        await this.acquire().catch((error) => console.error(error));
 
-        this.wakeLockSentinel = await navigator.wakeLock.request("screen");
-
+        let isReleased = false;
         return async () => {
-            this.isLockRequested = false;
-            await this.wakeLockSentinel?.release();
+            if (isReleased) {
+                return;
+            }
+            isReleased = true;
+            this.lockRequestCount--;
+            if (this.lockRequestCount > 0) {
+                // Someone else still wants the screen awake.
+                return;
+            }
+            const sentinel = this.wakeLockSentinel;
             this.wakeLockSentinel = undefined;
+            if (sentinel && !sentinel.released) {
+                await sentinel.release();
+            }
         };
+    }
+
+    private acquire(): Promise<void> {
+        if (this.lockRequestCount === 0 || this.hasActiveLock()) {
+            return Promise.resolve();
+        }
+        if (!this.acquisition) {
+            this.acquisition = navigator.wakeLock
+                .request("screen")
+                .then(async (sentinel) => {
+                    if (this.lockRequestCount === 0) {
+                        // Everybody released their request while we were acquiring the lock.
+                        await sentinel.release();
+                        return;
+                    }
+                    this.wakeLockSentinel = sentinel;
+                })
+                .finally(() => (this.acquisition = undefined));
+        }
+        return this.acquisition;
+    }
+
+    private hasActiveLock(): boolean {
+        // The browser keeps the sentinel object around after it auto-released the lock (when the
+        // document got hidden for instance), so the mere presence of a sentinel proves nothing.
+        return this.wakeLockSentinel !== undefined && !this.wakeLockSentinel.released;
     }
 }
 

--- a/play/src/front/Utils/ScreenWakeLock.ts
+++ b/play/src/front/Utils/ScreenWakeLock.ts
@@ -1,5 +1,7 @@
 class ScreenWakeLock {
     private isSupported: boolean;
+    private wakeLockSentinel: WakeLockSentinel | undefined;
+    private isLockRequested = false;
 
     constructor() {
         if ("wakeLock" in navigator) {
@@ -8,17 +10,34 @@ class ScreenWakeLock {
             this.isSupported = false;
             console.info("Wake lock is not supported by this browser.");
         }
+
+        if (this.isSupported) {
+            document.addEventListener("visibilitychange", this.onVisibilityChange);
+        }
     }
+
+    private onVisibilityChange = (): void => {
+        if (this.isLockRequested && document.visibilityState === "visible" && !this.wakeLockSentinel) {
+            navigator.wakeLock
+                .request("screen")
+                .then((sentinel) => (this.wakeLockSentinel = sentinel))
+                .catch((error) => console.error(error));
+        }
+    };
 
     async requestWakeLock() {
         if (!this.isSupported) {
             return;
         }
 
-        const request = await navigator.wakeLock.request("screen");
+        this.isLockRequested = true;
 
-        return async function () {
-            await request.release();
+        this.wakeLockSentinel = await navigator.wakeLock.request("screen");
+
+        return async () => {
+            this.isLockRequested = false;
+            await this.wakeLockSentinel?.release();
+            this.wakeLockSentinel = undefined;
         };
     }
 }


### PR DESCRIPTION
## Summary
- Request the screen wake lock for meeting room chats, not just proximity/bubble chats
- Re-acquire the wake lock when the page becomes visible again after a `visibilitychange` event, since the Screen Wake Lock API auto-releases it when a tab/app is hidden

Fixes #6454
