### PR TITLE
fix: stop GPU tilemap layers bleeding neighbouring tiles along tile edges

### DIFF
--- a/patches/phaser+4.2.0.patch
+++ b/patches/phaser+4.2.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/phaser/dist/phaser.esm.js b/node_modules/phaser/dist/phaser.esm.js
-index 07a961e..9e4cbf5 100644
+index 07a961e..d40f5b4 100644
 --- a/node_modules/phaser/dist/phaser.esm.js
 +++ b/node_modules/phaser/dist/phaser.esm.js
 @@ -208266,15 +208266,22 @@ module.exports = [
@@ -87,7 +87,29 @@ index 07a961e..9e4cbf5 100644
      '    if (flipX)',
      '    {',
      '        uv.x = 1.0 - uv.x;',
-@@ -208488,6 +208516,9 @@ module.exports = [
+@@ -208403,7 +208431,21 @@ module.exports = [
+     '    }',
+     '    #endif',
+     '    vec2 frameCorner = getFrameCorner(index);',
++    '    #ifdef FEATURE_BORDERFILTER',
+     '    return frameCorner + tile.uv;',
++    '    #else',
++    '    /* WA patch: keep the sample inside its own frame. uv is fract(), so it lives in [0,1), */',
++    '    /* but flipX, flipY and the rotation quadrant each mirror it into (0,1]. A fragment that */',
++    '    /* lands exactly on a tile boundary then gets uv == 1.0 and addresses the first texel of */',
++    '    /* the NEXT frame in the atlas: a one-pixel line of an unrelated tile along every tile */',
++    '    /* edge. Half a texel of inset is a no-op for every other fragment under NEAREST. The */',
++    '    /* BORDERFILTER (LINEAR) path needs the raw coordinate to measure that overshoot. */',
++    '    return clamp(',
++    '        frameCorner + tile.uv,',
++    '        frameCorner + 0.5,',
++    '        frameCorner + uTileWidthHeightMarginSpacing.xy - 0.5',
++    '    );',
++    '    #endif',
+     '}',
+     '#pragma phaserTemplate(fragmentHeader)',
+     'struct Samples {',
+@@ -208488,6 +208530,9 @@ module.exports = [
      '{',
      '    vec2 layerTexCoord = outTexCoord;',
      '    Tile tile = getLayerData(layerTexCoord);',
@@ -97,7 +119,7 @@ index 07a961e..9e4cbf5 100644
      '    Samples samples = getFinalSamples(tile, layerTexCoord);',
      '    vec4 fragColor = samples.color;',
      '    #pragma phaserTemplate(declareSamples)',
-@@ -208526,7 +208557,11 @@ module.exports = [
+@@ -208526,7 +208571,11 @@ module.exports = [
      '{',
      '    gl_Position = uProjectionMatrix * vec4(inPosition, 1.0, 1.0);',
      '    outTexCoord = inTexCoord;',
@@ -110,7 +132,7 @@ index 07a961e..9e4cbf5 100644
      '    #pragma phaserTemplate(vertexProcess)',
      '}',
  ].join('\n');
-@@ -243957,6 +243992,19 @@ var TilemapGPULayer = new Class({
+@@ -243957,6 +244006,19 @@ var TilemapGPULayer = new Class({
                  {
                      index |= 0x20000000;
                  }
@@ -130,7 +152,7 @@ index 07a961e..9e4cbf5 100644
                  if (tile.index === -1)
                  {
                      // Set the fourth bit to 1 to indicate an empty tile.
-@@ -246698,7 +246746,11 @@ var Tileset = new Class({
+@@ -246698,7 +246760,11 @@ var Tileset = new Class({
                  var animationDuration = tileDatum.animationDuration;
  
                  // This index maps to an animation, not a single tile.
@@ -144,7 +166,7 @@ index 07a961e..9e4cbf5 100644
                  // This animation points to a run of frames.
                  animations.push([ animationDuration, animFrames.length ]);
 diff --git a/node_modules/phaser/src/renderer/webgl/shaders/TilemapGPULayer-frag.js b/node_modules/phaser/src/renderer/webgl/shaders/TilemapGPULayer-frag.js
-index 8f3f66c..b2966b9 100644
+index 8f3f66c..6a770c6 100644
 --- a/node_modules/phaser/src/renderer/webgl/shaders/TilemapGPULayer-frag.js
 +++ b/node_modules/phaser/src/renderer/webgl/shaders/TilemapGPULayer-frag.js
 @@ -5,15 +5,22 @@ module.exports = [
@@ -232,7 +254,29 @@ index 8f3f66c..b2966b9 100644
      '    if (flipX)',
      '    {',
      '        uv.x = 1.0 - uv.x;',
-@@ -227,6 +255,9 @@ module.exports = [
+@@ -142,7 +170,21 @@ module.exports = [
+     '    }',
+     '    #endif',
+     '    vec2 frameCorner = getFrameCorner(index);',
++    '    #ifdef FEATURE_BORDERFILTER',
+     '    return frameCorner + tile.uv;',
++    '    #else',
++    '    /* WA patch: keep the sample inside its own frame. uv is fract(), so it lives in [0,1), */',
++    '    /* but flipX, flipY and the rotation quadrant each mirror it into (0,1]. A fragment that */',
++    '    /* lands exactly on a tile boundary then gets uv == 1.0 and addresses the first texel of */',
++    '    /* the NEXT frame in the atlas: a one-pixel line of an unrelated tile along every tile */',
++    '    /* edge. Half a texel of inset is a no-op for every other fragment under NEAREST. The */',
++    '    /* BORDERFILTER (LINEAR) path needs the raw coordinate to measure that overshoot. */',
++    '    return clamp(',
++    '        frameCorner + tile.uv,',
++    '        frameCorner + 0.5,',
++    '        frameCorner + uTileWidthHeightMarginSpacing.xy - 0.5',
++    '    );',
++    '    #endif',
+     '}',
+     '#pragma phaserTemplate(fragmentHeader)',
+     'struct Samples {',
+@@ -227,6 +269,9 @@ module.exports = [
      '{',
      '    vec2 layerTexCoord = outTexCoord;',
      '    Tile tile = getLayerData(layerTexCoord);',
@@ -260,7 +304,7 @@ index 83dc1e9..6ef0b12 100644
      '}',
  ].join('\n');
 diff --git a/node_modules/phaser/src/renderer/webgl/shaders/src/TilemapGPULayer.frag b/node_modules/phaser/src/renderer/webgl/shaders/src/TilemapGPULayer.frag
-index c5a0357..8581114 100644
+index c5a0357..9b9eaa5 100644
 --- a/node_modules/phaser/src/renderer/webgl/shaders/src/TilemapGPULayer.frag
 +++ b/node_modules/phaser/src/renderer/webgl/shaders/src/TilemapGPULayer.frag
 @@ -7,8 +7,10 @@
@@ -355,7 +399,35 @@ index c5a0357..8581114 100644
      if (flipX)
      {
          uv.x = 1.0 - uv.x;
-@@ -301,6 +332,10 @@ void main ()
+@@ -188,7 +219,27 @@ vec2 getTileTexelCoord (Tile tile)
+     #endif
+ 
+     vec2 frameCorner = getFrameCorner(index);
++
++    #ifdef FEATURE_BORDERFILTER
+     return frameCorner + tile.uv;
++    #else
++    // WA patch: keep the sample inside its own frame.
++    // `uv` is fract(), so it lives in [0, 1) - but flipY, flipX and the rotation quadrant each
++    // mirror it into (0, 1]. A fragment landing exactly on a tile boundary (fract() == 0, which
++    // happens for a whole row or column at once when the camera's sub-pixel offset lines the tile
++    // grid up with the fragment grid) then gets uv == 1.0, and `frameCorner + uv * tileSize`
++    // addresses the first texel of the NEXT frame in the atlas. Under NEAREST that paints a
++    // one-pixel line of an unrelated tile along every tile edge: horizontal for flipY and rot90,
++    // vertical for flipX and rot180, appearing and disappearing as the camera scrolls.
++    // Half a texel of inset is a no-op for every other fragment under NEAREST.
++    // The BORDERFILTER (LINEAR) path must keep the raw coordinate: it measures the overshoot
++    // itself in order to blend with the neighbouring tile.
++    return clamp(
++        frameCorner + tile.uv,
++        frameCorner + 0.5,
++        frameCorner + uTileWidthHeightMarginSpacing.xy - 0.5
++    );
++    #endif
+ }
+ 
+ #pragma phaserTemplate(fragmentHeader)
+@@ -301,6 +352,10 @@ void main ()
      vec2 layerTexCoord = outTexCoord;
      Tile tile = getLayerData(layerTexCoord);
  


### PR DESCRIPTION
Refs #6452.

Maps rendered with a `TilemapGPULayer` show a grid of one-pixel lines every 32px that appear and disappear as the woka moves — horizontal for some players, vertical for others. Only the GPU path is affected, so this arrived with the Phaser 4 migration.

### Cause

The tilemap fragment shader builds the in-tile sampling coordinate with `fract()`, so `uv` spans `[0, 1)` and the frame's far edge is never addressed. Our flip and rotation handling then mirrors it:

```glsl
if (rotQuad > 0.5) { /* rotate uv about the tile centre */ }
if (flipX) { uv.x = 1.0 - uv.x; }
if (flipY) { uv.y = 1.0 - uv.y; }
```

which turns that half-open range into a closed one. A fragment landing exactly on a tile boundary, where `fract()` is 0, then gets `uv == 1.0` on the mirrored axis, and `frameCorner + uv * tileSize` addresses the first texel of the **next frame in the tileset**. Under `NEAREST` — we run `antialias: false` — that is a whole row or column of an unrelated tile drawn along the tile edge.

Two things make it a grid rather than a stray pixel:

- a whole screen row shares one interpolated texture coordinate, so the bleed is a full-width line;
- the tile grid is regular, so when the camera's sub-pixel offset lines tile boundaries up with fragment centres, *every* boundary bleeds at once — and stops as soon as the phase changes, which is why walking makes them flicker.

Which axis is hit depends on how the tiles in view are flipped or rotated (`flipY`/`rot90` → horizontal, `flipX`/`rot180` → vertical), which is why the same map shows horizontal lines to one player and vertical lines to another. Unflipped, unrotated tiles are unaffected: `uv` never reaches the far edge.

### Fix

Inset the sample by half a texel, which is what the shader's `FEATURE_BORDERFILTER` branch already does for `LINEAR` filtering. Under `NEAREST` this cannot move a sample out of the texel it already lands in, so it is a no-op for every fragment except the out-of-frame one. The `BORDERFILTER` path deliberately keeps the raw coordinate: it measures the overshoot itself in order to blend with the neighbouring tile.

```glsl
#ifdef FEATURE_BORDERFILTER
return frameCorner + tile.uv;
#else
return clamp(frameCorner + tile.uv,
             frameCorner + 0.5,
             frameCorner + uTileWidthHeightMarginSpacing.xy - 0.5);
#endif
```

### Verification

A harness compiles the patched shader and renders a synthetic layer through a quad offset half a pixel, so boundaries land on fragment centres:

| tile | stock | patched |
|---|---|---|
| no flip | clean | clean |
| `flipY` | bleeding rows 0, 32, 64, … | clean |
| `flipX` | bleeding columns 0, 32, 64, … | clean |
| `rot90` | bleeding rows | clean |
| `rot180` | bleeding columns | clean |
| `FEATURE_BORDERFILTER` | clean | clean (path untouched) |

Through the engine, a GPU layer of one flipped tile swept over 512 sub-pixel camera offsets bleeds on every tile boundary before the change and none after.

### Notes

- Submitted upstream as https://github.com/phaserjs/phaser/pull/7360 (with an example at https://github.com/phaserjs/examples/pull/411). Drop this hunk from `patches/phaser+4.2.0.patch` once it lands.
- I could not reproduce the artefact on my own machine — whether a fragment lands *exactly* on a boundary depends on how the driver interpolates the varying — so the fix is verified at the shader level rather than by eye on a real map. Worth confirming on a real map, ideally by the reporter of #6452, before merging.
