### PR TITLE
Acknowledge admin messages so they are displayed only once

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -543,7 +543,13 @@ const roomManager = {
     sendAdminMessage(call: ServerUnaryCall<AdminMessage, Empty>, callback: sendUnaryData<Empty>): void {
         const adminMessage = call.request;
         socketManager
-            .sendAdminMessage(adminMessage.roomId, adminMessage.recipientUuid, adminMessage.message, adminMessage.type)
+            .sendAdminMessage(
+                adminMessage.roomId,
+                adminMessage.recipientUuid,
+                adminMessage.message,
+                adminMessage.type,
+                adminMessage.id,
+            )
             .catch((e) => {
                 console.error(e);
                 Sentry.captureException(e);

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -1076,7 +1076,13 @@ export class SocketManager {
         debug('Room "%s" was forcefully deleted from cache', roomId);
     }
 
-    public async sendAdminMessage(roomId: string, recipientUuid: string, message: string, type: string): Promise<void> {
+    public async sendAdminMessage(
+        roomId: string,
+        recipientUuid: string,
+        message: string,
+        type: string,
+        id = "",
+    ): Promise<void> {
         const room = await this.roomsPromises.get(roomId);
         if (!room) {
             console.error(
@@ -1113,6 +1119,7 @@ export class SocketManager {
                 sendUserMessage: {
                     message,
                     type,
+                    id,
                 },
             });
         }
@@ -1159,6 +1166,8 @@ export class SocketManager {
                 banUserMessage: {
                     message,
                     type: "banned",
+                    // The user is kicked right away, there is nothing to acknowledge.
+                    id: "",
                 },
             });
             endUserConnectionWithReason(recipient.socket, `User was banned: ${message}`);
@@ -1188,6 +1197,8 @@ export class SocketManager {
                 sendUserMessage: {
                     message,
                     type,
+                    // A room-wide message is not stored per user: nothing to acknowledge.
+                    id: "",
                 },
             });
         });

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -436,6 +436,7 @@ message ClientToServerMessage {
     MeetingInvitationResponseMessage meetingInvitationResponseMessage = 49;
     SetAreaPropertyVariableMessage setAreaPropertyVariableMessage = 46;
     VideoQualityReportMessage videoQualityReportMessage = 50;
+    UserMessageReadMessage userMessageReadMessage = 51;
   }
 }
 
@@ -1070,6 +1071,16 @@ message TeleportMessageMessage{
 message SendUserMessage{
   string type = 1;
   string message = 2;
+  // Identifier of the message on the admin side. Sent back by the client in a
+  // UserMessageReadMessage once the message has been read, so the admin can stop sending it.
+  // Empty when the admin did not provide one.
+  string id = 3;
+}
+
+// Sent by the client when the user acknowledged a message received in a SendUserMessage
+// (typically by clicking the "Ok" button of the moderation warning popup).
+message UserMessageReadMessage{
+  string id = 1;
 }
 
 message WorldFullWarningMessage{
@@ -1107,6 +1118,8 @@ message WorldConnectionMessage{
 message BanUserMessage{
   string type = 1;
   string message = 2;
+  // See SendUserMessage.id
+  string id = 3;
 }
 
 message AskPositionMessage{
@@ -1609,6 +1622,8 @@ message AdminMessage {
   string recipientUuid = 2;
   string roomId = 3;
   string type = 4;
+  // See SendUserMessage.id
+  string id = 5;
 }
 
 // A message sent by an administrator to everyone in a specific room

--- a/play/src/front/Administration/UserMessageManager.ts
+++ b/play/src/front/Administration/UserMessageManager.ts
@@ -13,7 +13,7 @@ class UserMessageManager {
         //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
         adminMessagesService.messageStream.subscribe((event) => {
             if (event.type === AdminMessageEventTypes.admin) {
-                textMessageStore.addMessage(event.text);
+                textMessageStore.addMessage(event.text, event.adminMessageId);
                 // Play sound in game scene if available
                 try {
                     gameManager.getCurrentGameScene().playSound("new-message", 0.2);
@@ -23,9 +23,9 @@ class UserMessageManager {
             } else if (event.type === AdminMessageEventTypes.audio) {
                 soundPlayingStore.playSound(UPLOADER_URL + event.text);
             } else if (event.type === AdminMessageEventTypes.ban) {
-                banMessageStore.addMessage(event.text);
+                banMessageStore.addMessage(event.text, event.adminMessageId);
             } else if (event.type === AdminMessageEventTypes.banned) {
-                banMessageStore.addMessage(event.text);
+                banMessageStore.addMessage(event.text, event.adminMessageId);
                 this.receiveBannedMessageListener();
             }
         });

--- a/play/src/front/Components/TypeMessage/BanMessage.svelte
+++ b/play/src/front/Components/TypeMessage/BanMessage.svelte
@@ -35,6 +35,14 @@
     }
 
     function closeBanMessage() {
+        if (message.adminMessageId !== undefined) {
+            // Tell the admin the message was read, so it is never displayed to this user again.
+            try {
+                gameManager.getCurrentGameScene().connection?.emitUserMessageRead(message.adminMessageId);
+            } catch (e) {
+                console.error("Could not acknowledge the moderation message", e);
+            }
+        }
         banMessageStore.clearMessageById(message.id);
     }
 </script>

--- a/play/src/front/Connection/AdminMessagesService.ts
+++ b/play/src/front/Connection/AdminMessagesService.ts
@@ -11,6 +11,8 @@ export enum AdminMessageEventTypes {
 interface AdminMessageEvent {
     type: AdminMessageEventTypes;
     text: string;
+    /** Identifier of the message on the admin side, empty when the admin did not provide one. */
+    adminMessageId?: string;
     //todo add optional properties for other event types
 }
 
@@ -24,6 +26,7 @@ class AdminMessagesService {
         this._messageStream.next({
             type: message.type as unknown as AdminMessageEventTypes,
             text: message.message,
+            adminMessageId: message.id !== "" ? message.id : undefined,
         });
     }
 }

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -1100,6 +1100,20 @@ export class RoomConnection implements RoomConnection {
         });
     }
 
+    /**
+     * Acknowledges a message sent by a moderator, so the admin never displays it again.
+     */
+    public emitUserMessageRead(adminMessageId: string): void {
+        this.send({
+            message: {
+                $case: "userMessageReadMessage",
+                userMessageReadMessage: {
+                    id: adminMessageId,
+                },
+            },
+        });
+    }
+
     public emitBanPlayerMessage(banUserUuid: string, banUserName: string): void {
         this.send({
             message: {

--- a/play/src/front/Stores/TypeMessageStore/MessageStore.ts
+++ b/play/src/front/Stores/TypeMessageStore/MessageStore.ts
@@ -4,6 +4,11 @@ import { v4 as uuidv4 } from "uuid";
 export interface Message {
     id: string;
     text: string;
+    /**
+     * Identifier of the message on the admin side, when it comes from one. Sent back to the admin
+     * once the user acknowledged the message, so it is never displayed again.
+     */
+    adminMessageId?: string;
 }
 
 /**
@@ -14,9 +19,9 @@ export function createMessageStore() {
 
     return {
         subscribe,
-        addMessage: (text: string): void => {
+        addMessage: (text: string, adminMessageId?: string): void => {
             update((messages: Message[]) => {
-                return [...messages, { id: uuidv4(), text }];
+                return [...messages, { id: uuidv4(), text, adminMessageId }];
             });
         },
         clearMessageById: (id: string): void => {

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -226,6 +226,7 @@ export class IoSocketController {
                                         messageToEmit.message,
                                         messageToEmit.type,
                                         roomId,
+                                        messageToEmit.id !== undefined ? String(messageToEmit.id) : "",
                                     )
                                     .catch((error) => {
                                         Sentry.captureException(error);
@@ -517,7 +518,13 @@ export class IoSocketController {
                     socket.send({
                         message: {
                             $case: "sendUserMessage",
-                            sendUserMessage: loginMessage,
+                            sendUserMessage: {
+                                type: loginMessage.type,
+                                message: loginMessage.message,
+                                // The admin identifies its messages with an integer: normalize it,
+                                // the client sends it back as-is to acknowledge the message.
+                                id: loginMessage.id !== undefined ? String(loginMessage.id) : "",
+                            },
                         },
                     });
                 }
@@ -1094,6 +1101,13 @@ export class IoSocketController {
                                 }`;
 
                                 await socketManager.handleBackEvent(socket, message.message.backEvent);
+                                break;
+                            }
+                            case "userMessageReadMessage": {
+                                await socketManager.handleUserMessageRead(
+                                    socket,
+                                    message.message.userMessageReadMessage,
+                                );
                                 break;
                             }
                             case "videoQualityReportMessage": {

--- a/play/src/pusher/models/Websocket/Admin/AdminMessages.ts
+++ b/play/src/pusher/models/Websocket/Admin/AdminMessages.ts
@@ -5,6 +5,9 @@ export const isBanBannedAdminMessageInterface = z.object({
     type: z.enum(["ban", "banned"]),
     message: z.string(),
     userUuid: z.string(),
+    // Identifier of the message on the admin side, so the client can acknowledge it once read.
+    // Optional: an admin that does not store the message simply gets no read receipt.
+    id: z.union([z.string(), z.number()]).optional(),
 });
 
 export const isUserMessageAdminMessageInterface = z.object({

--- a/play/src/pusher/services/AdminApi.ts
+++ b/play/src/pusher/services/AdminApi.ts
@@ -51,6 +51,10 @@ export type AdminBannedData = z.infer<typeof AdminBannedData>;
 export const AdminLoginMessage = z.object({
     type: z.string(),
     message: z.string(),
+    // Identifier of the message on the admin side. Sent back to the admin once the user read the
+    // message, so it is not displayed again on the next connection. Optional: an admin that does
+    // not provide it simply gets no read receipt.
+    id: z.union([z.string(), z.number()]).optional(),
 });
 
 export type AdminLoginMessage = z.infer<typeof AdminLoginMessage>;
@@ -595,6 +599,45 @@ class AdminApi implements AdminInterface {
             },
             {
                 headers: { Authorization: `${ADMIN_API_TOKEN}`, "Accept-Language": locale ?? "en" },
+            },
+        );
+    }
+
+    /**
+     * Tells the admin that the user read a message previously sent through SendUserMessage, so it
+     * is not sent again on the next connection.
+     */
+    async markUserMessageAsRead(messageId: string, userIdentifier: string): Promise<void> {
+        /**
+         * @openapi
+         * /api/room/message/{messageId}/read:
+         *   post:
+         *     tags: ["AdminAPI"]
+         *     description: Flags a message sent to a user as read, so it is never displayed again
+         *     security:
+         *      - Bearer: []
+         *     parameters:
+         *      - name: "messageId"
+         *        in: "path"
+         *        required: true
+         *        description: "The identifier of the message, as returned by /api/room/access"
+         *        type: "string"
+         *      - name: "userIdentifier"
+         *        in: "body"
+         *        required: true
+         *        description: "The identifier of the user who read the message"
+         *        type: "string"
+         *     responses:
+         *       200:
+         *         description: The message has been flagged as read
+         */
+        await axios.post(
+            `${ADMIN_API_URL}/api/room/message/${encodeURIComponent(messageId)}/read`,
+            {
+                userIdentifier,
+            },
+            {
+                headers: { Authorization: `${ADMIN_API_TOKEN}` },
             },
         );
     }

--- a/play/src/pusher/services/AdminInterface.ts
+++ b/play/src/pusher/services/AdminInterface.ts
@@ -77,6 +77,15 @@ export interface AdminInterface {
     ): Promise<unknown>;
 
     /**
+     * Flags a message previously sent to a user (see the "messages" field of fetchMemberDataByUuid)
+     * as read, so it is not sent again the next time the user connects.
+     *
+     * @param messageId identifier of the message, as returned by fetchMemberDataByUuid
+     * @param userIdentifier the user who read the message
+     */
+    markUserMessageAsRead(messageId: string, userIdentifier: string): Promise<void>;
+
+    /**
      * @param locale
      * @param userUuid
      * @param ipAddress

--- a/play/src/pusher/services/LocalAdmin.ts
+++ b/play/src/pusher/services/LocalAdmin.ts
@@ -362,6 +362,11 @@ class LocalAdmin implements AdminInterface {
         return Promise.reject(new Error("No admin backoffice set!"));
     }
 
+    markUserMessageAsRead(messageId: string, userIdentifier: string): Promise<void> {
+        // Without an admin backoffice there is no message to flag as read.
+        return Promise.resolve();
+    }
+
     async verifyBanUser(
         userUuid: string,
         ipAddress: string,

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -39,6 +39,7 @@ import type {
     SetPlayerDetailsMessage,
     IceServersAnswer,
     UpdateSpaceUserMessage,
+    UserMessageReadMessage,
     UserMovesMessage,
     ViewportMessage,
     GetSignedUrlAnswer,
@@ -726,6 +727,28 @@ export class SocketManager implements ZoneEventListener {
         }
     }
 
+    /**
+     * The user acknowledged a message sent by a moderator (typically by clicking "Ok" in the
+     * warning popup): tell the admin so the message is never displayed again.
+     */
+    async handleUserMessageRead(
+        client: PusherWebSocket,
+        userMessageReadMessage: UserMessageReadMessage,
+    ): Promise<void> {
+        const messageId = userMessageReadMessage.id;
+        if (!messageId) {
+            // Messages pushed live by a moderator to an already connected user carry no id.
+            return;
+        }
+        const socketData = client.getUserData();
+        try {
+            await adminService.markUserMessageAsRead(messageId, socketData.userUuid);
+        } catch (e) {
+            Sentry.captureException(`An error occurred on "handleUserMessageRead" ${e}`);
+            console.error(`An error occurred on "handleUserMessageRead" ${e}`);
+        }
+    }
+
     async handleBanPlayerMessage(client: PusherWebSocket, banPlayerMessage: BanPlayerMessage): Promise<void> {
         const socketData = client.getUserData();
         // Ban player only if the user is admin
@@ -861,7 +884,13 @@ export class SocketManager implements ZoneEventListener {
         return this.rooms;
     }
 
-    public async emitSendUserMessage(userUuid: string, message: string, type: string, roomId: string): Promise<void> {
+    public async emitSendUserMessage(
+        userUuid: string,
+        message: string,
+        type: string,
+        roomId: string,
+        id = "",
+    ): Promise<void> {
         /*const client = this.searchClientByUuid(userUuid);
         if(client) {
             const adminMessage = new SendUserMessage();
@@ -879,6 +908,7 @@ export class SocketManager implements ZoneEventListener {
             roomId,
             recipientUuid: userUuid,
             type,
+            id,
         };
         backConnection.sendAdminMessage(backAdminMessage, (error: unknown) => {
             if (error !== null) {


### PR DESCRIPTION
## Problem

The admin API returns, on every room access, the list of messages a moderator queued for a user (typically a warning before a ban). The client had no way to tell the admin it displayed them.

That left an admin with only bad options: keep returning the message forever (it pops up on every single page load), or drop it as soon as it is handed over — with no guarantee it ever reached a screen. Note that `/api/room/access` is queried **twice per page load** (once by the pusher's `/me`, once on the WebSocket upgrade) and only the second call forwards the messages, so "drop it on serve" reliably loses the message.

## What this does

Clicking **Ok** in the warning popup now sends a `UserMessageReadMessage` back. The pusher forwards it to the admin through `AdminApi.markUserMessageAsRead()`, which `POST`s to `/api/room/message/{messageId}/read`. The admin can then flag the message as read and stop returning it.

To make that possible, `SendUserMessage` / `BanUserMessage` / `AdminMessage` carry the admin-side identifier of the message:

- `SendUserMessage.id` / `BanUserMessage.id` (field 3), `AdminMessage.id` (field 5)
- new `UserMessageReadMessage { string id = 1; }` on `ClientToServerMessage` (field 51)

The id is empty for messages that are not stored per user — room-wide broadcasts, and bans that kick the user right away — and no receipt is sent in that case. It travels on the live moderation path too (admin dashboard WebSocket → pusher → back → client), so a warning read by an already-connected user is acknowledged as well.

## Backwards compatibility

`id` is optional in the admin API schema (`AdminLoginMessage`), and accepts a string or a number. An admin that does not provide one simply gets no read receipt and behaves exactly as before. `LocalAdmin` implements the new interface method as a no-op.

## Testing

- `npm run typecheck`, `npm run svelte-check` (0 errors), `npm run lint`, `npm run pretty-check` on `play`; `typecheck` + `lint` on `back`; `typecheck` on `libs/messages` and `map-storage`.
- Verified end to end against a WorkAdventure SaaS admin implementing the endpoint: a moderator sends a warning, the user reads it, and the message is neither redisplayed on reload nor on a fresh connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)