### PR TITLE
Allow Jitsi and megaphone properties when MS Teams is enabled

### DIFF
--- a/play/src/front/Components/MapEditor/PropertyEditor/AddPropertyButtonWrapper.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/AddPropertyButtonWrapper.svelte
@@ -14,7 +14,6 @@
     import LL from "../../../../i18n/i18n-svelte";
     import { extensionModuleStore } from "../../../Stores/GameSceneStore";
     import type { ExtensionModule, ExtensionModuleAreaProperty } from "../../../ExternalModule/ExtensionModule";
-    import { mapEditorRestrictedPropertiesStore } from "../../../Stores/MapEditorStore";
     import { gameManager } from "../../../Phaser/Game/GameManager";
     import AddPropertyButton from "./AddPropertyButton.svelte";
     import {
@@ -127,85 +126,43 @@
     />
 {/if}
 {#if property === "jitsiRoomProperty"}
-    {#if $mapEditorRestrictedPropertiesStore.includes("jitsiRoomProperty")}
-        <AddPropertyButton
-            headerText={$LL.mapEditor.properties.jitsiRoomProperty.label()}
-            descriptionText={$LL.mapEditor.properties.jitsiRoomProperty.disabled()}
-            img={jitsiPng}
-            style={`z-index: 260;${isActive ? "background-color: #4156f6;cursor:not-allowed;" : ""}`}
-            onclick={(event) => {
-                onclick?.(event);
-            }}
-            disabled={true}
-            testId="jitsiRoomProperty"
-        />
-    {:else}
-        <AddPropertyButton
-            headerText={$LL.mapEditor.properties.jitsiRoomProperty.label()}
-            descriptionText={$LL.mapEditor.properties.jitsiRoomProperty.description()}
-            img={jitsiPng}
-            style={`z-index: 260;${isActive ? "background-color: #4156f6;" : ""}`}
-            onclick={(event) => {
-                onclick?.(event);
-            }}
-            {disabled}
-            testId="jitsiRoomProperty"
-        />
-    {/if}
+    <AddPropertyButton
+        headerText={$LL.mapEditor.properties.jitsiRoomProperty.label()}
+        descriptionText={$LL.mapEditor.properties.jitsiRoomProperty.description()}
+        img={jitsiPng}
+        style={`z-index: 260;${isActive ? "background-color: #4156f6;" : ""}`}
+        onclick={(event) => {
+            onclick?.(event);
+        }}
+        {disabled}
+        testId="jitsiRoomProperty"
+    />
 {/if}
 {#if property === "speakerMegaphone"}
-    {#if $mapEditorRestrictedPropertiesStore.includes("speakerMegaphone")}
-        <AddPropertyButton
-            headerText={$LL.mapEditor.properties.speakerMegaphone.label()}
-            descriptionText={$LL.mapEditor.properties.speakerMegaphone.disabled()}
-            img={IconMicrophone}
-            style={`z-index: 260;${isActive ? "background-color: #4156f6;cursor:not-allowed;" : ""}`}
-            onclick={(event) => {
-                onclick?.(event);
-            }}
-            disabled={true}
-            testId="speakerMegaphone"
-        />
-    {:else}
-        <AddPropertyButton
-            headerText={$LL.mapEditor.properties.speakerMegaphone.label()}
-            descriptionText={$LL.mapEditor.properties.speakerMegaphone.description()}
-            img={IconMicrophone}
-            style={`z-index: 250;${isActive ? "background-color: #4156f6;" : ""}`}
-            onclick={(event) => {
-                onclick?.(event);
-            }}
-            {disabled}
-            testId="speakerMegaphone"
-        />
-    {/if}
+    <AddPropertyButton
+        headerText={$LL.mapEditor.properties.speakerMegaphone.label()}
+        descriptionText={$LL.mapEditor.properties.speakerMegaphone.description()}
+        img={IconMicrophone}
+        style={`z-index: 250;${isActive ? "background-color: #4156f6;" : ""}`}
+        onclick={(event) => {
+            onclick?.(event);
+        }}
+        {disabled}
+        testId="speakerMegaphone"
+    />
 {/if}
 {#if property === "listenerMegaphone"}
-    {#if $mapEditorRestrictedPropertiesStore.includes("speakerMegaphone")}
-        <AddPropertyButton
-            headerText={$LL.mapEditor.properties.listenerMegaphone.label()}
-            descriptionText={$LL.mapEditor.properties.listenerMegaphone.disabled()}
-            img={IconEar}
-            style={`z-index: 260;${isActive ? "background-color: #4156f6;cursor:not-allowed;" : ""}`}
-            onclick={(event) => {
-                onclick?.(event);
-            }}
-            disabled={true}
-            testId="listenerMegaphone"
-        />
-    {:else}
-        <AddPropertyButton
-            headerText={$LL.mapEditor.properties.listenerMegaphone.label()}
-            descriptionText={$LL.mapEditor.properties.listenerMegaphone.description()}
-            img={IconEar}
-            style={`z-index: 240;${isActive ? "background-color: #4156f6;" : ""}`}
-            onclick={(event) => {
-                onclick?.(event);
-            }}
-            {disabled}
-            testId="listenerMegaphone"
-        />
-    {/if}
+    <AddPropertyButton
+        headerText={$LL.mapEditor.properties.listenerMegaphone.label()}
+        descriptionText={$LL.mapEditor.properties.listenerMegaphone.description()}
+        img={IconEar}
+        style={`z-index: 240;${isActive ? "background-color: #4156f6;" : ""}`}
+        onclick={(event) => {
+            onclick?.(event);
+        }}
+        {disabled}
+        testId="listenerMegaphone"
+    />
 {/if}
 {#if property === "start"}
     <AddPropertyButton

--- a/play/src/front/ExternalModule/ExtensionModule.ts
+++ b/play/src/front/ExternalModule/ExtensionModule.ts
@@ -1,5 +1,5 @@
 import type { AvailabilityStatus, ExternalModuleMessage, OauthRefreshToken } from "@workadventure/messages";
-import type { Readable, Updater, Writable } from "svelte/store";
+import type { Readable, Updater } from "svelte/store";
 import type { CalendarEventInterface, TodoListInterface } from "@workadventure/shared-utils";
 import type { AreaData, AreaDataProperties } from "@workadventure/map-editor";
 import type { Observable } from "rxjs";
@@ -26,7 +26,6 @@ export interface ExtensionModuleOptions {
     roomId: string;
     externalModuleMessage: Observable<ExternalModuleMessage>;
     externalSvelteComponent: ExternalSvelteComponentServiceInterface;
-    externalRestrictedMapEditorProperties?: Writable<string[]>;
     onExtensionModuleStatusChange: (workAdventureNewStatus: AvailabilityStatus) => void;
     openCoWebSite: (openCoWebsiteObject: OpenCoWebsiteObject, source: MessageEventSource | null) => { id: string };
     closeCoWebsite: (id: string) => unknown;

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -139,7 +139,6 @@ import type { GameStateEvent } from "../../Api/Events/GameStateEvent";
 import { currentPlayerWokaStore } from "../../Stores/CurrentPlayerWokaStore";
 import {
     mapEditorModeStore,
-    mapEditorRestrictedPropertiesStore,
     mapEditorSelectedToolStore,
     mapEditorWamSettingsEditorToolCurrentMenuItemStore,
     mapExplorationModeStore,
@@ -2556,7 +2555,6 @@ export class GameScene extends DirtyScene {
                         logoutCallback: () => {
                             connectionManager.logout();
                         },
-                        externalRestrictedMapEditorProperties: mapEditorRestrictedPropertiesStore,
                         showComponentInChat(component, props?) {
                             navChat.switchToCustomComponent(component, props);
                             chatVisibilityStore.set(true);

--- a/play/src/front/Stores/MapEditorStore.ts
+++ b/play/src/front/Stores/MapEditorStore.ts
@@ -96,5 +96,3 @@ export type CategoryTag =
       };
 export type SelectableTag = CategoryTag | undefined;
 export const selectCategoryStore = writable<SelectableTag>(undefined);
-
-export const mapEditorRestrictedPropertiesStore = writable<string[]>([]);

--- a/play/src/i18n/ar-SA/mapEditor.ts
+++ b/play/src/i18n/ar-SA/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "إلغاء",
                 validate: "اعتماد",
             },
-            disabled: "تم تعطيل تكامل Jitsi لهذه الغرفة ❌",
             actionButtonLabel: "بدء اجتماع Jitsi",
         },
         playAudio: {
@@ -123,14 +122,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             description: 'يمكن للمستخدمين على المنصة (المسرح) التحدث إلى جميع الحاضرين في منطقة "الجمهور" المطابقة.',
             nameLabel: "الاسم",
             namePlaceholder: "المسرح الرئيسي",
-            disabled: "المنصة معطلة لهذه الغرفة ❌",
             actionButtonLabel: "الانضمام إلى المنصة",
         },
         listenerMegaphone: {
             label: "الجمهور",
             description: "يمكن للمستخدمين في منطقة الجمهور سماع المتحدث على المنصة المرتبطة.",
             nameLabel: "اسم المنصة",
-            disabled: "الجمهور معطل لهذه الغرفة ❌",
             waitingMediaLinkLabel: "الوسائط المعروضة قبل بدء البث",
             waitingMediaLinkPlaceholder: "https://www… (أدخل رابط الوسائط)",
             waitingMedialLinkError: "يبدو أن هناك مشكلة في الرابط الذي قدمته. هل يمكنك التحقق منه مرة أخرى؟ 🙏",

--- a/play/src/i18n/ca-ES/mapEditor.ts
+++ b/play/src/i18n/ca-ES/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "Cancel·lar",
                 validate: "Validar",
             },
-            disabled: "La integració de Jitsi està desactivada per a aquesta sala ❌",
             actionButtonLabel: "Iniciar una reunió Jitsi",
         },
         playAudio: {
@@ -123,14 +122,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 'Els usuaris al pòdium (escenari) poden parlar a tots els assistents a l\'àrea "Audiència" corresponent.',
             nameLabel: "Nom",
             namePlaceholder: "EscenariPrincipal",
-            disabled: "El pòdium està desactivat per a aquesta sala ❌",
             actionButtonLabel: "Unir-se al pòdium",
         },
         listenerMegaphone: {
             label: "Audiència",
             description: "Els usuaris a l'àrea d'audiència poden escoltar l'orador al pòdium vinculat.",
             nameLabel: "Nom del pòdium",
-            disabled: "L'audiència està desactivada per a aquesta sala ❌",
             namePlaceholder: "LaMevaZonaDeParlant",
             waitingMediaLinkLabel: "Mitjà a mostrar abans que comenci la transmissió en directe",
             waitingMediaLinkPlaceholder: "https://www....",

--- a/play/src/i18n/de-DE/mapEditor.ts
+++ b/play/src/i18n/de-DE/mapEditor.ts
@@ -50,7 +50,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             durationLabel: "Übergangsdauer (ms)",
         },
         jitsiRoomProperty: {
-            disabled: "Jitsi integration is disabled for this room ❌",
             label: "Jitsi-Raum",
             description: "Starten Sie ein Jitsi-Meeting beim Betreten.",
             roomNameLabel: "Raumname",
@@ -124,7 +123,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 'Benutzer auf dem Podium (Bühne) können zu allen Teilnehmern im zugehörigen "Publikum"-Bereich sprechen.',
             nameLabel: "Name",
             namePlaceholder: "Hauptbühne",
-            disabled: "Podium ist für diesen Raum deaktiviert ❌",
             actionButtonLabel: "Podium beitreten",
         },
         listenerMegaphone: {
@@ -132,7 +130,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             description: "Benutzer im Publikumsbereich können den Sprecher auf dem verknüpften Podium hören.",
             nameLabel: "Podiumsname",
             namePlaceholder: "MySpeakerZone",
-            disabled: "Publikum ist für diesen Raum deaktiviert ❌",
             waitingMediaLinkLabel: "Medien, die vor Beginn des Livestreams angezeigt werden",
             waitingMediaLinkPlaceholder: "https://www… (Medien-URL eingeben)",
             waitingMedialLinkError:

--- a/play/src/i18n/dsb-DE/mapEditor.ts
+++ b/play/src/i18n/dsb-DE/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "Pśetergnuś",
                 validate: "Waliděrowaś",
             },
-            disabled: "Jitsi-integracia jo za toś ten rum znjemóžnjona ❌",
             actionButtonLabel: "Jitsi-konferencu startowaś",
         },
         playAudio: {
@@ -124,14 +123,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 'Wužywarje na podiumje (pódij) mógu wšym wobźělnikam w pśisłušnej "Publikum"-wobceŕku powědaś.',
             nameLabel: "Mě",
             namePlaceholder: "HłownePódij",
-            disabled: "Podium jo za toś ten rum znjemóžnjony ❌",
             actionButtonLabel: "K podiumoju pśipowjazaś",
         },
         listenerMegaphone: {
             label: "Publikum",
             description: "Wužywarje w publikumowem wobceŕku mógu powědarja na zwězanem podiumje słyšaś.",
             nameLabel: "Mě podiuma",
-            disabled: "Publikum jo za toś ten rum znjemóžnjony ❌",
             namePlaceholder: "Mója pśisłuchaŕska cona",
             waitingMediaLinkLabel: "Media, kótara se pokazujo, nježli žywy pśenos se zachopje",
             waitingMediaLinkPlaceholder: "https://www....",

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -75,7 +75,6 @@ const mapEditor: BaseTranslation = {
                 cancel: "Cancel",
                 validate: "Validate",
             },
-            disabled: "Jitsi integration is disabled for this room ❌",
             actionButtonLabel: "Start Jitsi meeting",
         },
         playAudio: {
@@ -121,14 +120,12 @@ const mapEditor: BaseTranslation = {
             description: 'Users on the podium (stage) can speak to all attendees in the matching "Audience" area.',
             nameLabel: "Name",
             namePlaceholder: "MainStage",
-            disabled: "Podium is disabled for this room ❌",
             actionButtonLabel: "Join podium",
         },
         listenerMegaphone: {
             label: "Audience",
             description: "Users in the audience area can hear the speaker on the linked podium.",
             nameLabel: "Podium Name",
-            disabled: "Audience is disabled for this room ❌",
             namePlaceholder: "MySpeakerZone",
             waitingMediaLinkLabel: "Media to display before the live starts",
             waitingMediaLinkPlaceholder: "https://www....",

--- a/play/src/i18n/es-ES/mapEditor.ts
+++ b/play/src/i18n/es-ES/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "Cancelar",
                 validate: "Validar",
             },
-            disabled: "La integración Jitsi está desactivada en esta sala ❌",
             actionButtonLabel: "Iniciar reunión Jitsi",
         },
         playAudio: {
@@ -123,14 +122,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 'Los usuarios en el podio (escenario) pueden hablar a todos los asistentes en la zona "Audiencia" correspondiente.',
             nameLabel: "Nombre",
             namePlaceholder: "EscenarioPrincipal",
-            disabled: "El podio está desactivado en esta sala ❌",
             actionButtonLabel: "Unirse al podio",
         },
         listenerMegaphone: {
             label: "Audiencia",
             description: "Los usuarios en la zona de audiencia pueden escuchar al orador en el podio vinculado.",
             nameLabel: "Nombre del podio",
-            disabled: "La audiencia está desactivada en esta sala ❌",
             namePlaceholder: "MiZonaDeOrador",
             waitingMediaLinkLabel: "Medio a mostrar antes del inicio del directo",
             waitingMediaLinkPlaceholder: "https://www....",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "Annuler",
                 validate: "Valider",
             },
-            disabled: "L'intégration Jitsi est désactivée sur ce salon ❌",
             actionButtonLabel: "Démarrer une réunion Jitsi",
         },
         playAudio: {
@@ -125,14 +124,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 'Les utilisateurs sur le podium (scène) peuvent parler à tous les participants dans la zone "Audience" correspondante.',
             nameLabel: "Nom du podium",
             namePlaceholder: "MonPodium",
-            disabled: "Les podiums sont désactivés sur ce salon ❌",
             actionButtonLabel: "Rejoindre le podium",
         },
         listenerMegaphone: {
             label: "Audience",
             description: "Les utilisateurs dans la zone d'audience peuvent entendre l'orateur sur le podium lié.",
             nameLabel: "Nom du podium attaché",
-            disabled: 'Les zones "Audience" sont désactivées sur ce salon ❌',
             namePlaceholder: "MaZoneDeDiffusion",
             waitingMediaLinkLabel: "Média à afficher avant le début du live",
             waitingMediaLinkPlaceholder: "https://www… (entrez l’URL du média)",

--- a/play/src/i18n/hsb-DE/mapEditor.ts
+++ b/play/src/i18n/hsb-DE/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "přetorhnyć",
                 validate: "waliděrować",
             },
-            disabled: "Jitsi-integracia je za tutu rumnosć znjemóžnjena ❌",
             actionButtonLabel: "Jitsi-meeting startować",
         },
         playAudio: {
@@ -123,7 +122,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             description: 'Wužiwarjo na podiumje (podij) móža wšěm wobdźělnikam w přisłušnej "Publikum"-wobłuku rěčeć.',
             nameLabel: "Mjeno",
             namePlaceholder: "HłownyPodij",
-            disabled: "Podium je za tutu rumnosć znjemóžnjeny ❌",
             actionButtonLabel: "K podiumej připojować",
         },
         listenerMegaphone: {
@@ -137,7 +135,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 "Zda so, zo je problem ze wotkazom, kotryž sy zapósłał. Prošu přepruwuj jón hišće raz. 🙏",
             waitingMedialLinkHelp: "Prawy wotkaz měł być 'https://monlienmedia.com/…'.",
             waitingSpeaker: "Čaka so na rěčnika 🎤✨",
-            disabled: "Publikum je za tutu rumnosć znjemóžnjeny ❌",
             actionButtonLabel: "K publikumjej připojować",
         },
         chatEnabled: "Chat aktiwizowany",

--- a/play/src/i18n/it-IT/mapEditor.ts
+++ b/play/src/i18n/it-IT/mapEditor.ts
@@ -51,7 +51,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             durationLabel: "Durata transizione (ms)",
         },
         jitsiRoomProperty: {
-            disabled: "Jitsi integration is disabled for this room ❌",
             label: "Stanza Jitsi",
             description: "Avvia una riunione Jitsi all'ingresso.",
             roomNameLabel: "Nome Stanza",
@@ -125,14 +124,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 'Gli utenti sul podio (palco) possono parlare a tutti i partecipanti nell\'area "Pubblico" corrispondente.',
             nameLabel: "Nome",
             namePlaceholder: "PalcoPrincipale",
-            disabled: "Il podio è disabilitato per questa stanza ❌",
             actionButtonLabel: "Unisciti al podio",
         },
         listenerMegaphone: {
             label: "Pubblico",
             description: "Gli utenti nell'area del pubblico possono sentire l'oratore sul podio collegato.",
             nameLabel: "Nome del Podio",
-            disabled: "Il pubblico è disabilitato per questa stanza ❌",
             namePlaceholder: "MiaZonaAltoparlante",
             waitingMediaLinkLabel: "Contenuto da mostrare prima dell’inizio della diretta",
             waitingMediaLinkPlaceholder: "https://www… (inserisci l’URL del contenuto)",

--- a/play/src/i18n/ja-JP/mapEditor.ts
+++ b/play/src/i18n/ja-JP/mapEditor.ts
@@ -50,7 +50,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             durationLabel: "トランジション時間（ミリ秒）",
         },
         jitsiRoomProperty: {
-            disabled: "Jitsi integration is disabled for this room ❌",
             label: "Jitsi ルーム",
             description: "入室時に Jitsi ミーティングを開始します。",
             roomNameLabel: "ルーム名",
@@ -124,14 +123,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 "ポディウム（ステージ）上のユーザーは、対応する「オーディエンス」エリアのすべての参加者に話すことができます。",
             nameLabel: "名前",
             namePlaceholder: "メインステージ",
-            disabled: "この部屋ではポディウムが無効になっています ❌",
             actionButtonLabel: "ポディウムに参加",
         },
         listenerMegaphone: {
             label: "オーディエンス",
             description: "オーディエンスエリアのユーザーは、リンクされたポディウムのスピーカーを聞くことができます。",
             nameLabel: "ポディウム名",
-            disabled: "この部屋ではオーディエンスが無効になっています ❌",
             namePlaceholder: "私のスピーカーゾーン",
             waitingMediaLinkLabel: "配信開始前に表示するメディア",
             waitingMediaLinkPlaceholder: "https://www…（メディアのURLを入力）",

--- a/play/src/i18n/ko-KR/mapEditor.ts
+++ b/play/src/i18n/ko-KR/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "취소",
                 validate: "확인",
             },
-            disabled: "이 방에서는 Jitsi 연동이 비활성화되었습니다 ❌",
             actionButtonLabel: "Jitsi 미팅 시작",
         },
         playAudio: {
@@ -123,7 +122,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             description: '연단(무대)에 있는 사용자는 연결된 "청중" 영역에 있는 모든 참석자에게 말할 수 있습니다.',
             nameLabel: "이름",
             namePlaceholder: "MainStage",
-            disabled: "이 방에서는 연단 기능이 비활성화되었습니다 ❌",
             actionButtonLabel: "연단 참가",
         },
         listenerMegaphone: {
@@ -131,7 +129,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             description: "청중 영역의 사용자는 연결된 연단의 연사를 들을 수 있습니다.",
             nameLabel: "연결할 연단 이름",
             namePlaceholder: "MySpeakerZone",
-            disabled: "이 방에서는 청중 기능이 비활성화되었습니다 ❌",
             waitingMediaLinkLabel: "라이브 시작 전 표시할 미디어",
             waitingMediaLinkPlaceholder: "https://www....",
             waitingMedialLinkError: "링크에 문제가 있는 것 같습니다. 한 번 더 확인해 주시겠어요? 🙏",

--- a/play/src/i18n/nl-NL/mapEditor.ts
+++ b/play/src/i18n/nl-NL/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "Annuleren",
                 validate: "Valideren",
             },
-            disabled: "Jitsi-integratie is uitgeschakeld voor deze kamer ❌",
             actionButtonLabel: "Start Jitsi-vergadering",
         },
         playAudio: {
@@ -125,14 +124,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 'Gebruikers op het podium (podium) kunnen spreken tot alle deelnemers in het bijbehorende "Publiek" gebied.',
             nameLabel: "Naam",
             namePlaceholder: "HoofdPodium",
-            disabled: "Podium is uitgeschakeld voor deze kamer ❌",
             actionButtonLabel: "Deelnemen aan podium",
         },
         listenerMegaphone: {
             label: "Publiek",
             description: "Gebruikers in het publieksgebied kunnen de spreker op het gekoppelde podium horen.",
             nameLabel: "Podiumnaam",
-            disabled: "Publiek is uitgeschakeld voor deze kamer ❌",
             namePlaceholder: "MijnSprekerZone",
             waitingMediaLinkLabel: "Media om weer te geven voordat de livestream begint",
             waitingMediaLinkPlaceholder: "https://www… (media-URL invoeren)",

--- a/play/src/i18n/pt-BR/mapEditor.ts
+++ b/play/src/i18n/pt-BR/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "Cancelar",
                 validate: "Validar",
             },
-            disabled: "Integração Jitsi está desabilitada para esta sala ❌",
             actionButtonLabel: "Iniciar reunião Jitsi",
         },
         playAudio: {
@@ -124,14 +123,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 'Os usuários no pódio (palco) podem falar com todos os participantes na área "Audiência" correspondente.',
             nameLabel: "Nome",
             namePlaceholder: "PalcoPrincipal",
-            disabled: "O pódio está desabilitado para esta sala ❌",
             actionButtonLabel: "Entrar no pódio",
         },
         listenerMegaphone: {
             label: "Audiência",
             description: "Os usuários na área da audiência podem ouvir o palestrante no pódio vinculado.",
             nameLabel: "Nome do Pódio",
-            disabled: "A audiência está desabilitada para esta sala ❌",
             namePlaceholder: "MinhaZonaPalestrante",
             waitingMediaLinkLabel: "Mídia exibida antes do início da transmissão",
             waitingMediaLinkPlaceholder: "https://www… (insira a URL da mídia)",

--- a/play/src/i18n/zh-CN/mapEditor.ts
+++ b/play/src/i18n/zh-CN/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "取消",
                 validate: "验证",
             },
-            disabled: "此房间的 Jitsi 集成已禁用 ❌",
             actionButtonLabel: "开始 Jitsi 会议",
         },
         playAudio: {
@@ -122,14 +121,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             description: '讲台（舞台）上的用户可以向匹配的"观众"区域中的所有与会者讲话。',
             nameLabel: "名称",
             namePlaceholder: "主舞台",
-            disabled: "此房间的讲台已禁用 ❌",
             actionButtonLabel: "加入讲台",
         },
         listenerMegaphone: {
             label: "观众",
             description: "观众区域的用户可以听到链接讲台上的演讲者。",
             nameLabel: "讲台名称",
-            disabled: "此房间的观众已禁用 ❌",
             namePlaceholder: "我的演讲者区域",
             waitingMediaLinkLabel: "直播开始前显示的媒体",
             waitingMediaLinkPlaceholder: "https://www....",

--- a/play/src/i18n/zh-TW/mapEditor.ts
+++ b/play/src/i18n/zh-TW/mapEditor.ts
@@ -76,7 +76,6 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 cancel: "取消",
                 validate: "驗證",
             },
-            disabled: "此房間的 Jitsi 整合已停用 ❌",
             actionButtonLabel: "開始 Jitsi 會議",
         },
         playAudio: {
@@ -122,14 +121,12 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             description: "講台（舞台）上的使用者可以向相符的「觀眾」區域中的所有與會者講話。",
             nameLabel: "名稱",
             namePlaceholder: "主舞台",
-            disabled: "此房間的講台已停用 ❌",
             actionButtonLabel: "加入講台",
         },
         listenerMegaphone: {
             label: "觀眾",
             description: "觀眾區域的使用者可以聽到所連結講台上的演講者。",
             nameLabel: "講台名稱",
-            disabled: "此房間的觀眾已停用 ❌",
             namePlaceholder: "我的演講者區域",
             waitingMediaLinkLabel: "直播開始前顯示的媒體",
             waitingMediaLinkPlaceholder: "https://www....",


### PR DESCRIPTION
## Context

At some point we added a restriction: when the MS Teams module was active (with online meetings available), the map editor disabled the **Jitsi room**, **Podium** and **Audience** area properties, because Teams meetings were meant to replace them.

This is no longer true — anyone, even with MS Teams, can now create a Jitsi/LiveKit meeting area.

## What this PR does

Removes the whole `externalRestrictedMapEditorProperties` notion:

- `ExtensionModuleOptions.externalRestrictedMapEditorProperties` is gone from [ExtensionModule.ts](play/src/front/ExternalModule/ExtensionModule.ts) (no extension module in this repo ever used it; the only consumer was the closed-source MS Teams module).
- `mapEditorRestrictedPropertiesStore` is removed from [MapEditorStore.ts](play/src/front/Stores/MapEditorStore.ts) and unwired from `GameScene`.
- `AddPropertyButtonWrapper.svelte` loses the three `{#if restricted}…{:else}…{/if}` branches; the "enabled" branch is now the only one.
- The three now-unused `disabled` translations (`jitsiRoomProperty`, `speakerMegaphone`, `listenerMegaphone`) are dropped from all 15 locales.

Net: 34 insertions, 127 deletions. No behaviour change other than the properties never being greyed out.

## Ordering

The MS Teams module (in the SaaS repository) is the only caller. Its companion MR removing the call site should be merged **before** this PR, otherwise the SaaS build fails to type-check.

## Checks run

- `tsc --noEmit` — clean
- `svelte-check` — 0 errors, 0 warnings
- `eslint` on the touched files — clean
- `prettier --check` on the touched files — clean
- `npm run i18n:check` — "All translations are complete"

🤖 Generated with [Claude Code](https://claude.com/claude-code)