### PR TITLE
fix(chat): stop forking a duplicate direct room when messaging a user you already chat with

### DIFF
--- a/play/src/front/Chat/Components/UserList/User.svelte
+++ b/play/src/front/Chat/Components/UserList/User.svelte
@@ -25,8 +25,6 @@
 
     let { user, isMatrixChatEnabled = true }: Props = $props();
 
-    let showRoomCreationInProgress = false;
-
     let { chatId, availabilityStatus, username = "", color, isAdmin, pictureStore } = $derived(user);
 
     /** Tint: local name, Matrix `account_data`, or peer cache — deps keep the row in sync. */
@@ -54,8 +52,6 @@
             query: $chatSearchBarValue,
         }),
     );
-
-    const roomCreationInProgress = gameManager.chatConnection.roomCreationInProgress;
 
     function getNameOfAvailabilityStatus(status: AvailabilityStatus) {
         switch (status) {
@@ -188,7 +184,7 @@
                         <UserActionButton {user} />
                     {/if}
                 </div>
-                {#if !isMe && !showRoomCreationInProgress && isMatrixChatEnabled}
+                {#if !isMe && isMatrixChatEnabled}
                     <!-- svelte-ignore a11y_no_static_element_interactions -->
                     <div
                         class="relative"
@@ -233,10 +229,6 @@
                                 {/if}
                             </div>
                         {/if}
-                    </div>
-                {:else if $roomCreationInProgress && showRoomCreationInProgress}
-                    <div class="min-h-[30px] text-md flex gap-2 justify-center flex-row items-center p-1">
-                        <IconLoader class="animate-spin" />
                     </div>
                 {/if}
             </div>

--- a/play/src/front/Chat/Connection/ChatConnection.ts
+++ b/play/src/front/Chat/Connection/ChatConnection.ts
@@ -519,7 +519,7 @@ export interface ChatConnectionInterface {
     createFolder: (roomOptions: CreateRoomOptions) => Promise<{ room_id: string }>;
     createDirectRoom(userChatId: string): Promise<(ChatRoom & ChatRoomMembershipManagement) | undefined>;
     roomCreationInProgress: Readable<boolean>;
-    getDirectRoomFor(userChatId: string): (ChatRoom & ChatRoomMembershipManagement) | undefined;
+    getDirectRoomFor(userChatId: string): Promise<(ChatRoom & ChatRoomMembershipManagement) | undefined>;
     searchAccessibleRooms(searchText: string): Promise<
         {
             id: string;

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -1863,7 +1863,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             return Promise.reject(new Error(CLIENT_NOT_INITIALIZED_ERROR_MSG));
         }
 
-        const existingDirectRoom = this.getDirectRoomFor(userToInvite);
+        const existingDirectRoom = await this.getDirectRoomFor(userToInvite);
 
         if (existingDirectRoom) return existingDirectRoom;
 
@@ -1900,24 +1900,33 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         }
     }
 
-    getDirectRoomFor(userID: string): (ChatRoom & ChatRoomMembershipManagement) | undefined {
-        const directRooms = Array.from(this.roomList.values()).filter((room) => {
-            if (get(room.type) !== "direct") return false;
-            // Read the SDK room, not room.members: that Svelte store stays empty until a
-            // participants panel triggers ensureMembersInitialized() (lazy loading, #6049).
-            const memberIDs = room
-                .getMatrixRoom()
-                .getMembers()
-                .filter(
-                    (member) =>
-                        member.membership === KnownMembership.Join || member.membership === KnownMembership.Invite,
-                )
-                .map((member) => member.userId);
-            return memberIDs.length === 2 && memberIDs.includes(userID);
+    async getDirectRoomFor(userID: string): Promise<(ChatRoom & ChatRoomMembershipManagement) | undefined> {
+        if (!this.client) return undefined;
+
+        const isActiveMembership = (membership: string | undefined) =>
+            membership === KnownMembership.Join || membership === KnownMembership.Invite;
+
+        // Look the DM up in the SDK client, not in roomList: roomList is filled asynchronously
+        // (one room per animation frame) and rooms transiently leave it during placement
+        // reconciliation, so it can miss a DM the client already knows about — every miss here
+        // forks a duplicate room. Same heuristic as Element's findDMForUser: a DM is a room of
+        // exactly two active people containing those two people.
+        const suitableRooms = this.client.getRooms().filter((room) => {
+            if (room.isSpaceRoom() || !isActiveMembership(room.getMyMembership())) return false;
+            const activeMembers = room.getMembers().filter((member) => isActiveMembership(member.membership));
+            return activeMembers.length === 2 && activeMembers.some((member) => member.userId === userID);
         });
+
         // Duplicate DMs already exist for some users: pick the most recently active one
-        // (the sidebar sort criterion) instead of Map insertion order.
-        return directRooms.sort((roomA, roomB) => roomB.lastMessageTimestamp - roomA.lastMessageTimestamp)[0];
+        // (the sidebar sort criterion) instead of an arbitrary insertion order.
+        const bestRoom = suitableRooms.sort(
+            (roomA, roomB) => roomB.getLastActiveTimestamp() - roomA.getLastActiveTimestamp(),
+        )[0];
+        if (!bestRoom) return undefined;
+
+        const existingWrapper = await this.findRoomOrFolder(bestRoom.roomId);
+        if (existingWrapper instanceof MatrixChatRoom) return existingWrapper;
+        return this.createAndAddNewRootRoom(bestRoom);
     }
 
     async searchChatUsers(searchText: string, limit = 20) {

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -140,6 +140,10 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     isGuest: Writable<boolean> = writable(false);
     hasUnreadMessages: Readable<boolean>;
     roomCreationInProgress: Writable<boolean> = writable(false);
+    private pendingDirectRoomCreation = new Map<
+        string,
+        Promise<(ChatRoom & ChatRoomMembershipManagement) | undefined>
+    >();
     roomFolders: MapStore<MatrixRoomFolder["id"], MatrixRoomFolder> = new MapStore<
         MatrixRoomFolder["id"],
         MatrixRoomFolder
@@ -1840,6 +1844,21 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     }
 
     async createDirectRoom(userToInvite: string): Promise<(ChatRoom & ChatRoomMembershipManagement) | undefined> {
+        // Deduplicate concurrent calls (e.g. a double click on the "send message" button):
+        // both callers must resolve to the same room instead of racing two createRoom requests.
+        const pendingCreation = this.pendingDirectRoomCreation.get(userToInvite);
+        if (pendingCreation) return pendingCreation;
+
+        const creation = this.doCreateDirectRoom(userToInvite).finally(() => {
+            this.pendingDirectRoomCreation.delete(userToInvite);
+        });
+        this.pendingDirectRoomCreation.set(userToInvite, creation);
+        return creation;
+    }
+
+    private async doCreateDirectRoom(
+        userToInvite: string,
+    ): Promise<(ChatRoom & ChatRoomMembershipManagement) | undefined> {
         if (!this.client) {
             return Promise.reject(new Error(CLIENT_NOT_INITIALIZED_ERROR_MSG));
         }
@@ -1882,19 +1901,23 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     }
 
     getDirectRoomFor(userID: string): (ChatRoom & ChatRoomMembershipManagement) | undefined {
-        const directRooms = Array.from(this.roomList.values())
-            .filter((room) => {
-                const memberIDs = get(room.members)
-                    .filter((member) => member.id && ["join", "invite"].includes(get(member.membership)))
-                    .map((member) => member.id);
-                return (
-                    get(room.type) === "direct" &&
-                    memberIDs.some((memberId) => memberId === userID && memberIDs.length === 2)
-                );
-            })
-            .map((room) => room);
-        if (directRooms.length > 0) return directRooms[0];
-        return undefined;
+        const directRooms = Array.from(this.roomList.values()).filter((room) => {
+            if (get(room.type) !== "direct") return false;
+            // Read the SDK room, not room.members: that Svelte store stays empty until a
+            // participants panel triggers ensureMembersInitialized() (lazy loading, #6049).
+            const memberIDs = room
+                .getMatrixRoom()
+                .getMembers()
+                .filter(
+                    (member) =>
+                        member.membership === KnownMembership.Join || member.membership === KnownMembership.Invite,
+                )
+                .map((member) => member.userId);
+            return memberIDs.length === 2 && memberIDs.includes(userID);
+        });
+        // Duplicate DMs already exist for some users: pick the most recently active one
+        // (the sidebar sort criterion) instead of Map insertion order.
+        return directRooms.sort((roomA, roomB) => roomB.lastMessageTimestamp - roomA.lastMessageTimestamp)[0];
     }
 
     async searchChatUsers(searchText: string, limit = 20) {
@@ -2037,7 +2060,9 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             throw new Error(CLIENT_NOT_INITIALIZED_ERROR_MSG);
         }
         const directMap: Record<string, string[]> = this.client.getAccountData(EventType.Direct)?.getContent() || {};
-        directMap[userId] = [...(directMap[userId] || []), roomId];
+        const roomsForUser = directMap[userId] ?? [];
+        if (roomsForUser.includes(roomId)) return;
+        directMap[userId] = [...roomsForUser, roomId];
         await this.client.setAccountData(EventType.Direct, directMap);
     }
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -1315,12 +1315,16 @@ export class MatrixChatRoom
     }
 
     private onRoomNewMember(event: MatrixEvent, state: RoomState, member: RoomMember) {
-        const newWrapper = new MatrixChatRoomMember(member, this.matrixRoom.client.baseUrl, this.matrixRoom.client);
-        const merger = get(this.userProviderMergerStore);
-        if (merger) {
-            newWrapper.setUserProviderMergerContext(merger);
+        // A re-emitted membership event for an already-known member must not append a
+        // duplicate wrapper: stores deriving from this list count members.
+        if (!get(this.members).some((existingMember) => existingMember.id === member.userId)) {
+            const newWrapper = new MatrixChatRoomMember(member, this.matrixRoom.client.baseUrl, this.matrixRoom.client);
+            const merger = get(this.userProviderMergerStore);
+            if (merger) {
+                newWrapper.setUserProviderMergerContext(merger);
+            }
+            this.members.update((members) => [...members, newWrapper]);
         }
-        this.members.update((members) => [...members, newWrapper]);
         this.refreshRoomType();
         this.refreshJoinedMemberCount();
     }

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -619,6 +619,133 @@ describe("MatrixChatConnection", () => {
             //eslint-disable-next-line @typescript-eslint/unbound-method
             expect(mockMatrixClient.getRoom).toHaveBeenCalledOnce();
         });
+        it("should deduplicate concurrent creations for the same user", async () => {
+            const mockMatrixClient = {
+                isGuest: vi.fn(),
+                off: vi.fn(),
+                on: vi.fn().mockImplementation((_, funcToResolve) => {
+                    funcToResolve(SyncState.Syncing);
+                }),
+                once: vi.fn().mockImplementation((_, funcToResolve) => {
+                    funcToResolve(SyncState.Syncing);
+                }),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                createRoom: vi.fn().mockResolvedValue({ room_id: "1" }),
+                getRoom: vi.fn(),
+            } as unknown as MatrixClient;
+
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+
+            const spyGetDirectRoomFor = vi.spyOn(matrixChatConnection, "getDirectRoomFor");
+            spyGetDirectRoomFor.mockImplementation(() => undefined);
+            matrixChatConnection["addDMRoomInAccountData"] = vi.fn();
+
+            // A double click issues two concurrent calls: only one room must be created.
+            await Promise.all([
+                matrixChatConnection.createDirectRoom("AliceID"),
+                matrixChatConnection.createDirectRoom("AliceID"),
+            ]);
+            expect(mockMatrixClient.createRoom).toHaveBeenCalledOnce();
+
+            // Once settled, a later call goes through the whole flow again.
+            await matrixChatConnection.createDirectRoom("AliceID");
+            expect(mockMatrixClient.createRoom).toHaveBeenCalledTimes(2);
+        });
+    });
+    describe("getDirectRoomFor", () => {
+        const createDirectRoomStub = (
+            id: string,
+            memberships: [string, string][],
+            { type = "direct", lastMessageTimestamp = 0 }: { type?: string; lastMessageTimestamp?: number } = {},
+        ) =>
+            ({
+                id,
+                type: readable(type),
+                // Regression guard: the lookup must not rely on this lazily-initialized store,
+                // it stays empty until a participants panel calls ensureMembersInitialized().
+                members: writable([]),
+                lastMessageTimestamp,
+                getMatrixRoom: () => ({
+                    getMembers: () => memberships.map(([userId, membership]) => ({ userId, membership })),
+                }),
+            }) as unknown as MatrixChatRoom;
+
+        const getConnectionWithRooms = async (rooms: MatrixChatRoom[]) => {
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve({} as unknown as MatrixClient));
+            rooms.forEach((room) => matrixChatConnection["roomList"].set(room.id, room));
+            return matrixChatConnection;
+        };
+
+        it("should find a direct room even when its members store was never initialized", async () => {
+            const directRoom = createDirectRoomStub("dm", [
+                ["@me:matrix.org", KnownMembership.Join],
+                ["@alice:matrix.org", KnownMembership.Join],
+            ]);
+            const connection = await getConnectionWithRooms([directRoom]);
+
+            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBe(directRoom);
+        });
+
+        it("should find a direct room where the other user is still invited", async () => {
+            const directRoom = createDirectRoomStub("dm", [
+                ["@me:matrix.org", KnownMembership.Join],
+                ["@alice:matrix.org", KnownMembership.Invite],
+            ]);
+            const connection = await getConnectionWithRooms([directRoom]);
+
+            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBe(directRoom);
+        });
+
+        it("should ignore rooms that are not typed direct", async () => {
+            const multipleRoom = createDirectRoomStub(
+                "notADm",
+                [
+                    ["@me:matrix.org", KnownMembership.Join],
+                    ["@alice:matrix.org", KnownMembership.Join],
+                ],
+                { type: "multiple" },
+            );
+            const connection = await getConnectionWithRooms([multipleRoom]);
+
+            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+        });
+
+        it("should ignore rooms with more than two active members", async () => {
+            const crowdedRoom = createDirectRoomStub("crowded", [
+                ["@me:matrix.org", KnownMembership.Join],
+                ["@alice:matrix.org", KnownMembership.Join],
+                ["@bob:matrix.org", KnownMembership.Join],
+            ]);
+            const connection = await getConnectionWithRooms([crowdedRoom]);
+
+            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+        });
+
+        it("should ignore rooms the other user has left", async () => {
+            const abandonedRoom = createDirectRoomStub("abandoned", [
+                ["@me:matrix.org", KnownMembership.Join],
+                ["@alice:matrix.org", KnownMembership.Leave],
+            ]);
+            const connection = await getConnectionWithRooms([abandonedRoom]);
+
+            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+        });
+
+        it("should pick the most recently active room when duplicates exist", async () => {
+            const memberships: [string, string][] = [
+                ["@me:matrix.org", KnownMembership.Join],
+                ["@alice:matrix.org", KnownMembership.Join],
+            ];
+            const staleRoom = createDirectRoomStub("stale", memberships, { lastMessageTimestamp: 100 });
+            const activeRoom = createDirectRoomStub("active", memberships, { lastMessageTimestamp: 200 });
+            const connection = await getConnectionWithRooms([staleRoom, activeRoom]);
+
+            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBe(activeRoom);
+        });
     });
     describe("searchAccessibleRooms", () => {
         it("should search all public rooms with searchText in the options", async () => {
@@ -962,6 +1089,38 @@ describe("MatrixChatConnection", () => {
             expect(mockSetAccountData.mock.calls[0][0]).toBe("m.direct");
             expect(mockSetAccountData.mock.calls[0][1][userId]).toContain(roomId);
             expect(mockSetAccountData.mock.calls[0][1][userId]).toContain(roomId2);
+        });
+        it("should not rewrite account data when the room is already recorded for this user", async () => {
+            const userId = "AliceId";
+            const roomId = "roomTest";
+
+            const mockGetContent = vi.fn().mockReturnValue({ [userId]: [roomId] });
+            const mockSetAccountData = vi.fn();
+            const mockMatrixClient = {
+                isGuest: vi.fn(),
+                on: vi.fn(),
+                once: vi.fn().mockImplementation((_, funcToResolve) => {
+                    funcToResolve(SyncState.Syncing);
+                }),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                createRoom: vi.fn(),
+                getRoom: vi.fn().mockReturnValue(null),
+                joinRoom: vi.fn().mockResolvedValue(""),
+                getAccountData: vi.fn().mockReturnValue({
+                    getContent: mockGetContent,
+                }),
+                setAccountData: mockSetAccountData,
+            } as unknown as MatrixClient;
+
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+
+            await matrixChatConnection["addDMRoomInAccountData"](userId, roomId);
+
+            expect(mockSetAccountData).not.toHaveBeenCalled();
         });
     });
 

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -1,4 +1,4 @@
-import type { MatrixClient } from "matrix-js-sdk";
+import type { MatrixClient, Room } from "matrix-js-sdk";
 import { ClientEvent, EventType, PendingEventOrdering, RoomEvent, SyncState } from "matrix-js-sdk";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { KnownMembership } from "matrix-js-sdk/lib/types";
@@ -564,7 +564,7 @@ describe("MatrixChatConnection", () => {
 
             const spyGetDirectRoomFor = vi.spyOn(matrixChatConnection, "getDirectRoomFor");
 
-            spyGetDirectRoomFor.mockImplementation(() => oldDirectRoom);
+            spyGetDirectRoomFor.mockResolvedValue(oldDirectRoom);
             matrixChatConnection["addDMRoomInAccountData"] = vi.fn();
 
             expect(await matrixChatConnection.createDirectRoom(userId)).toEqual(oldDirectRoom);
@@ -604,7 +604,7 @@ describe("MatrixChatConnection", () => {
             const userId = "AliceID";
 
             const spyGetDirectRoomFor = vi.spyOn(matrixChatConnection, "getDirectRoomFor");
-            spyGetDirectRoomFor.mockImplementation(() => undefined);
+            spyGetDirectRoomFor.mockResolvedValue(undefined);
 
             matrixChatConnection["createRoom"] = vi.fn().mockResolvedValue({
                 room_id: "newRoomId",
@@ -641,7 +641,7 @@ describe("MatrixChatConnection", () => {
             const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
 
             const spyGetDirectRoomFor = vi.spyOn(matrixChatConnection, "getDirectRoomFor");
-            spyGetDirectRoomFor.mockImplementation(() => undefined);
+            spyGetDirectRoomFor.mockResolvedValue(undefined);
             matrixChatConnection["addDMRoomInAccountData"] = vi.fn();
 
             // A double click issues two concurrent calls: only one room must be created.
@@ -649,102 +649,147 @@ describe("MatrixChatConnection", () => {
                 matrixChatConnection.createDirectRoom("AliceID"),
                 matrixChatConnection.createDirectRoom("AliceID"),
             ]);
+            //eslint-disable-next-line @typescript-eslint/unbound-method
             expect(mockMatrixClient.createRoom).toHaveBeenCalledOnce();
 
             // Once settled, a later call goes through the whole flow again.
             await matrixChatConnection.createDirectRoom("AliceID");
+            //eslint-disable-next-line @typescript-eslint/unbound-method
             expect(mockMatrixClient.createRoom).toHaveBeenCalledTimes(2);
         });
     });
     describe("getDirectRoomFor", () => {
-        const createDirectRoomStub = (
-            id: string,
+        const createSdkRoomStub = (
+            roomId: string,
             memberships: [string, string][],
-            { type = "direct", lastMessageTimestamp = 0 }: { type?: string; lastMessageTimestamp?: number } = {},
+            {
+                myMembership = KnownMembership.Join,
+                lastActiveTimestamp = 0,
+                isSpace = false,
+            }: { myMembership?: string; lastActiveTimestamp?: number; isSpace?: boolean } = {},
         ) =>
             ({
-                id,
-                type: readable(type),
-                // Regression guard: the lookup must not rely on this lazily-initialized store,
-                // it stays empty until a participants panel calls ensureMembersInitialized().
-                members: writable([]),
-                lastMessageTimestamp,
-                getMatrixRoom: () => ({
-                    getMembers: () => memberships.map(([userId, membership]) => ({ userId, membership })),
-                }),
-            }) as unknown as MatrixChatRoom;
+                roomId,
+                isSpaceRoom: () => isSpace,
+                getMyMembership: () => myMembership,
+                getMembers: () => memberships.map(([userId, membership]) => ({ userId, membership })),
+                getLastActiveTimestamp: () => lastActiveTimestamp,
+            }) as unknown as Room;
 
-        const getConnectionWithRooms = async (rooms: MatrixChatRoom[]) => {
-            const matrixChatConnection = await getMatrixConnection(Promise.resolve({} as unknown as MatrixClient));
-            rooms.forEach((room) => matrixChatConnection["roomList"].set(room.id, room));
-            return matrixChatConnection;
+        // The lookup must read the SDK client directly: roomList is filled asynchronously
+        // and can miss a DM the client already knows about (cold start, reconciliation).
+        const getConnectionWithSdkRooms = async (sdkRooms: Room[]) => {
+            const mockMatrixClient = {
+                getRooms: () => sdkRooms,
+            } as unknown as MatrixClient;
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+            const createAndAddNewRootRoom = vi.fn(
+                (room: Room) => ({ id: room.roomId, createdFrom: room }) as unknown as MatrixChatRoom,
+            );
+            matrixChatConnection["createAndAddNewRootRoom"] = createAndAddNewRootRoom;
+            return { matrixChatConnection, createAndAddNewRootRoom };
         };
 
-        it("should find a direct room even when its members store was never initialized", async () => {
-            const directRoom = createDirectRoomStub("dm", [
-                ["@me:matrix.org", KnownMembership.Join],
-                ["@alice:matrix.org", KnownMembership.Join],
-            ]);
-            const connection = await getConnectionWithRooms([directRoom]);
+        const directMemberships: [string, string][] = [
+            ["@me:matrix.org", KnownMembership.Join],
+            ["@alice:matrix.org", KnownMembership.Join],
+        ];
 
-            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBe(directRoom);
+        it("should find an existing direct room from the SDK client even when roomList is empty", async () => {
+            const directRoom = createSdkRoomStub("dm", directMemberships);
+            const { matrixChatConnection, createAndAddNewRootRoom } = await getConnectionWithSdkRooms([directRoom]);
+
+            const foundRoom = await matrixChatConnection.getDirectRoomFor("@alice:matrix.org");
+
+            expect(createAndAddNewRootRoom).toHaveBeenCalledWith(directRoom);
+            expect(foundRoom?.id).toBe("dm");
+        });
+
+        it("should return the already-registered wrapper instead of creating a new one", async () => {
+            const directRoom = createSdkRoomStub("dm", directMemberships);
+            const { matrixChatConnection, createAndAddNewRootRoom } = await getConnectionWithSdkRooms([directRoom]);
+            const existingWrapper = Object.create(MatrixChatRoomClass.prototype) as MatrixChatRoom;
+            matrixChatConnection["roomList"].set("dm", existingWrapper);
+
+            const foundRoom = await matrixChatConnection.getDirectRoomFor("@alice:matrix.org");
+
+            expect(foundRoom).toBe(existingWrapper);
+            expect(createAndAddNewRootRoom).not.toHaveBeenCalled();
         });
 
         it("should find a direct room where the other user is still invited", async () => {
-            const directRoom = createDirectRoomStub("dm", [
+            const directRoom = createSdkRoomStub("dm", [
                 ["@me:matrix.org", KnownMembership.Join],
                 ["@alice:matrix.org", KnownMembership.Invite],
             ]);
-            const connection = await getConnectionWithRooms([directRoom]);
+            const { matrixChatConnection } = await getConnectionWithSdkRooms([directRoom]);
 
-            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBe(directRoom);
+            expect(await matrixChatConnection.getDirectRoomFor("@alice:matrix.org")).toBeDefined();
         });
 
-        it("should ignore rooms that are not typed direct", async () => {
-            const multipleRoom = createDirectRoomStub(
-                "notADm",
+        it("should find a direct room I am still invited to", async () => {
+            const directRoom = createSdkRoomStub(
+                "dm",
                 [
-                    ["@me:matrix.org", KnownMembership.Join],
+                    ["@me:matrix.org", KnownMembership.Invite],
                     ["@alice:matrix.org", KnownMembership.Join],
                 ],
-                { type: "multiple" },
+                { myMembership: KnownMembership.Invite },
             );
-            const connection = await getConnectionWithRooms([multipleRoom]);
+            const { matrixChatConnection } = await getConnectionWithSdkRooms([directRoom]);
 
-            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+            expect(await matrixChatConnection.getDirectRoomFor("@alice:matrix.org")).toBeDefined();
         });
 
         it("should ignore rooms with more than two active members", async () => {
-            const crowdedRoom = createDirectRoomStub("crowded", [
+            const crowdedRoom = createSdkRoomStub("crowded", [
                 ["@me:matrix.org", KnownMembership.Join],
                 ["@alice:matrix.org", KnownMembership.Join],
                 ["@bob:matrix.org", KnownMembership.Join],
             ]);
-            const connection = await getConnectionWithRooms([crowdedRoom]);
+            const { matrixChatConnection } = await getConnectionWithSdkRooms([crowdedRoom]);
 
-            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+            expect(await matrixChatConnection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
         });
 
         it("should ignore rooms the other user has left", async () => {
-            const abandonedRoom = createDirectRoomStub("abandoned", [
+            const abandonedRoom = createSdkRoomStub("abandoned", [
                 ["@me:matrix.org", KnownMembership.Join],
                 ["@alice:matrix.org", KnownMembership.Leave],
             ]);
-            const connection = await getConnectionWithRooms([abandonedRoom]);
+            const { matrixChatConnection } = await getConnectionWithSdkRooms([abandonedRoom]);
 
-            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+            expect(await matrixChatConnection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+        });
+
+        it("should ignore rooms I have left", async () => {
+            const leftRoom = createSdkRoomStub("left", directMemberships, {
+                myMembership: KnownMembership.Leave,
+            });
+            const { matrixChatConnection } = await getConnectionWithSdkRooms([leftRoom]);
+
+            expect(await matrixChatConnection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+        });
+
+        it("should ignore space rooms", async () => {
+            const spaceRoom = createSdkRoomStub("space", directMemberships, { isSpace: true });
+            const { matrixChatConnection } = await getConnectionWithSdkRooms([spaceRoom]);
+
+            expect(await matrixChatConnection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
         });
 
         it("should pick the most recently active room when duplicates exist", async () => {
-            const memberships: [string, string][] = [
-                ["@me:matrix.org", KnownMembership.Join],
-                ["@alice:matrix.org", KnownMembership.Join],
-            ];
-            const staleRoom = createDirectRoomStub("stale", memberships, { lastMessageTimestamp: 100 });
-            const activeRoom = createDirectRoomStub("active", memberships, { lastMessageTimestamp: 200 });
-            const connection = await getConnectionWithRooms([staleRoom, activeRoom]);
+            const staleRoom = createSdkRoomStub("stale", directMemberships, { lastActiveTimestamp: 100 });
+            const activeRoom = createSdkRoomStub("active", directMemberships, { lastActiveTimestamp: 200 });
+            const { matrixChatConnection, createAndAddNewRootRoom } = await getConnectionWithSdkRooms([
+                staleRoom,
+                activeRoom,
+            ]);
 
-            expect(connection.getDirectRoomFor("@alice:matrix.org")).toBe(activeRoom);
+            const foundRoom = await matrixChatConnection.getDirectRoomFor("@alice:matrix.org");
+
+            expect(createAndAddNewRootRoom).toHaveBeenCalledWith(activeRoom);
+            expect(foundRoom?.id).toBe("active");
         });
     });
     describe("searchAccessibleRooms", () => {

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatRoom.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatRoom.test.ts
@@ -1,0 +1,94 @@
+import type { MatrixEvent, RoomMember, RoomState } from "matrix-js-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { get, readable, writable } from "svelte/store";
+import { MatrixChatRoom } from "../MatrixChatRoom";
+
+vi.mock("../../../../Phaser/Game/GameManager", () => {
+    return {
+        gameManager: {
+            getCurrentGameScene: () => ({}),
+        },
+    };
+});
+
+// Importing the real MatrixChatRoom (unlike MatrixChatConnection.test.ts, which mocks it)
+// drags GameScene in, whose module graph cannot initialize in a unit test.
+vi.mock("../../../../Phaser/Game/GameScene", () => {
+    return {
+        GameScene: class {},
+    };
+});
+
+vi.mock("../../../../Phaser/Entity/CharacterLayerManager", () => {
+    return {
+        CharacterLayerManager: {
+            wokaBase64(): Promise<string> {
+                return Promise.resolve("");
+            },
+        },
+    };
+});
+
+vi.mock(
+    "../../../../Enum/EnvironmentVariable.ts",
+    () => import("../../../../../../tests/front/mocks/frontEnvironmentVariableMock"),
+);
+
+vi.mock("../../../Stores/ChatStore.ts", () => {
+    return {
+        selectedRoomStore: writable(undefined),
+    };
+});
+
+describe("MatrixChatRoom", () => {
+    describe("onRoomNewMember", () => {
+        const createMemberStub = (userId: string) =>
+            ({
+                userId,
+                name: userId,
+                membership: "join",
+                powerLevel: 0,
+                on: vi.fn(),
+                off: vi.fn(),
+            }) as unknown as RoomMember;
+
+        // Building a full MatrixChatRoom needs a heavy Room mock: create a bare instance
+        // with only the state onRoomNewMember touches.
+        const createRoomStub = () => {
+            const room = Object.create(MatrixChatRoom.prototype) as MatrixChatRoom;
+            Object.assign(room, {
+                members: writable([]),
+                userProviderMergerStore: readable(undefined),
+                matrixRoom: {
+                    client: {
+                        baseUrl: "https://matrix.example.com",
+                        getUser: () => null,
+                        getUserId: () => "@me:matrix.org",
+                    },
+                },
+            });
+            room["refreshRoomType"] = vi.fn();
+            room["refreshJoinedMemberCount"] = vi.fn();
+            return room;
+        };
+
+        it("should not append a duplicate wrapper when a membership event for a known member is re-emitted", () => {
+            const room = createRoomStub();
+            const member = createMemberStub("@alice:matrix.org");
+
+            room["onRoomNewMember"]({} as MatrixEvent, {} as RoomState, member);
+            room["onRoomNewMember"]({} as MatrixEvent, {} as RoomState, member);
+
+            expect(get(room.members)).toHaveLength(1);
+        });
+
+        it("should append distinct members", () => {
+            const room = createRoomStub();
+
+            room["onRoomNewMember"]({} as MatrixEvent, {} as RoomState, createMemberStub("@alice:matrix.org"));
+            room["onRoomNewMember"]({} as MatrixEvent, {} as RoomState, createMemberStub("@bob:matrix.org"));
+
+            expect(get(room.members)).toHaveLength(2);
+        });
+    });
+});

--- a/play/src/front/Chat/Connection/VoidChatConnection.ts
+++ b/play/src/front/Chat/Connection/VoidChatConnection.ts
@@ -46,8 +46,8 @@ export class VoidChatConnection implements ChatConnectionInterface {
         throw new Error("VoidChatConnection: createDirectRoom is not implemented.");
     }
 
-    getDirectRoomFor(userChatId: string): (ChatRoom & ChatRoomMembershipManagement) | undefined {
-        return undefined;
+    getDirectRoomFor(userChatId: string): Promise<(ChatRoom & ChatRoomMembershipManagement) | undefined> {
+        return Promise.resolve(undefined);
     }
 
     searchAccessibleRooms(searchText: string): Promise<{ id: string; name: string | undefined }[]> {

--- a/play/src/front/Chat/Utils.ts
+++ b/play/src/front/Chat/Utils.ts
@@ -78,7 +78,7 @@ export const openDirectChatRoom = async (chatID: string) => {
             return;
         }
         const chatConnection = await gameManager.getChatConnection();
-        let room = chatConnection.getDirectRoomFor(chatID);
+        let room = await chatConnection.getDirectRoomFor(chatID);
         if (!room) room = await chatConnection.createDirectRoom(chatID);
         if (!room) throw new Error("Failed to create room");
         analyticsClient.createMatrixRoom();


### PR DESCRIPTION
## The bug

Clicking "send message" on a person you already have a DM with (chat user list, visit card or woka menu) sometimes created a **new** empty conversation next to the existing one — which stayed visible in the sidebar the whole time.

## Root causes (two eras)

**Since #6049 (lazy member loading, April):** `MatrixChatRoom.members` starts empty and is only populated when a participants panel calls `ensureMembersInitialized()`. `getDirectRoomFor()` filtered on that store, so it almost never found the existing DM and `createDirectRoom()` forked a new room. The sidebar kept showing the old conversation because `roomTypeStore`/`directRooms` read the SDK room directly.

**Before that:** `roomList` is filled asynchronously (one room per animation frame since #6061), rooms transiently leave it during placement reconciliation (#6038), and the chat connection promise resolves even when the initial sync timed out — any click landing in one of those windows missed the DM too. The anti-duplicate loader added for this exact ticket in #4094 was removed in #4767, leaving no guard at all.

## The fix

- `getDirectRoomFor()` now searches `client.getRooms()` directly — complete as soon as the initial sync lands, immune to the roomList timing and to the lazy members store. Same heuristic as Element's `findDMForUser`: exactly two join/invite members including the target, space rooms excluded, most recently active first (so users who already have duplicates land on the conversation with the history, not the empty fork). The registered `MatrixChatRoom` wrapper is reused when present, otherwise registered through the existing `createAndAddNewRootRoom` idiom (same as `joinRoom`).
- `createDirectRoom()` deduplicates concurrent calls per user (double click), covering all entry points with one guard.
- `addDMRoomInAccountData()` no longer appends a room already recorded in `m.direct`.
- `onRoomNewMember` no longer appends a duplicate wrapper when a membership event is re-emitted for a known member.
- Removed the dead `showRoomCreationInProgress` flag from `User.svelte` (never set since #4767, its spinner branch was unreachable).

## Tests

The real `getDirectRoomFor()` is now unit-tested (it was previously always mocked): cold-start lookup with an empty roomList, wrapper reuse, invite-state rooms on both sides, peer-left/3-member/space rejection, most-recent pick among duplicates, in-flight dedup, `m.direct` idempotence, `onRoomNewMember` idempotence. The lookup regression tests fail on master and pass on this branch.

Left out of scope (documented while diagnosing): re-inviting into a DM the peer left, multi-tab coordination, the `currentState` listener captured by `MatrixChatRoom` going dead after a gappy sync, and the early-return-after-detach in `onRoomEventMembership` during initial sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)