### PR TITLE
fix(media): fall back to VP9 when AV1 screen-share encoding is unavailable

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -10,6 +10,7 @@ import {
     Track,
     VideoPresets,
     DisconnectReason,
+    supportsAV1,
 } from "livekit-client";
 import type { Readable, Unsubscriber } from "svelte/store";
 import { get } from "svelte/store";
@@ -392,7 +393,11 @@ export class LiveKitRoom implements LiveKitRoomInterface {
 
             const screenSharePublishOptions: TrackPublishOptions = {
                 source: Track.Source.ScreenShare,
-                videoCodec: "av1",
+                // When AV1 encoding is unavailable (Chrome on Android, Chromium builds without
+                // libaom, Firefox, Safari...), LiveKit silently rewrites the codec to its hardcoded
+                // default of VP8 rather than to `publishDefaults.videoCodec`. Fall back to VP9
+                // explicitly; LiveKit still degrades VP9 to VP8 on its own if VP9 is missing too.
+                videoCodec: supportsAV1() ? "av1" : "vp9",
                 simulcast: true,
                 // Commented out: the default simulcast layers are sufficient for our use case
                 // screenShareSimulcastLayers: [ScreenSharePresets.h720fps30]


### PR DESCRIPTION
## Problem

Screen sharing is published to LiveKit with `videoCodec: "av1"`. When the publishing browser has no AV1 **encoder**, `LocalParticipant.publish` rewrites the codec itself:

```js
if (opts.videoCodec === 'av1' && !supportsAV1()) opts.videoCodec = undefined;
if (opts.videoCodec === undefined) opts.videoCodec = defaultVideoCodec;  // 'vp8'
```

The rewrite targets `livekit-client`'s hardcoded `defaultVideoCodec`, which is **VP8** — it does *not* consult our `publishDefaults.videoCodec: "vp9"`. Those users drop two tiers, straight from AV1 to VP8, and share a visibly worse screen than their browser is capable of.

This is not an exotic case. `supportsAV1()` is a `RTCRtpSender.getCapabilities("video")` lookup, plus a hard `false` for Firefox and Safari (whose SVC publishing is broken or unreliable). Plenty of Chrome installs decode AV1 without being able to encode it:

- Chrome on Android and WebView ship the AV1 decoder but not the libaom encoder
- Chromium rebuilds configured without `enable_libaom`
- AV1 send only landed in Chrome 111

## Fix

Pick the codec up front rather than letting `livekit-client` silently rewrite it.

The P2P path already degrades gracefully — its `preferredCodecs` list is `["video/AV1", "video/VP9", "video/VP8"]`, intersected with the sender capabilities, so a machine without an AV1 encoder lands on VP9. This makes LiveKit mode behave the same way.

VP9 is still subject to `livekit-client`'s own `supportsVP9()` check, so a browser with neither AV1 nor VP9 continues to fall through to VP8 exactly as before. No behaviour change for browsers that *do* have an AV1 encoder.

## How this was found

Users reported screen shares arriving as **VP8 in LiveKit mode** while the same machines got **VP9 in P2P mode**. The asymmetry was the tell: one missing AV1 encoder, two different fallback ladders.

Affected users can confirm the root cause in the console — the list will not contain `video/AV1`:

```js
RTCRtpSender.getCapabilities('video').codecs.map(c => c.mimeType)
```

## Testing

Not covered by an automated test — the branch depends on the browser's encoder capabilities, which the e2e browsers do not vary. Verified manually by forcing `supportsAV1()` to `false` and confirming the published screen-share track negotiates VP9 instead of VP8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
