### PR TITLE
fix(chat): search the whole world when inviting users to a room

### DIFF
--- a/play/src/front/Chat/Components/Room/searchChatMembersRule.ts
+++ b/play/src/front/Chat/Components/Room/searchChatMembersRule.ts
@@ -1,4 +1,3 @@
-import { get } from "svelte/store";
 import { gameManager } from "../../../Phaser/Game/GameManager";
 import type { ChatUser } from "../../Connection/ChatConnection";
 
@@ -10,47 +9,44 @@ export interface SelectItem {
 }
 
 export const searchChatMembersRule = () => {
-    const chat = gameManager.chatConnection;
     const userProviderMergerPromise = gameManager.getCurrentGameScene().userProviderMerger;
 
-    async function searchMembers(filterText: string) {
-        try {
-            const chatUsers = await chat.searchChatUsers(filterText);
-            if (chatUsers === undefined) {
-                return [];
-            }
-            return chatUsers.map((user) => ({ value: user.id, label: user.name ?? user.id }));
-        } catch (error) {
-            console.error(error);
-        }
+    /**
+     * Subscribes to the list of users known by the user providers (world members from the Admin API,
+     * users currently connected and users we already have a direct room with).
+     *
+     * The subscription must be kept alive for as long as the list is displayed: the providers only
+     * load their users (and only honor `setFilter`) while their store has at least one subscriber.
+     */
+    async function subscribeToWorldMembers(onMembers: (members: SelectItem[]) => void): Promise<() => void> {
+        const userProviderMerger = await userProviderMergerPromise;
 
-        return [];
-    }
-
-    async function searchWorldMembers(filterText: string): Promise<SelectItem[]> {
-        try {
-            const userProviderMerger = await userProviderMergerPromise;
-            const chatUsersMap = get(userProviderMerger.usersByRoomStore);
+        return userProviderMerger.usersByRoomStore.subscribe((chatUsersMap) => {
             const chatUsers = Array.from(chatUsersMap.values())
                 .flatMap((room) => room.users)
-                .filter((user) => user.username?.includes(filterText) && user.chatId) as (ChatUser & {
-                chatId: string;
-            })[];
-            if (chatUsers === undefined) {
-                return [];
-            }
-            return chatUsers.map((user) => ({
-                value: user.chatId,
-                label: user.username ?? user.spaceUserId?.toString(),
-                verified: true,
-                created: false,
-            }));
-        } catch (error) {
-            console.error(error);
-        }
+                .filter((user) => user.chatId) as (ChatUser & { chatId: string })[];
 
-        return [];
+            onMembers(
+                chatUsers.map((user) => ({
+                    value: user.chatId,
+                    label: user.username ?? user.spaceUserId?.toString(),
+                    verified: true,
+                    created: false,
+                })),
+            );
+        });
     }
 
-    return { searchMembers, searchWorldMembers };
+    /**
+     * Asks the user providers to reload their users for the given search text.
+     *
+     * This is what makes users that are not part of the members initially loaded from the Admin API
+     * (only the first few hundreds are) reachable: the search is performed by the Admin API itself.
+     */
+    async function searchWorldMembers(searchText: string): Promise<void> {
+        const userProviderMerger = await userProviderMergerPromise;
+        await userProviderMerger.setFilter(searchText);
+    }
+
+    return { subscribeToWorldMembers, searchWorldMembers };
 };

--- a/play/src/front/Chat/Components/SelectMatrixUser.svelte
+++ b/play/src/front/Chat/Components/SelectMatrixUser.svelte
@@ -5,9 +5,12 @@
     import Select from "svelte-select";
     import LL from "../../../i18n/i18n-svelte";
     import { gameManager } from "../../Phaser/Game/GameManager";
+    import { chatSearchBarValue } from "../Stores/ChatStore";
     import type { SelectItem } from "./Room/searchChatMembersRule";
     import { searchChatMembersRule } from "./Room/searchChatMembersRule";
     import { IconUsers } from "@wa-icons";
+
+    const SEARCH_DEBOUNCE_DELAY = 300;
 
     interface Props {
         value?: SelectItem[];
@@ -22,16 +25,25 @@
         value = [];
     }
 
-    let items: SelectItem[] = $state([]);
+    let members: SelectItem[] = $state([]);
+    let createdItem: SelectItem | undefined = $state(undefined);
+    let items: SelectItem[] = $derived(createdItem === undefined ? members : [...members, createdItem]);
     const chat = gameManager.chatConnection;
 
-    const { searchWorldMembers } = searchChatMembersRule();
+    const { subscribeToWorldMembers, searchWorldMembers } = searchChatMembersRule();
+
+    function handleSearchError(error: unknown) {
+        onerror?.(get(LL).chat.matrixUserSelect.failedToLoadUsers());
+        console.error(error);
+        Sentry.captureException(error);
+    }
 
     function handleFilter(e: CustomEvent) {
         if (value.find((i) => i.label === filterText)) return;
         if (e.detail.length === 0 && filterText.length > 0) {
-            const prev = items.filter((i) => !i.created);
-            items = [...prev, { value: filterText, label: filterText, created: true }];
+            createdItem = { value: filterText, label: filterText, created: true };
+        } else if (filterText.length === 0) {
+            createdItem = undefined;
         }
     }
 
@@ -64,15 +76,44 @@
     }
 
     onMount(() => {
-        searchWorldMembers(filterText)
-            .then((newItems) => {
-                items = newItems;
+        let unsubscribeFromMembers: (() => void) | undefined;
+        let destroyed = false;
+
+        subscribeToWorldMembers((newMembers) => {
+            members = newMembers;
+        })
+            .then((unsubscribe) => {
+                if (destroyed) {
+                    unsubscribe();
+                    return;
+                }
+                unsubscribeFromMembers = unsubscribe;
             })
-            .catch((error) => {
-                onerror?.(get(LL).chat.matrixUserSelect.failedToLoadUsers());
-                console.error(error);
-                Sentry.captureException(error);
-            });
+            .catch(handleSearchError);
+
+        return () => {
+            destroyed = true;
+            unsubscribeFromMembers?.();
+            // The user providers are shared with the chat sidebar: give it back the filter of its own search bar.
+            searchWorldMembers(get(chatSearchBarValue)).catch((error) => console.error(error));
+        };
+    });
+
+    // Only a limited number of members is kept in memory, so we ask the user providers to search the
+    // whole world (the search is performed by the Admin API) whenever the user types in the selector.
+    let searchedText = "";
+    $effect(() => {
+        const text = filterText;
+        if (text === searchedText) {
+            return;
+        }
+        searchedText = text;
+
+        const timeout = setTimeout(() => {
+            searchWorldMembers(text).catch(handleSearchError);
+        }, SEARCH_DEBOUNCE_DELAY);
+
+        return () => clearTimeout(timeout);
     });
 </script>
 


### PR DESCRIPTION
## Problem

In the chat, the user selector of the *create room* / *create folder* / *manage participants* modals lists the users that happen to be in memory **when the modal is mounted**:

- the members returned by the Admin API (`GET /api/chat/members`) — capped at 200, ordered by `woka_name`,
- the users currently connected in the world,
- the users we already have a direct room with.

Typing in the selector filters that snapshot client-side, and nothing else: `setFilter()` — the only path that queries the Admin API again — is called from the chat sidebar search bar only. So a member outside the first batch is unreachable, and the workaround is to search for them in the sidebar first, then reopen the modal.

The local filter was also case sensitive (`username.includes(filterText)`).

## Fix

- `SelectMatrixUser` keeps a **subscription** on the merged user list instead of taking a one-shot `get()` snapshot. This matters twice: the providers only load their users while their store has a subscriber (so the selector could show an empty list when opened before the sidebar), and `setFilter()` is a no-op without one.
- Typing in the selector calls `setFilter()` (debounced 300 ms), so the search is performed by the Admin API over the whole world. Delegating to the providers also means the world settings keep deciding which providers exist (`enableChatDisconnectedList` / `enableChatOnlineList`) — no member is exposed that was not exposed before.
- The providers are shared with the chat sidebar, so the selector restores the sidebar's own search text when it is destroyed.
- The case-sensitive local filter is dropped; `svelte-select` already filters the displayed items, case-insensitively.
- Removes `searchMembers()`, dead since nothing imported it.

## Test

- `eslint` and `svelte-check` clean on `play`.
- Manual: open *create room*, type the name of a member ranked past the 200 first ones → they now show up.

No automated test: `searchChatMembersRule` reaches the world through the `gameManager` singleton, whose import chain pulls Phaser in.