### PR TITLE
fix(map-editor): guard optional MapEditorModeManager to prevent crash

### DIFF
--- a/play/src/front/Components/ActionBar/MenuIcons/MapSubMenuContent.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/MapSubMenuContent.svelte
@@ -52,11 +52,11 @@
         if ($mapEditorModeStore && !$mapExplorationModeStore) {
             analyticsClient.toggleMapEditor(false);
             mapEditorModeStore.switchMode(false);
-            gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(undefined);
+            gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(undefined);
         } else {
             analyticsClient.toggleMapEditor(true);
             mapEditorModeStore.switchMode(true);
-            gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(EditorToolName.EntityEditor);
+            gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(EditorToolName.EntityEditor);
         }
         isTodoListVisibleStore.set(false);
         isCalendarVisibleStore.set(false);
@@ -65,11 +65,11 @@
 
     function toggleMapExplorerMode() {
         if ($mapExplorationModeStore) {
-            gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(undefined);
+            gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(undefined);
             mapEditorModeStore.switchMode(false);
         } else {
             mapEditorModeStore.switchMode(true);
-            gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(EditorToolName.ExploreTheRoom);
+            gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(EditorToolName.ExploreTheRoom);
         }
 
         analyticsClient.clickTopOpenMapExplorer();

--- a/play/src/front/Components/ActionsMenu/ExplorerMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/ExplorerMenu.svelte
@@ -97,14 +97,14 @@
         analyticsClient.clickTopOpenMapExplorer();
 
         mapEditorModeStore.switchMode(true);
-        gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(EditorToolName.ExploreTheRoom);
+        gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(EditorToolName.ExploreTheRoom);
     }
 
     function centerToUser() {
         analyticsClient.clickCenterToUser();
 
         mapEditorModeStore.switchMode(false);
-        gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(EditorToolName.CloseMapEditor);
+        gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(EditorToolName.CloseMapEditor);
     }
 
     onDestroy(() => {

--- a/play/src/front/Components/Exploration/Explorer.svelte
+++ b/play/src/front/Components/Exploration/Explorer.svelte
@@ -139,8 +139,10 @@
         gameManager.getCurrentGameScene().getCameraManager().centerCameraOn(entity);
         // Use explorer tool to define the zoom to center camera position
         (
-            gameManager.getCurrentGameScene().getMapEditorModeManager().currentlyActiveTool as ExplorerTool
-        ).defineZoomToCenterCameraPosition();
+            gameManager.getCurrentGameScene().getMapEditorModeManager()?.currentlyActiveTool as
+                | ExplorerTool
+                | undefined
+        )?.defineZoomToCenterCameraPosition();
     }
     function unhighlightEntity(entity: Entity) {
         // Don't unhighlight if the entity is selected
@@ -155,8 +157,10 @@
         gameManager.getCurrentGameScene().getCameraManager().centerCameraOn(area);
         // Use explorer tool to define the zoom to center camera position
         (
-            gameManager.getCurrentGameScene().getMapEditorModeManager().currentlyActiveTool as ExplorerTool
-        ).defineZoomToCenterCameraPosition();
+            gameManager.getCurrentGameScene().getMapEditorModeManager()?.currentlyActiveTool as
+                | ExplorerTool
+                | undefined
+        )?.defineZoomToCenterCameraPosition();
     }
     function unhighlightArea(area: AreaPreview) {
         // Don't unhighlight if the area is selected
@@ -246,7 +250,7 @@
                     closable: true,
                 });
             });
-        gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(undefined);
+        gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(undefined);
 
         // Close map editor to walk on the entity or zone
         analyticsClient.toggleMapEditor(!$mapEditorModeStore);

--- a/play/src/front/Components/Exploration/Explorer.svelte
+++ b/play/src/front/Components/Exploration/Explorer.svelte
@@ -138,11 +138,8 @@
         entity.setPointedToEditColor(0xf9e82d);
         gameManager.getCurrentGameScene().getCameraManager().centerCameraOn(entity);
         // Use explorer tool to define the zoom to center camera position
-        (
-            gameManager.getCurrentGameScene().getMapEditorModeManager()?.currentlyActiveTool as
-                | ExplorerTool
-                | undefined
-        )?.defineZoomToCenterCameraPosition();
+        const activeTool = gameManager.getCurrentGameScene().getMapEditorModeManager()?.currentlyActiveTool;
+        (activeTool as ExplorerTool | undefined)?.defineZoomToCenterCameraPosition();
     }
     function unhighlightEntity(entity: Entity) {
         // Don't unhighlight if the entity is selected
@@ -156,11 +153,8 @@
         area.setStrokeStyle(2, 0xf9e82d);
         gameManager.getCurrentGameScene().getCameraManager().centerCameraOn(area);
         // Use explorer tool to define the zoom to center camera position
-        (
-            gameManager.getCurrentGameScene().getMapEditorModeManager()?.currentlyActiveTool as
-                | ExplorerTool
-                | undefined
-        )?.defineZoomToCenterCameraPosition();
+        const activeTool = gameManager.getCurrentGameScene().getMapEditorModeManager()?.currentlyActiveTool;
+        (activeTool as ExplorerTool | undefined)?.defineZoomToCenterCameraPosition();
     }
     function unhighlightArea(area: AreaPreview) {
         // Don't unhighlight if the area is selected

--- a/play/src/front/Components/MapEditor/ClaimPersonalAreaDialogBox.svelte
+++ b/play/src/front/Components/MapEditor/ClaimPersonalAreaDialogBox.svelte
@@ -100,7 +100,7 @@
                         variant="secondary"
                         class="w-fit px-10"
                         onclick={() => {
-                            mapEditorModeManager.claimPersonalArea(name);
+                            mapEditorModeManager?.claimPersonalArea(name);
                             closeDialog();
                         }}
                     >

--- a/play/src/front/Components/MapEditor/MapEditorSideBar.svelte
+++ b/play/src/front/Components/MapEditor/MapEditorSideBar.svelte
@@ -72,7 +72,7 @@
             mapEditorVisibilityStore.set(true);
         }
         analyticsClient.openMapEditorTool(newTool);
-        gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(newTool);
+        gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(newTool);
     }
 
     function toggleMapEditor() {

--- a/play/src/front/Components/MapEditor/WAMSettingsEditor.svelte
+++ b/play/src/front/Components/MapEditor/WAMSettingsEditor.svelte
@@ -54,7 +54,7 @@
 
     function close() {
         mapEditorWamSettingsEditorToolCurrentMenuItemStore.set(undefined);
-        gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(EditorToolName.EntityEditor);
+        gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(EditorToolName.EntityEditor);
     }
 </script>
 

--- a/play/src/front/Components/Modal/ObjectDetails.svelte
+++ b/play/src/front/Components/Modal/ObjectDetails.svelte
@@ -156,7 +156,7 @@
                         closable: true,
                     });
                 });
-            gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(undefined);
+            gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(undefined);
 
             // Close map editor to walk on the entity or zone
             analyticsClient.toggleMapEditor(!$mapEditorModeStore);

--- a/play/src/front/Components/PopUp/PopUpDropFileEntity.svelte
+++ b/play/src/front/Components/PopUp/PopUpDropFileEntity.svelte
@@ -113,7 +113,7 @@
 
         analyticsClient.dragDropFile();
         mapEditorModeStore.switchMode(true);
-        mapEditorModeManager.equipTool(EditorToolName.EntityEditor);
+        mapEditorModeManager?.equipTool(EditorToolName.EntityEditor);
         mapEditorEntityFileDroppedStore.set(true);
         mapEditorEntityModeStore.set("ADD");
         mapEditorSelectedEntityPrefabStore.set($state.snapshot(entityPrefab || defaultEntityPrefab));

--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -370,7 +370,7 @@ export class EntitiesManager extends EventEmitter {
                 this.isEntityEditorToolActive() == false
             ) {
                 // Activate entity editor tool
-                this.scene.getMapEditorModeManager().equipTool(EditorToolName.EntityEditor);
+                this.scene.getMapEditorModeManager()?.equipTool(EditorToolName.EntityEditor);
             }
 
             if (get(mapEditorModeStore) && !get(mapEditorSelectedEntityPrefabStore)) {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -358,7 +358,7 @@ export class GameScene extends DirtyScene {
     private mapTransitioning = false; //used to prevent transitions happening at the same time.
     private emoteManager!: EmoteManager;
     private cameraManager!: CameraManager;
-    private mapEditorModeManager!: MapEditorModeManager;
+    private mapEditorModeManager: MapEditorModeManager | undefined;
     private entitiesCollectionsManager!: EntitiesCollectionsManager;
     private pathfindingManager!: PathfindingManager;
     private activatablesManager!: ActivatablesManager;
@@ -1752,7 +1752,7 @@ export class GameScene extends DirtyScene {
         return this.remotePlayersRepository;
     }
 
-    public getMapEditorModeManager(): MapEditorModeManager {
+    public getMapEditorModeManager(): MapEditorModeManager | undefined {
         return this.mapEditorModeManager;
     }
 

--- a/play/src/front/Phaser/Game/LocateManager.ts
+++ b/play/src/front/Phaser/Game/LocateManager.ts
@@ -48,7 +48,7 @@ export class LocateManager {
         // Subscribe to woka menu store to stop following the remote player when the woka menu is closed.
         this.wokaMenuStoreUnsubscriber = wokaMenuStore.subscribe((value) => {
             if (value === undefined && previouslyFollowedRemotePlayer !== undefined) {
-                if (!this.scene.getMapEditorModeManager().returnToLastMode()) {
+                if (!this.scene.getMapEditorModeManager()?.returnToLastMode()) {
                     this.cameraManager.stopFollowRemotePlayer();
                 }
                 previouslyFollowedRemotePlayer = undefined;

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Facades.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Facades.ts
@@ -13,7 +13,7 @@ export async function executeUpdateWAMSettings(
     if (!wamFile || !scene.connection) {
         return;
     }
-    await scene.getMapEditorModeManager().executeCommand(
+    await scene.getMapEditorModeManager()?.executeCommand(
         new UpdateWAMSettingFrontCommand(
             wamFile,
             {

--- a/play/src/front/Phaser/Game/MapEditor/Tools/CloseTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/CloseTool.ts
@@ -14,7 +14,7 @@ export class CloseTool implements MapEditorTool {
     }
     public activate(): void {
         analyticsClient.toggleMapEditor(false);
-        gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(undefined);
+        gameManager.getCurrentGameScene().getMapEditorModeManager()?.equipTool(undefined);
         mapEditorModeStore.switchMode(false);
         mapEditorVisibilityStore.set(false);
     }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
@@ -349,7 +349,7 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
             // Check that the user can open map editor to edit an area
             if (get(mapEditorActivated)) {
                 if (clickedAreaPreview && get(mapEditorSelectedToolStore) !== EditorToolName.AreaEditor) {
-                    this.scene.getMapEditorModeManager().equipTool(EditorToolName.AreaEditor);
+                    this.scene.getMapEditorModeManager()?.equipTool(EditorToolName.AreaEditor);
                 }
             }
             return;


### PR DESCRIPTION
## Summary

When `ENABLE_MAP_EDITOR=false`, `GameScene` never instantiates `mapEditorModeManager`, but `getMapEditorModeManager()` was typed to always return a `MapEditorModeManager` and several call sites (notably `LocateManager`, used when closing the Woka menu after following a remote player) called into it unconditionally, throwing a `TypeError`.

- `getMapEditorModeManager()` now returns `MapEditorModeManager | undefined`
- Removed the non-null assertion (`!`) on the `mapEditorModeManager` field in `GameScene`
- Fixed every now-unguarded call site with optional chaining

Fixes #6441, related to #5618.

Generated with [Claude Code](https://claude.ai/code)