### PR TITLE
fix(front): stop pathfinding moves from walking map editors into locked areas

### DIFF
--- a/play/src/front/Phaser/Game/GameMap/AreasManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/AreasManager.ts
@@ -150,11 +150,14 @@ export class AreasManager {
 
     /**
      * Returns the list of all areas that should collide for the current player.
+     *
+     * Note: this must stay aligned with the physical collider applied on each Area (see Area.applyCollider), which
+     * is based on shouldAreaCollide() too. Otherwise, a pathfinding move (right click, "walk to" / "talk to", the
+     * scripting API...) would compute a path going through an area the player cannot walk into with the keyboard.
+     * Users allowed to edit the map are already granted access by AreaPermissions.isUserHasAreaAccess(), so they
+     * never collide because of missing rights, but they are still stopped by locks and by full areas.
      */
     public getCollidingAreas(): AreaData[] {
-        if (this.userCanEdit) {
-            return [];
-        }
         return Array.from(this.gameMapAreas.getAreas().values()).filter((area) => this.shouldAreaCollide(area.id));
     }
 

--- a/tests/tests/map_editor/map_editor_lock_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_lock_area.spec.ts
@@ -134,4 +134,43 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         expect(alicePositionAfterAreaMove.y).toBeGreaterThan(6 * 32);
         await expect(page2.getByText("This area is locked. You cannot enter.")).toBeHidden();
     });
+
+    test("Lock area also blocks pathfinding moves of a user allowed to edit the map", async ({ browser, request }) => {
+        await resetWamMaps(request);
+        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        const areaLeftBoundX = 1 * 32;
+
+        // Create an area just to the right of the spawn and make it lockable.
+        await Menu.openMapEditor(page);
+        await MapEditor.openAreaEditor(page);
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 1 * 32 }, { x: 7 * 32, y: 7 * 32 });
+        await AreaEditor.addProperty(page, "lockableAreaPropertyData");
+        await Menu.closeMapEditor(page);
+
+        // Admin1 stays out of the area, Alice enters it and locks it.
+        await Map.teleportToPosition(page, 0, 3 * 32);
+        await using page2 = await getPage(browser, "Alice", Map.url("empty"));
+        await Map.teleportToPosition(page2, 4 * 32, 4 * 32);
+        await expect(page2.getByTestId("lock-button")).toBeVisible();
+        await page2.getByTestId("lock-button").click();
+        await expect(page2.getByTestId("lock-button")).toHaveClass(/bg-danger/);
+
+        // Admin1 can edit the map, which used to remove every area from his pathfinding collision grid. He must not
+        // be able to walk into the locked area with a pathfinding move, which is the code path used by the "talk to"
+        // action of the chat, by a right click on the map and by the scripting API.
+        await Map.walkToPosition(page, 4 * 32, 4 * 32).catch(() => {
+            // Expected: no path can be found into a locked area.
+        });
+        const adminPositionWhileLocked = await Map.getPosition(page);
+        expect(adminPositionWhileLocked.x).toBeLessThan(areaLeftBoundX);
+
+        // Once Alice unlocks the area, the very same move brings Admin1 inside: editing rights are still enough to
+        // enter an area he is not allowed to enter otherwise.
+        await page2.getByTestId("lock-button").click();
+        await expect(page2.getByTestId("lock-button")).not.toHaveClass(/bg-danger/);
+
+        await Map.walkToPosition(page, 4 * 32, 4 * 32);
+        const adminPositionAfterUnlock = await Map.getPosition(page);
+        expect(adminPositionAfterUnlock.x).toBeGreaterThan(areaLeftBoundX);
+    });
 });


### PR DESCRIPTION
## The bug

Lock a meeting room from the inside, then have someone use the chat's **Talk to** action on you: they walk straight in, through the lock. Same thing with a right click on the map, or with `WA.player.moveTo()`.

## Root cause

`AreasManager.getCollidingAreas()` returned an empty list for every user allowed to edit the map:

```ts
public getCollidingAreas(): AreaData[] {
    if (this.userCanEdit) {
        return [];
    }
    ...
}
```

That list is what `GameMapFrontWrapper.rebuildAreasCollisionLayer()` writes into the collision grid used by the pathfinding. So for a map editor, no area existed as far as the pathfinding was concerned: `GameScene.moveTo()` happily computed a path through the locked area.

Following that path then runs with `setDirectControl(true)` and a `setPosition()` per frame recomputed from the precomputed path, so the area's static collider gets overridden every frame and the woka tunnels in.

The physical collider itself never had this exemption: `Area` applies it from `shouldAreaCollide()` directly. Hence the asymmetry users reported — the same person is blocked with the arrow keys, but not with **Talk to**.

## The fix

Drop the early return so pathfinding and physics agree on the same predicate.

This does not over-block editors: `getAreaBlockReason()` goes through `AreaPermissions.isUserHasAreaAccess()`, which already returns `true` when `userCanEdit`. An editor can therefore never collide because of missing rights — only because of a lock or a full area, which is exactly what their collider already enforces.

## Test

A second case in `map_editor_lock_area.spec.ts`: Admin1 (edit rights) stays outside, Alice locks the area, Admin1's pathfinding move must leave him outside — then, once Alice unlocks, the very same move must bring him in (guard against over-blocking editors).

It drives the scripting `movePlayerTo` rather than the chat menu: both funnel into the same `GameScene.moveTo()` → pathfinding grid, which is the root cause, and it keeps the test off Matrix and DM-room setup.

## Not covered here

The collision grid is snapshotted when `moveTo()` starts and the path is never recomputed, so locking an area *while* someone is already walking towards you still lets them in, editor or not. Separate fix (cutting the path in `Area.onCollideAction()`).

Area access is still enforced client-side only — the back returns any user's position on request and never validates a destination.