### PR TITLE
perf(front): take the room, WAM and TMJ requests off the render loop

### DIFF
--- a/play/src/front/Components/App.svelte
+++ b/play/src/front/Components/App.svelte
@@ -28,6 +28,8 @@
     import { waScaleManager } from "../Phaser/Services/WaScaleManager";
     import { HtmlUtils } from "../WebRtc/HtmlUtils";
     import { iframeListener } from "../Api/IframeListener";
+    import { connectionManager } from "../Connection/ConnectionManager";
+    import { prefetchWamFile } from "../Connection/MapPrefetch";
     import { desktopApi } from "../Api/Desktop";
     import { canvasSize, coWebsiteManager, coWebsites, fullScreenCowebsite } from "../Stores/CoWebsiteStore";
     import { urlManager } from "../Url/UrlManager";
@@ -83,6 +85,25 @@
                 console.error("Error while initializing Sentry", e);
             }
         }
+
+        // Resolve the room and authenticate now, in parallel with everything below. This is HTTP,
+        // the URL and localUserStore — no Phaser — but it used to run from EntryScene.create(),
+        // which means it only started once Phaser had booted and EntryScene had downloaded its own
+        // assets. Started here it overlaps them, and GameManager.init() awaits a request that is
+        // usually already in flight. The result is memoized, so awaiting it there is not a second
+        // request.
+        //
+        // The catch is deliberately empty: the failure is handled where the result is consumed
+        // (GameManager.init -> errorScreenStore). This only keeps the kick-off from surfacing as an
+        // unhandled rejection when nothing has awaited it yet.
+        connectionManager.startGameConnexion().catch(() => {
+            // handled by the awaiting caller
+        });
+
+        // Chained on the room above: the WAM's URL comes from the /room response, and the file is a
+        // plain axios GET that Phaser's loader only sequences. Starting it here means GameScene
+        // usually finds it already downloaded instead of opening the request itself.
+        prefetchWamFile();
 
         const { width, height } = coWebsiteManager.getGameSize();
         const fps: Phaser.Types.Core.FPSConfig = {

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -48,6 +48,7 @@ class ConnectionManager {
     private _unloading = false;
     private authToken: string | null = null;
     private _currentRoom: Room | null = null;
+    private gameConnexionPromise: ReturnType<ConnectionManager["initGameConnexion"]> | undefined;
 
     private serviceWorker?: _ServiceWorker;
 
@@ -142,6 +143,23 @@ class ConnectionManager {
      *
      * @return returns a promise to the Room we are going to load OR a pointer to the URL we must redirect to if authentication is needed.
      */
+    /**
+     * Start resolving the room and authenticating, and hand back the same promise to everyone who
+     * asks. Nothing here touches Phaser — it is HTTP, the URL and localUserStore — so it does not
+     * have to wait for the game loop to hand it a turn. Kicking it off as the app mounts overlaps
+     * the round-trip with Phaser's boot and EntryScene's asset load, instead of queueing behind
+     * them; `GameManager.init` then awaits a request that is usually already in flight.
+     *
+     * Memoized rather than idempotent-by-luck: EntryScene runs once per page load, but a caller
+     * asking twice must not fire a second /room request nor race a second anonymous login.
+     */
+    public startGameConnexion(): ReturnType<ConnectionManager["initGameConnexion"]> {
+        if (!this.gameConnexionPromise) {
+            this.gameConnexionPromise = this.initGameConnexion();
+        }
+        return this.gameConnexionPromise;
+    }
+
     public async initGameConnexion(): Promise<
         | {
               room: Room;

--- a/play/src/front/Connection/MapPrefetch.ts
+++ b/play/src/front/Connection/MapPrefetch.ts
@@ -1,0 +1,98 @@
+import { wamFileMigration } from "@workadventure/map-editor/src/Migrations/WamFileMigration";
+
+import { connectionManager } from "./ConnectionManager";
+import { axiosWithRetry } from "./AxiosUtils";
+
+/**
+ * Starts downloading the map — the WAM, then the TMJ it points at — as soon as the room is known,
+ * instead of waiting for Phaser to boot and reach GameScene.preload().
+ *
+ * The WAM was never loaded through Phaser's Loader — it is a plain axios GET, only *sequenced* by
+ * the loader through superLoad.loadPromise. So nothing stops it from starting earlier: its URL
+ * comes from the /room response, which App.svelte already asks for as it mounts.
+ *
+ * Handed over exactly once. A GameScene is re-created on portals, on room changes and after a
+ * reconnection, and each of those must see the WAM as it is *then* — a lasting cache would serve a
+ * stale map-editor state. Taking the prefetch out of the box makes the second load a normal fetch.
+ */
+
+let prefetched: { url: string; response: Promise<unknown> } | undefined;
+
+function absoluteWamUrl(wamUrl: string): string {
+    return new URL(wamUrl, window.location.href).toString();
+}
+
+export function prefetchWamFile(): void {
+    connectionManager
+        .startGameConnexion()
+        .then((result) => {
+            // A redirect (URL) or an error carries no room to prefetch for.
+            if (result instanceof URL || result.nextScene === "errorScene") {
+                return;
+            }
+            const wamUrl = result.room.wamUrl;
+            if (!wamUrl) {
+                // Plain TMJ map: nothing to prefetch, the loader handles it.
+                return;
+            }
+            const url = absoluteWamUrl(wamUrl);
+            const response = axiosWithRetry.get(url).then((res: { data: unknown }) => res.data);
+            // The consumer attaches the real handling; this only keeps a prefetch nobody claimed
+            // (an aborted boot, a redirect landing first) from surfacing as an unhandled rejection.
+            response.catch(() => {
+                // claimed by takePrefetchedWamFile, or deliberately dropped
+            });
+            prefetched = { url, response };
+
+            prefetchTmjFile(url, response);
+        })
+        .catch(() => {
+            // Room resolution failures are handled by GameManager.init.
+        });
+}
+
+/**
+ * Claim the prefetched WAM for this URL, if it is the one we anticipated. Returns undefined when
+ * there is nothing to claim, and the caller fetches normally.
+ */
+export function takePrefetchedWamFile(absoluteUrl: string): Promise<unknown> | undefined {
+    if (prefetched?.url !== absoluteUrl) {
+        return undefined;
+    }
+    const { response } = prefetched;
+    prefetched = undefined;
+    return response;
+}
+
+/**
+ * The TMJ the WAM points at, chained on the WAM download above. Same one-shot handover, same
+ * reason: a re-created scene must read the map as it is then.
+ */
+let prefetchedTmj: { url: string; response: Promise<unknown> } | undefined;
+
+function prefetchTmjFile(absoluteWamFileUrl: string, wamResponse: Promise<unknown>): void {
+    wamResponse
+        .then((wamData) => {
+            // Migrated on a copy purely to read `mapUrl`: GameScene still receives the untouched
+            // response and migrates it itself, so nothing here can change what it sees.
+            const wamFile = wamFileMigration.migrate(structuredClone(wamData));
+            const url = new URL(wamFile.mapUrl, absoluteWamFileUrl).toString();
+            const response = axiosWithRetry.get(url).then((res: { data: unknown }) => res.data);
+            response.catch(() => {
+                // claimed by takePrefetchedTmjFile, or deliberately dropped
+            });
+            prefetchedTmj = { url, response };
+        })
+        .catch(() => {
+            // The WAM failed; GameScene surfaces that when it claims the WAM.
+        });
+}
+
+export function takePrefetchedTmjFile(absoluteUrl: string): Promise<unknown> | undefined {
+    if (prefetchedTmj?.url !== absoluteUrl) {
+        return undefined;
+    }
+    const { response } = prefetchedTmj;
+    prefetchedTmj = undefined;
+    return response;
+}

--- a/play/src/front/Phaser/Game/GameManager.ts
+++ b/play/src/front/Phaser/Game/GameManager.ts
@@ -72,7 +72,9 @@ export class GameManager {
 
     public async init(scenePlugin: ScenePlugin): Promise<string> {
         this.scenePlugin = scenePlugin;
-        const result = await connectionManager.initGameConnexion();
+        // Awaits the request App.svelte already started; only falls back to firing it here if
+        // nothing did (tests, or any entry point that does not go through App.svelte).
+        const result = await connectionManager.startGameConnexion();
         if (result instanceof URL) {
             window.location.assign(result.toString());
             // window.location.assign is not immediate and Javascript keeps running after.

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -25,6 +25,7 @@ import type { Entity } from "../../ECS/Entity";
 import { DEPTH_OVERLAY_INDEX } from "../DepthIndexes";
 import type { ITiledPlace } from "../GameMapPropertiesListener";
 import type { GameScene } from "../GameScene";
+import { buildDynamicAreas, randomPositionFromLayer } from "./GameMapLookups";
 import { EntitiesManager } from "./EntitiesManager";
 import { AreasManager } from "./AreasManager";
 import { getTileLayerStats, isWorthRenderingOnGpu } from "./TilemapGpuLayerEligibility";
@@ -180,36 +181,9 @@ export class GameMapFrontWrapper {
             }
         }
 
-        let nbUnnamedTileArea = 0;
-
-        // NOTE: We leave "zone" for legacy reasons
-        this.gameMap.tiledObjects
-            .filter((object) => ["zone", "area"].includes(object.class ?? ""))
-            .forEach((tiledArea: ITiledMapObject) => {
-                if (!tiledArea.name) {
-                    tiledArea.name = "unnamed_tiled_area_" + nbUnnamedTileArea;
-                    nbUnnamedTileArea++;
-                }
-
-                if (tiledArea.width === undefined || tiledArea.height === undefined) {
-                    console.warn("Areas must be square objects. Object " + tiledArea.name + " is not square.");
-                    return;
-                }
-                // In case an area already exists with the same name, we rename it to avoid conflicts
-                if (this.dynamicAreas.get(tiledArea.name)) {
-                    console.warn("There are several '" + tiledArea.name + "' areas existing in your Tiled map.");
-                    tiledArea.name = "unnamed_tiled_area_" + nbUnnamedTileArea;
-                    nbUnnamedTileArea++;
-                }
-                this.dynamicAreas.set(tiledArea.name, {
-                    name: tiledArea.name,
-                    width: tiledArea.width,
-                    height: tiledArea.height,
-                    x: tiledArea.x,
-                    y: tiledArea.y,
-                    properties: this.mapTiledPropertiesToDynamicAreaProperties(tiledArea.properties ?? []),
-                });
-            });
+        for (const [name, dynamicArea] of buildDynamicAreas(this.gameMap)) {
+            this.dynamicAreas.set(name, dynamicArea);
+        }
 
         this.collisionGrid = [];
         // NOTE: We cannot really proceed without it
@@ -1094,28 +1068,7 @@ export class GameMapFrontWrapper {
     }
 
     public getRandomPositionFromLayer(layerName: string): { x: number; y: number } {
-        const layer = this.findLayer(layerName) as ITiledMapTileLayer;
-        if (!layer) {
-            throw new Error(`No layer "${layerName}" was found`);
-        }
-        const tiles = layer.data;
-        if (!tiles) {
-            throw new Error(`No tiles in "${layerName}" were found`);
-        }
-        if (typeof tiles === "string") {
-            throw new Error("The content of a JSON map must be filled as a JSON array, not as a string");
-        }
-        const possiblePositions: { x: number; y: number }[] = [];
-        tiles.forEach((objectKey: number, key: number) => {
-            if (objectKey === 0) {
-                return;
-            }
-            possiblePositions.push({ x: key % layer.width, y: Math.floor(key / layer.width) });
-        });
-        if (possiblePositions.length > 0) {
-            return MathUtils.randomFromArray(possiblePositions);
-        }
-        throw new Error(`No possible position found, layer "${layerName}" is empty`);
+        return randomPositionFromLayer(this.gameMap, layerName);
     }
 
     public getTiledObjectProperty(

--- a/play/src/front/Phaser/Game/GameMap/GameMapLookups.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapLookups.ts
@@ -1,0 +1,83 @@
+import type { GameMap } from "@workadventure/map-editor";
+import { MathUtils } from "@workadventure/math-utils";
+import type { ITiledMapObject, ITiledMapTileLayer } from "@workadventure/tiled-map-type-guard";
+
+// Type-only: erased at compile time, so this does not close a runtime cycle with the wrapper.
+import type { DynamicArea } from "./GameMapFrontWrapper";
+
+/**
+ * Reads over the Tiled map that GameMapFrontWrapper used to do inline. They are here because they
+ * need no Phaser at all, which both shortens the wrapper and lets them be tested on their own.
+ */
+
+/**
+ * Tiled "zone"/"area" objects, keyed by name. Note this names the unnamed ones as it goes, which
+ * mutates the objects it walks — kept as it was, because names are how areas are addressed later.
+ */
+export function buildDynamicAreas(gameMap: GameMap): Map<string, DynamicArea> {
+    const dynamicAreas = new Map<string, DynamicArea>();
+    let nbUnnamedTileArea = 0;
+
+    // NOTE: We leave "zone" for legacy reasons
+    gameMap.tiledObjects
+        .filter((object) => ["zone", "area"].includes(object.class ?? ""))
+        .forEach((tiledArea: ITiledMapObject) => {
+            if (!tiledArea.name) {
+                tiledArea.name = "unnamed_tiled_area_" + nbUnnamedTileArea;
+                nbUnnamedTileArea++;
+            }
+
+            if (tiledArea.width === undefined || tiledArea.height === undefined) {
+                console.warn("Areas must be square objects. Object " + tiledArea.name + " is not square.");
+                return;
+            }
+            // In case an area already exists with the same name, we rename it to avoid conflicts
+            if (dynamicAreas.get(tiledArea.name)) {
+                console.warn("There are several '" + tiledArea.name + "' areas existing in your Tiled map.");
+                tiledArea.name = "unnamed_tiled_area_" + nbUnnamedTileArea;
+                nbUnnamedTileArea++;
+            }
+
+            const properties: { [key: string]: unknown } = {};
+            for (const tiledProperty of tiledArea.properties ?? []) {
+                properties[tiledProperty.name] = tiledProperty.value;
+            }
+
+            dynamicAreas.set(tiledArea.name, {
+                name: tiledArea.name,
+                width: tiledArea.width,
+                height: tiledArea.height,
+                x: tiledArea.x,
+                y: tiledArea.y,
+                properties,
+            });
+        });
+
+    return dynamicAreas;
+}
+
+/** A random non-empty tile of a layer, in tile coordinates. */
+export function randomPositionFromLayer(gameMap: GameMap, layerName: string): { x: number; y: number } {
+    const layer = gameMap.findLayer(layerName) as ITiledMapTileLayer;
+    if (!layer) {
+        throw new Error(`No layer "${layerName}" was found`);
+    }
+    const tiles = layer.data;
+    if (!tiles) {
+        throw new Error(`No tiles in "${layerName}" were found`);
+    }
+    if (typeof tiles === "string") {
+        throw new Error("The content of a JSON map must be filled as a JSON array, not as a string");
+    }
+    const possiblePositions: { x: number; y: number }[] = [];
+    tiles.forEach((objectKey: number, key: number) => {
+        if (objectKey === 0) {
+            return;
+        }
+        possiblePositions.push({ x: key % layer.width, y: Math.floor(key / layer.width) });
+    });
+    if (possiblePositions.length > 0) {
+        return MathUtils.randomFromArray(possiblePositions);
+    }
+    throw new Error(`No possible position found, layer "${layerName}" is empty`);
+}

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -123,6 +123,7 @@ import { audioInterruptedStore } from "../../Stores/AudioInterruptedStore";
 import { GameSceneUserInputHandler } from "../UserInput/GameSceneUserInputHandler";
 import { followUsersColorStore, followUsersStore } from "../../Stores/FollowStore";
 import { axiosWithRetry, hideConnectionIssueMessage, showConnectionIssueMessage } from "../../Connection/AxiosUtils";
+import { takePrefetchedTmjFile, takePrefetchedWamFile } from "../../Connection/MapPrefetch";
 import { StringUtils } from "../../Utils/StringUtils";
 import { PHASER_COLOR_DESIGN_SYSTEM_SECONDARY } from "../../Utils/DesignSystemPhaserColors";
 
@@ -565,10 +566,17 @@ export class GameScene extends DirtyScene {
         if (this.wamUrlFile) {
             const absoluteWamFileUrl = new URL(this.wamUrlFile, window.location.href).toString();
 
+            // Usually already in flight: App.svelte prefetches it as soon as the room resolves.
+            // Falls back to fetching here when there is nothing to claim — a re-created scene
+            // (portal, room change, reconnection), which must read the WAM as it is now.
+            const wamResponse =
+                takePrefetchedWamFile(absoluteWamFileUrl) ??
+                axiosWithRetry.get(absoluteWamFileUrl).then((response: { data: unknown }) => response.data);
+
             this.superLoad.loadPromise(
-                axiosWithRetry.get(absoluteWamFileUrl).then((response) => {
+                wamResponse.then((wamData) => {
                     try {
-                        this.wamFile = wamFileMigration.migrate(response.data);
+                        this.wamFile = wamFileMigration.migrate(wamData);
                         this.mapUrlFile = new URL(this.wamFile.mapUrl, absoluteWamFileUrl).toString();
                         this.doLoadTMJFile(this.mapUrlFile);
                         this.loadEntityCollections();
@@ -1782,6 +1790,20 @@ export class GameScene extends DirtyScene {
     }
 
     private doLoadTMJFile(mapUrlFile: string): void {
+        // Usually already downloaded: MapPrefetch chained it on the WAM as soon as the room
+        // resolved. Handing it to Phaser's tilemap cache keeps everything downstream — onMapLoad,
+        // the tileset loads, the renderable layers — on exactly the path it takes today.
+        const prefetched = takePrefetchedTmjFile(mapUrlFile);
+        if (prefetched) {
+            this.superLoad.loadPromise(
+                prefetched.then(async (data) => {
+                    this.cache.tilemap.add(mapUrlFile, { format: Phaser.Tilemaps.Formats.TILED_JSON, data });
+                    await this.onMapLoad(data);
+                }),
+            );
+            return;
+        }
+
         this.load.on("filecomplete-tilemapJSON-" + mapUrlFile, (key: string, type: string, data: unknown) => {
             this.onMapLoad(data).catch((e) => console.error(e));
         });

--- a/play/tests/front/Connection/MapPrefetch.test.ts
+++ b/play/tests/front/Connection/MapPrefetch.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const startGameConnexion = vi.fn();
+const get = vi.fn();
+
+vi.mock("../../../src/front/Connection/ConnectionManager", () => ({
+    connectionManager: {
+        startGameConnexion: () => startGameConnexion(),
+    },
+}));
+vi.mock("@workadventure/map-editor/src/Migrations/WamFileMigration", () => ({
+    wamFileMigration: {
+        migrate: (wam: { mapUrl: string }) => wam,
+    },
+}));
+vi.mock("../../../src/front/Connection/AxiosUtils", () => ({
+    axiosWithRetry: {
+        get: (url: string) => get(url),
+    },
+}));
+
+// Type-only, so it is erased and does not load the module eagerly. The instance under test is
+// imported per test, after vi.resetModules(): MapPrefetch keeps its boxes at module scope, and a
+// prefetch chain started by one test keeps running into the next one. A fresh module per test is
+// the only way each of them describes a single boot.
+import type * as MapPrefetch from "../../../src/front/Connection/MapPrefetch";
+
+let prefetchWamFile: typeof MapPrefetch.prefetchWamFile;
+let takePrefetchedWamFile: typeof MapPrefetch.takePrefetchedWamFile;
+let takePrefetchedTmjFile: typeof MapPrefetch.takePrefetchedTmjFile;
+
+const WAM_URL = "/_/global/maps.example.com/world.wam";
+const ABSOLUTE_WAM_URL = new URL(WAM_URL, window.location.href).toString();
+const ABSOLUTE_TMJ_URL = new URL("world.tmj", ABSOLUTE_WAM_URL).toString();
+
+function roomResolvingTo(wamUrl: string | undefined) {
+    return Promise.resolve({ nextScene: "gameScene", room: { wamUrl } });
+}
+
+/** Let the prefetch's promise chain settle before inspecting what it stored. */
+const settle = () =>
+    new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+describe("WAM prefetch", () => {
+    beforeEach(async () => {
+        vi.resetModules();
+        startGameConnexion.mockReset();
+        get.mockReset();
+        get.mockReturnValue(Promise.resolve({ data: { mapUrl: "world.tmj" } }));
+        ({ prefetchWamFile, takePrefetchedWamFile, takePrefetchedTmjFile } =
+            await import("../../../src/front/Connection/MapPrefetch"));
+    });
+
+    it("downloads the WAM as soon as the room resolves", async () => {
+        startGameConnexion.mockReturnValue(roomResolvingTo(WAM_URL));
+
+        prefetchWamFile();
+        await settle();
+
+        expect(get).toHaveBeenCalledWith(ABSOLUTE_WAM_URL);
+        await expect(takePrefetchedWamFile(ABSOLUTE_WAM_URL)).resolves.toEqual({ mapUrl: "world.tmj" });
+    });
+
+    it("hands the download over only once, so a re-created scene refetches", async () => {
+        startGameConnexion.mockReturnValue(roomResolvingTo(WAM_URL));
+
+        prefetchWamFile();
+        await settle();
+
+        expect(takePrefetchedWamFile(ABSOLUTE_WAM_URL)).toBeDefined();
+        // A portal, a room change or a reconnection rebuilds the scene: it must read the WAM as it
+        // is then, not the copy downloaded at boot.
+        expect(takePrefetchedWamFile(ABSOLUTE_WAM_URL)).toBeUndefined();
+    });
+
+    it("ignores a prefetch for another map", async () => {
+        startGameConnexion.mockReturnValue(roomResolvingTo(WAM_URL));
+
+        prefetchWamFile();
+        await settle();
+
+        expect(takePrefetchedWamFile(new URL("/other.wam", window.location.href).toString())).toBeUndefined();
+    });
+
+    it("downloads nothing for a plain TMJ map", async () => {
+        startGameConnexion.mockReturnValue(roomResolvingTo(undefined));
+
+        prefetchWamFile();
+        await settle();
+
+        expect(get).not.toHaveBeenCalled();
+    });
+
+    it("downloads nothing when the room resolution fails", async () => {
+        startGameConnexion.mockReturnValue(Promise.reject(new Error("no room")));
+
+        prefetchWamFile();
+        await settle();
+
+        expect(get).not.toHaveBeenCalled();
+    });
+});
+
+describe("TMJ prefetch", () => {
+    beforeEach(async () => {
+        vi.resetModules();
+        startGameConnexion.mockReset();
+        get.mockReset();
+        ({ prefetchWamFile, takePrefetchedWamFile, takePrefetchedTmjFile } =
+            await import("../../../src/front/Connection/MapPrefetch"));
+    });
+
+    it("chains the TMJ on the WAM, resolving its URL against the WAM's", async () => {
+        startGameConnexion.mockReturnValue(roomResolvingTo(WAM_URL));
+        get.mockImplementation((url: string) =>
+            url === ABSOLUTE_WAM_URL
+                ? Promise.resolve({ data: { mapUrl: "world.tmj" } })
+                : Promise.resolve({ data: { layers: [] } }),
+        );
+
+        prefetchWamFile();
+        await settle();
+        await settle();
+
+        expect(get).toHaveBeenCalledWith(ABSOLUTE_TMJ_URL);
+        await expect(takePrefetchedTmjFile(ABSOLUTE_TMJ_URL)).resolves.toEqual({ layers: [] });
+    });
+
+    it("hands the TMJ over only once", async () => {
+        startGameConnexion.mockReturnValue(roomResolvingTo(WAM_URL));
+        get.mockImplementation((url: string) =>
+            url === ABSOLUTE_WAM_URL
+                ? Promise.resolve({ data: { mapUrl: "world.tmj" } })
+                : Promise.resolve({ data: { layers: [] } }),
+        );
+
+        prefetchWamFile();
+        await settle();
+        await settle();
+
+        expect(takePrefetchedTmjFile(ABSOLUTE_TMJ_URL)).toBeDefined();
+        expect(takePrefetchedTmjFile(ABSOLUTE_TMJ_URL)).toBeUndefined();
+    });
+
+    it("downloads no TMJ when the WAM fails", async () => {
+        startGameConnexion.mockReturnValue(roomResolvingTo(WAM_URL));
+        get.mockReturnValue(Promise.reject(new Error("no wam")));
+
+        prefetchWamFile();
+        await settle();
+        await settle();
+
+        expect(get).not.toHaveBeenCalledWith(ABSOLUTE_TMJ_URL);
+    });
+});

--- a/play/tests/front/Phaser/Game/GameMap/GameMapLookups.test.ts
+++ b/play/tests/front/Phaser/Game/GameMap/GameMapLookups.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GameMap } from "@workadventure/map-editor";
+import type { ITiledMapObject } from "@workadventure/tiled-map-type-guard";
+
+import {
+    buildDynamicAreas,
+    randomPositionFromLayer,
+} from "../../../../../src/front/Phaser/Game/GameMap/GameMapLookups";
+
+function gameMapWith(tiledObjects: Partial<ITiledMapObject>[]): GameMap {
+    return { tiledObjects } as unknown as GameMap;
+}
+
+function area(overrides: Partial<ITiledMapObject>): Partial<ITiledMapObject> {
+    return { class: "area", x: 0, y: 0, width: 32, height: 32, ...overrides };
+}
+
+describe("buildDynamicAreas", () => {
+    it("keeps Tiled zone and area objects, and nothing else", () => {
+        const areas = buildDynamicAreas(
+            gameMapWith([
+                area({ name: "meeting" }),
+                // "zone" is the legacy spelling and must keep working.
+                area({ name: "legacy", class: "zone" }),
+                area({ name: "not-an-area", class: "chair" }),
+            ]),
+        );
+
+        expect([...areas.keys()]).toEqual(["meeting", "legacy"]);
+    });
+
+    it("names the unnamed ones so they stay addressable", () => {
+        const areas = buildDynamicAreas(gameMapWith([area({ name: "" }), area({ name: "" })]));
+
+        expect([...areas.keys()]).toEqual(["unnamed_tiled_area_0", "unnamed_tiled_area_1"]);
+    });
+
+    it("renames a duplicate instead of dropping the first one", () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        const areas = buildDynamicAreas(gameMapWith([area({ name: "twice" }), area({ name: "twice" })]));
+
+        expect([...areas.keys()]).toEqual(["twice", "unnamed_tiled_area_0"]);
+        warn.mockRestore();
+    });
+
+    it("skips an object that is not square", () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        const areas = buildDynamicAreas(gameMapWith([area({ name: "flat", width: undefined })]));
+
+        expect(areas.size).toBe(0);
+        warn.mockRestore();
+    });
+
+    it("flattens Tiled properties into a plain object", () => {
+        const areas = buildDynamicAreas(
+            gameMapWith([area({ name: "focus", properties: [{ name: "start", type: "bool", value: true }] })]),
+        );
+
+        expect(areas.get("focus")?.properties).toEqual({ start: true });
+    });
+});
+
+describe("randomPositionFromLayer", () => {
+    function gameMapWithLayer(data: number[], width: number): GameMap {
+        return {
+            findLayer: () => ({ name: "start", data, width }),
+        } as unknown as GameMap;
+    }
+
+    it("only ever returns a non-empty tile", () => {
+        // Tile 0 means "no tile": picking one would drop the player outside the start area.
+        const position = randomPositionFromLayer(gameMapWithLayer([0, 0, 0, 7], 2), "start");
+
+        expect(position).toEqual({ x: 1, y: 1 });
+    });
+
+    it("refuses an empty layer rather than returning a wrong position", () => {
+        expect(() => randomPositionFromLayer(gameMapWithLayer([0, 0], 2), "start")).toThrow(/is empty/);
+    });
+
+    it("refuses a missing layer", () => {
+        expect(() => randomPositionFromLayer({ findLayer: () => undefined } as unknown as GameMap, "nope")).toThrow(
+            /was found/,
+        );
+    });
+});


### PR DESCRIPTION
> **Stacked on #6495** (background loading). This PR's own diff is the two commits below; the
> base will retarget to `master` when #6495 merges.

## What this PR does

**1. Takes the network off the render loop.** The room resolution (`/room`), the WAM and the TMJ
used to be requested from `EntryScene.create()` and `GameScene.preload()`, so they only started
once Phaser had booted and `EntryScene` had downloaded its own assets. They now start from
`App.svelte`'s `onMount`, in parallel with all of that, and `GameScene` finds the map already
downloaded instead of opening the request itself. `ConnectionManager.startGameConnexion()`
memoizes the request so `GameManager.init()` awaits the one already in flight.

**2. Lifts two Phaser-free reads over the Tiled map** (`buildDynamicAreas`,
`randomPositionFromLayer`) out of `GameMapFrontWrapper` into `GameMap/GameMapLookups`, where they
are under test. Fifty lines shorter in the wrapper.

## What is, and is not, measured

*The size of the prefetch win is not quantified.* The mechanism is plain — the requests leave at
`onMount` instead of queueing behind Phaser's boot — but measuring the end-to-end gain needs a
production build, and on a dev stack the run-to-run spread (6.0s vs 8.3s for the same commit)
swamps it. Kept on the strength of the mechanism, not of a number.

Non-regression is measured: with these commits on top of #6495, a hidden window still reaches
its world (room joined, window never shown) and a visible one loads normally.

## History

This branch previously also carried the background-boot pump (now #6495, on its own) and an
attempt to join the room before the renderer exists, which broke three ordering-dependent
consumers — personal desks, availability status, the scripting API — and was reverted. That work
is preserved on `feat/join-before-render`. The branch was rebuilt as two clean commits rather than
rebased hunk by hunk through that history.
