### PR TITLE
feat(front): reroute or stop a pathfinding move when the collision grid changes mid-walk

### DIFF
--- a/play/src/front/Phaser/Entity/Area.ts
+++ b/play/src/front/Phaser/Entity/Area.ts
@@ -157,7 +157,7 @@ export class Area extends Rectangle {
         });
     }
 
-    private displayWarningMessageOnCollide() {
+    public displayBlockedWarningMessage() {
         // Get the reason why the area is blocked
         let message: string = get(LL).area.noAccess(); // Default message
         const messageId = `area-blocked-${this.areaData.id}`;
@@ -236,14 +236,14 @@ export class Area extends Rectangle {
                     this.highLightArea();
                 }
 
-                this.displayWarningMessageOnCollide();
+                this.displayBlockedWarningMessage();
                 this.collideTimeOut = setTimeout(() => (this.userHasCollideWithArea = false), 3000);
             }
         } else if (!this.userHasCollideWithArea) {
             // Fallback if areasManager is not available
             this.userHasCollideWithArea = true;
             this.highLightArea();
-            this.displayWarningMessageOnCollide();
+            this.displayBlockedWarningMessage();
             this.collideTimeOut = setTimeout(() => (this.userHasCollideWithArea = false), 3000);
         }
     }

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -439,7 +439,7 @@ export abstract class Character extends Container implements OutlineableInterfac
 
         const resolve = this.pathFollowingResolve;
         this.pathFollowingResolve = undefined;
-        resolve?.({ x: this.x, y: this.y, cancelled, ...(blocked ? { blocked: true } : {}) });
+        resolve?.({ x: this.x, y: this.y, cancelled, blocked });
     }
 
     protected isFollowingPath(): boolean {
@@ -452,7 +452,7 @@ export abstract class Character extends Container implements OutlineableInterfac
 
     /**
      * Called each time a waypoint of the followed path is reached, i.e. on each tile change.
-     * Subclasses can abort the path following from here (e.g. when the remaining path started colliding).
+     * Subclasses can abort the path following from here (e.g. when the next waypoint started colliding).
      */
     protected onPathWaypointReached(): void {}
 

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -46,14 +46,11 @@ export type PathFollowResult = {
     x: number;
     y: number;
     cancelled: boolean;
-    /** Set when the path was aborted because a tile of the remaining path started colliding (e.g. an area got locked mid-walk). */
+    /**
+     * Set when the path was aborted because its next waypoint started colliding (e.g. an area got locked
+     * mid-walk); the character stopped just before the blocking tile.
+     */
     blocked?: boolean;
-    /** With `blocked`: last waypoint of the aborted path that is still walkable, in game pixels (feet position). */
-    lastReachablePosition?: { x: number; y: number };
-};
-
-export type PathBlockedInfo = {
-    lastReachablePosition: { x: number; y: number };
 };
 
 export abstract class Character extends Container implements OutlineableInterface, Movable {
@@ -434,7 +431,7 @@ export abstract class Character extends Container implements OutlineableInterfac
         });
     }
 
-    public finishFollowingPath(cancelled = false, blockedInfo?: PathBlockedInfo): void {
+    public finishFollowingPath(cancelled = false, blocked = false): void {
         this.pathToFollow = undefined;
         this.pathWalkingSpeed = undefined;
         this.currentPathSegmentDistanceFromStart = 0;
@@ -442,7 +439,7 @@ export abstract class Character extends Container implements OutlineableInterfac
 
         const resolve = this.pathFollowingResolve;
         this.pathFollowingResolve = undefined;
-        resolve?.({ x: this.x, y: this.y, cancelled, ...(blockedInfo ? { blocked: true, ...blockedInfo } : {}) });
+        resolve?.({ x: this.x, y: this.y, cancelled, ...(blocked ? { blocked: true } : {}) });
     }
 
     protected isFollowingPath(): boolean {

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -50,13 +50,10 @@ export type PathFollowResult = {
     blocked?: boolean;
     /** With `blocked`: last waypoint of the aborted path that is still walkable, in game pixels (feet position). */
     lastReachablePosition?: { x: number; y: number };
-    /** With `blocked`: first waypoint of the aborted path that is now colliding, in game pixels (feet position). */
-    blockedPosition?: { x: number; y: number };
 };
 
 export type PathBlockedInfo = {
     lastReachablePosition: { x: number; y: number };
-    blockedPosition: { x: number; y: number };
 };
 
 export abstract class Character extends Container implements OutlineableInterface, Movable {

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -42,7 +42,22 @@ export const CHARACTER_BODY_OFFSET_Y = 8;
 
 export const PLAYTEXT_NEW_MEDIA_DEVICE_PREFIX = "playtext-mediadevice-";
 
-export type PathFollowResult = { x: number; y: number; cancelled: boolean };
+export type PathFollowResult = {
+    x: number;
+    y: number;
+    cancelled: boolean;
+    /** Set when the path was aborted because a tile of the remaining path started colliding (e.g. an area got locked mid-walk). */
+    blocked?: boolean;
+    /** With `blocked`: last waypoint of the aborted path that is still walkable, in game pixels (feet position). */
+    lastReachablePosition?: { x: number; y: number };
+    /** With `blocked`: first waypoint of the aborted path that is now colliding, in game pixels (feet position). */
+    blockedPosition?: { x: number; y: number };
+};
+
+export type PathBlockedInfo = {
+    lastReachablePosition: { x: number; y: number };
+    blockedPosition: { x: number; y: number };
+};
 
 export abstract class Character extends Container implements OutlineableInterface, Movable {
     private readonly movedSubject = new Subject<PositionInterface>();
@@ -422,7 +437,7 @@ export abstract class Character extends Container implements OutlineableInterfac
         });
     }
 
-    public finishFollowingPath(cancelled = false): void {
+    public finishFollowingPath(cancelled = false, blockedInfo?: PathBlockedInfo): void {
         this.pathToFollow = undefined;
         this.pathWalkingSpeed = undefined;
         this.currentPathSegmentDistanceFromStart = 0;
@@ -430,7 +445,7 @@ export abstract class Character extends Container implements OutlineableInterfac
 
         const resolve = this.pathFollowingResolve;
         this.pathFollowingResolve = undefined;
-        resolve?.({ x: this.x, y: this.y, cancelled });
+        resolve?.({ x: this.x, y: this.y, cancelled, ...(blockedInfo ? { blocked: true, ...blockedInfo } : {}) });
     }
 
     protected isFollowingPath(): boolean {
@@ -440,6 +455,12 @@ export abstract class Character extends Container implements OutlineableInterfac
     protected getPathWalkingSpeed(): number {
         return this.pathWalkingSpeed ?? WOKA_SPEED;
     }
+
+    /**
+     * Called each time a waypoint of the followed path is reached, i.e. on each tile change.
+     * Subclasses can abort the path following from here (e.g. when the remaining path started colliding).
+     */
+    protected onPathWaypointReached(): void {}
 
     protected adjustPathToColliderBounds(path: { x: number; y: number }[]): { x: number; y: number }[] {
         const body = this.getBody();
@@ -473,6 +494,12 @@ export abstract class Character extends Container implements OutlineableInterfac
             if (this.pathToFollow.length === 1) {
                 this.setPosition(this.pathToFollow[0].x, this.pathToFollow[0].y);
                 this.finishFollowingPath();
+                return;
+            }
+
+            this.onPathWaypointReached();
+            if (!this.pathToFollow) {
+                // The hook aborted the path following.
                 return;
             }
 

--- a/play/src/front/Phaser/Entity/RemotePlayer.ts
+++ b/play/src/front/Phaser/Entity/RemotePlayer.ts
@@ -11,6 +11,7 @@ import {
 import type { WokaMenuAction } from "../../Stores/WokaMenuStore";
 import { wokaMenuStore } from "../../Stores/WokaMenuStore";
 import { Character } from "../Entity/Character";
+import type { PathBlockedInfo } from "../Entity/Character";
 import type { GameScene } from "../Game/GameScene";
 import { WOKA_SPEED } from "../../Enum/EnvironmentVariable";
 import type { ActivatableInterface } from "../Game/ActivatableInterface";
@@ -124,8 +125,8 @@ export class RemotePlayer extends Character implements ActivatableInterface {
         }
     }
 
-    public finishFollowingPath(cancelled = false): void {
-        super.finishFollowingPath(cancelled);
+    public finishFollowingPath(cancelled = false, blockedInfo?: PathBlockedInfo): void {
+        super.finishFollowingPath(cancelled, blockedInfo);
         this.scene.events.off(Phaser.Scenes.Events.UPDATE, this.pathFollowingUpdateCallback);
         this.scene.markDirty();
     }

--- a/play/src/front/Phaser/Entity/RemotePlayer.ts
+++ b/play/src/front/Phaser/Entity/RemotePlayer.ts
@@ -11,7 +11,6 @@ import {
 import type { WokaMenuAction } from "../../Stores/WokaMenuStore";
 import { wokaMenuStore } from "../../Stores/WokaMenuStore";
 import { Character } from "../Entity/Character";
-import type { PathBlockedInfo } from "../Entity/Character";
 import type { GameScene } from "../Game/GameScene";
 import { WOKA_SPEED } from "../../Enum/EnvironmentVariable";
 import type { ActivatableInterface } from "../Game/ActivatableInterface";
@@ -125,8 +124,8 @@ export class RemotePlayer extends Character implements ActivatableInterface {
         }
     }
 
-    public finishFollowingPath(cancelled = false, blockedInfo?: PathBlockedInfo): void {
-        super.finishFollowingPath(cancelled, blockedInfo);
+    public finishFollowingPath(cancelled = false, blocked = false): void {
+        super.finishFollowingPath(cancelled, blocked);
         this.scene.events.off(Phaser.Scenes.Events.UPDATE, this.pathFollowingUpdateCallback);
         this.scene.markDirty();
     }

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -194,7 +194,6 @@ import type { ChatConnectionInterface, ChatUser } from "../../Chat/Connection/Ch
 import { selectedRoomStore } from "../../Chat/Stores/SelectRoomStore";
 import { raceTimeout } from "../../Utils/PromiseUtils";
 import { PLAYTEXT_NEW_MEDIA_DEVICE_PREFIX } from "../Entity/Character";
-import type { PathFollowResult } from "../Entity/Character";
 import { type Avatar, ConversationBubble } from "../Entity/ConversationBubble";
 import { DarkenOutsideAreaEffect } from "../Components/DarkenOutsideArea/DarkenOutsideAreaEffect";
 import { isInsidePersonalAreaStore } from "../../Stores/PersonalDeskStore";
@@ -3886,11 +3885,10 @@ ${escapedMessage}
     ): Promise<{ x: number; y: number; cancelled: boolean }> {
         const pathfindingManager = this.getPathfindingManager();
         const resolvedSpeed = speed ?? this.CurrentPlayer.walkingSpeed;
-        let lastBlockedResult: PathFollowResult | undefined;
 
         // The collision grid can change while the path is followed (an area gets locked or full...): the
-        // player then aborts the path (see Player.onPathWaypointReached) and we compute a new route to the
-        // destination.
+        // player then aborts right before walking onto a blocking tile (see Player.onPathWaypointReached)
+        // and we compute a new route to the destination.
         for (let attempt = 0; attempt <= MAX_PATH_REROUTES; attempt += 1) {
             pathfindingManager.setCollisionGrid(
                 this.gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false }),
@@ -3915,82 +3913,32 @@ ${escapedMessage}
                 // Normal arrival, or cancellation by the user taking over: never reroute in that case.
                 return { x: result.x, y: result.y, cancelled: result.cancelled };
             }
-            lastBlockedResult = result;
         }
 
-        // The destination is not reachable anymore: walk to the last waypoint of the blocked path that is
-        // still walkable ("up to the door"), then warn the user.
-        const lastReachablePosition = lastBlockedResult?.lastReachablePosition;
-        if (lastReachablePosition) {
-            const distanceToDoor = MathUtils.distanceBetween(
-                { x: this.CurrentPlayer.x, y: this.CurrentPlayer.y },
-                lastReachablePosition,
-            );
-            if (distanceToDoor > this.gameMapFrontWrapper.getTileDimensions().width / 2) {
-                pathfindingManager.setCollisionGrid(
-                    this.gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false }),
-                );
-                const doorPath = await pathfindingManager.findPathFromGameCoordinates(
-                    {
-                        x: this.CurrentPlayer.x,
-                        y: this.CurrentPlayer.y,
-                    },
-                    lastReachablePosition,
-                    true,
-                );
-                if (doorPath.length > 0) {
-                    const doorResult = await this.CurrentPlayer.setPathToFollow(doorPath, resolvedSpeed);
-                    if (doorResult.cancelled && !doorResult.blocked) {
-                        // The user took over while walking to the door: no warning.
-                        return { x: doorResult.x, y: doorResult.y, cancelled: true };
-                    }
-                }
-            }
-        }
+        // The path got blocked mid-walk and the destination is not reachable anymore. The woka already
+        // stands right before the blocking tile: warn about the area blocking the destination.
         this.displayPathBlockedWarning(position);
         return { x: this.CurrentPlayer.x, y: this.CurrentPlayer.y, cancelled: true };
     }
 
     /**
      * Displays the blocked-area warning above the woka when a pathfinding move had to stop short of its
-     * unreachable destination. Mirrors the messages shown by Area.displayWarningMessageOnCollide on
-     * physical contact.
+     * unreachable destination, reusing the same message (and admin unlock affordance) as a physical
+     * collision with the area.
      */
     private displayPathBlockedWarning(destination: { x: number; y: number }): void {
         const areasManager = this.gameMapFrontWrapper.areasManager;
+        if (!areasManager) {
+            return;
+        }
         const blockingArea = areasManager
-            ?.getCollidingAreas()
+            .getCollidingAreas()
             .find((area) => MathUtils.isOverlappingWithRectangle(destination, area));
-        if (!areasManager || !blockingArea) {
+        if (!blockingArea) {
             // Blocked by something else than an area (an entity, a layer change...): stay silent.
             return;
         }
-        const blockReason = areasManager.getAreaBlockReason(blockingArea.id);
-        if (!blockReason) {
-            return;
-        }
-        let message: string;
-        switch (blockReason) {
-            case "locked":
-                message = get(LL).area.blocked.locked();
-                break;
-            case "maxUsers":
-                message = get(LL).area.blocked.maxUsers();
-                break;
-            case "noAccess":
-                message = get(LL).area.blocked.noAccess();
-                break;
-        }
-        const messageId = `path-blocked-${blockingArea.id}`;
-        this.CurrentPlayer.destroyText(messageId);
-        this.CurrentPlayer.playText(
-            messageId,
-            message,
-            5000,
-            () => this.CurrentPlayer.destroyText(messageId),
-            true,
-            "warning",
-        );
+        areasManager.getAreaById(blockingArea.id)?.displayBlockedWarningMessage();
     }
 
     /**

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3884,7 +3884,6 @@ ${escapedMessage}
         speed: number | undefined = undefined,
     ): Promise<{ x: number; y: number; cancelled: boolean }> {
         const pathfindingManager = this.getPathfindingManager();
-        const resolvedSpeed = speed ?? this.CurrentPlayer.walkingSpeed;
 
         // The collision grid can change while the path is followed (an area gets locked or full...): the
         // player then aborts right before walking onto a blocking tile (see Player.onPathWaypointReached)
@@ -3908,7 +3907,7 @@ ${escapedMessage}
                 break;
             }
             // eslint-disable-next-line no-await-in-loop
-            const result = await this.CurrentPlayer.setPathToFollow(path, resolvedSpeed);
+            const result = await this.CurrentPlayer.setPathToFollow(path, speed ?? this.CurrentPlayer.walkingSpeed);
             if (!result.blocked) {
                 // Normal arrival, or cancellation by the user taking over: never reroute in that case.
                 return { x: result.x, y: result.y, cancelled: result.cancelled };

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3947,19 +3947,20 @@ ${escapedMessage}
                 }
             }
         }
-        this.displayPathBlockedWarning(lastBlockedResult?.blockedPosition ?? position);
+        this.displayPathBlockedWarning(position);
         return { x: this.CurrentPlayer.x, y: this.CurrentPlayer.y, cancelled: true };
     }
 
     /**
      * Displays the blocked-area warning above the woka when a pathfinding move had to stop short of its
-     * destination. Mirrors the messages shown by Area.displayWarningMessageOnCollide on physical contact.
+     * unreachable destination. Mirrors the messages shown by Area.displayWarningMessageOnCollide on
+     * physical contact.
      */
-    private displayPathBlockedWarning(blockedPosition: { x: number; y: number }): void {
+    private displayPathBlockedWarning(destination: { x: number; y: number }): void {
         const areasManager = this.gameMapFrontWrapper.areasManager;
         const blockingArea = areasManager
             ?.getCollidingAreas()
-            .find((area) => MathUtils.isOverlappingWithRectangle(blockedPosition, area));
+            .find((area) => MathUtils.isOverlappingWithRectangle(destination, area));
         if (!areasManager || !blockingArea) {
             // Blocked by something else than an area (an entity, a layer change...): stay silent.
             return;

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -194,6 +194,7 @@ import type { ChatConnectionInterface, ChatUser } from "../../Chat/Connection/Ch
 import { selectedRoomStore } from "../../Chat/Stores/SelectRoomStore";
 import { raceTimeout } from "../../Utils/PromiseUtils";
 import { PLAYTEXT_NEW_MEDIA_DEVICE_PREFIX } from "../Entity/Character";
+import type { PathFollowResult } from "../Entity/Character";
 import { type Avatar, ConversationBubble } from "../Entity/ConversationBubble";
 import { DarkenOutsideAreaEffect } from "../Components/DarkenOutsideArea/DarkenOutsideAreaEffect";
 import { isInsidePersonalAreaStore } from "../../Stores/PersonalDeskStore";
@@ -281,6 +282,9 @@ interface PositionCoordinates {
 
 const WORLD_SPACE_NAME = "allWorldUser";
 const debug = Debug("GameScene");
+
+// Safety cap for moveTo() reroutes when the collision grid keeps changing while the path is followed.
+const MAX_PATH_REROUTES = 5;
 
 export class GameScene extends DirtyScene {
     Terrains: Array<Tileset>;
@@ -3881,18 +3885,111 @@ ${escapedMessage}
         speed: number | undefined = undefined,
     ): Promise<{ x: number; y: number; cancelled: boolean }> {
         const pathfindingManager = this.getPathfindingManager();
-        pathfindingManager.setCollisionGrid(this.gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false }));
+        const resolvedSpeed = speed ?? this.CurrentPlayer.walkingSpeed;
+        let lastBlockedResult: PathFollowResult | undefined;
 
-        const path = await pathfindingManager.findPathFromGameCoordinates(
-            {
-                x: this.CurrentPlayer.x,
-                y: this.CurrentPlayer.y,
-            },
-            position,
-            tryFindingNearestAvailable,
+        // The collision grid can change while the path is followed (an area gets locked or full...): the
+        // player then aborts the path (see Player.onPathWaypointReached) and we compute a new route to the
+        // destination.
+        for (let attempt = 0; attempt <= MAX_PATH_REROUTES; attempt += 1) {
+            pathfindingManager.setCollisionGrid(
+                this.gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false }),
+            );
+            // Each attempt must fully complete (walk, then maybe reroute) before the next one starts.
+            // eslint-disable-next-line no-await-in-loop
+            const path = await pathfindingManager.findPathFromGameCoordinates(
+                {
+                    x: this.CurrentPlayer.x,
+                    y: this.CurrentPlayer.y,
+                },
+                position,
+                tryFindingNearestAvailable,
+            );
+            if (path.length === 0) {
+                if (attempt === 0) throw new Error("No path found");
+                break;
+            }
+            // eslint-disable-next-line no-await-in-loop
+            const result = await this.CurrentPlayer.setPathToFollow(path, resolvedSpeed);
+            if (!result.blocked) {
+                // Normal arrival, or cancellation by the user taking over: never reroute in that case.
+                return { x: result.x, y: result.y, cancelled: result.cancelled };
+            }
+            lastBlockedResult = result;
+        }
+
+        // The destination is not reachable anymore: walk to the last waypoint of the blocked path that is
+        // still walkable ("up to the door"), then warn the user.
+        const lastReachablePosition = lastBlockedResult?.lastReachablePosition;
+        if (lastReachablePosition) {
+            const distanceToDoor = MathUtils.distanceBetween(
+                { x: this.CurrentPlayer.x, y: this.CurrentPlayer.y },
+                lastReachablePosition,
+            );
+            if (distanceToDoor > this.gameMapFrontWrapper.getTileDimensions().width / 2) {
+                pathfindingManager.setCollisionGrid(
+                    this.gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false }),
+                );
+                const doorPath = await pathfindingManager.findPathFromGameCoordinates(
+                    {
+                        x: this.CurrentPlayer.x,
+                        y: this.CurrentPlayer.y,
+                    },
+                    lastReachablePosition,
+                    true,
+                );
+                if (doorPath.length > 0) {
+                    const doorResult = await this.CurrentPlayer.setPathToFollow(doorPath, resolvedSpeed);
+                    if (doorResult.cancelled && !doorResult.blocked) {
+                        // The user took over while walking to the door: no warning.
+                        return { x: doorResult.x, y: doorResult.y, cancelled: true };
+                    }
+                }
+            }
+        }
+        this.displayPathBlockedWarning(lastBlockedResult?.blockedPosition ?? position);
+        return { x: this.CurrentPlayer.x, y: this.CurrentPlayer.y, cancelled: true };
+    }
+
+    /**
+     * Displays the blocked-area warning above the woka when a pathfinding move had to stop short of its
+     * destination. Mirrors the messages shown by Area.displayWarningMessageOnCollide on physical contact.
+     */
+    private displayPathBlockedWarning(blockedPosition: { x: number; y: number }): void {
+        const areasManager = this.gameMapFrontWrapper.areasManager;
+        const blockingArea = areasManager
+            ?.getCollidingAreas()
+            .find((area) => MathUtils.isOverlappingWithRectangle(blockedPosition, area));
+        if (!areasManager || !blockingArea) {
+            // Blocked by something else than an area (an entity, a layer change...): stay silent.
+            return;
+        }
+        const blockReason = areasManager.getAreaBlockReason(blockingArea.id);
+        if (!blockReason) {
+            return;
+        }
+        let message: string;
+        switch (blockReason) {
+            case "locked":
+                message = get(LL).area.blocked.locked();
+                break;
+            case "maxUsers":
+                message = get(LL).area.blocked.maxUsers();
+                break;
+            case "noAccess":
+                message = get(LL).area.blocked.noAccess();
+                break;
+        }
+        const messageId = `path-blocked-${blockingArea.id}`;
+        this.CurrentPlayer.destroyText(messageId);
+        this.CurrentPlayer.playText(
+            messageId,
+            message,
+            5000,
+            () => this.CurrentPlayer.destroyText(messageId),
+            true,
+            "warning",
         );
-        if (path.length === 0) throw new Error("No path found");
-        return this.CurrentPlayer.setPathToFollow(path, speed ?? this.CurrentPlayer.walkingSpeed);
     }
 
     /**

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -6,9 +6,9 @@ import type { GameScene } from "../Game/GameScene";
 import type { ActiveEventList } from "../UserInput/UserInputManager";
 import { UserInputEvent } from "../UserInput/UserInputManager";
 import { Character } from "../Entity/Character";
-import type { PathBlockedInfo, PathFollowResult } from "../Entity/Character";
+import type { PathFollowResult } from "../Entity/Character";
 import { PathTileType } from "../../Utils/PathfindingManager";
-import { findFirstBlockedWaypointIndex } from "../../Utils/PathValidation";
+import { isWaypointBlocked } from "../../Utils/PathValidation";
 
 import { userMovingStore } from "../../Stores/GameStore";
 import { followStateStore, followRoleStore, followUsersStore } from "../../Stores/FollowStore";
@@ -239,18 +239,20 @@ export class Player extends Character {
         super.moveToPathPosition(x, y);
     }
 
-    public finishFollowingPath(cancelled = false, blockedInfo?: PathBlockedInfo): void {
+    public finishFollowingPath(cancelled = false, blocked = false): void {
         const wasFollowing = this.isFollowingPath();
-        super.finishFollowingPath(cancelled, blockedInfo);
+        super.finishFollowingPath(cancelled, blocked);
         this.onPathFinished(wasFollowing);
     }
 
     /**
      * The collision grid can change while a path is being followed (an area gets locked or full, an
      * entity is dropped...). Since the path following runs with direct body control, colliders would
-     * not stop us: revalidate the remaining path on each tile change and abort as soon as a waypoint
-     * ahead started colliding. GameScene.moveTo() then reroutes to the destination, or walks to the
-     * last reachable waypoint if the destination is not reachable anymore.
+     * not stop us: check the next waypoint on each tile change and abort right before walking onto a
+     * tile that started colliding. Only the NEXT waypoint is checked, on purpose: the woka keeps
+     * walking up to the obstacle, so the blocked warning shows next to the area it talks about, and a
+     * lock lifted before the woka reaches the area never interrupts the walk. GameScene.moveTo() then
+     * reroutes to the destination, or stops there when it is not reachable anymore.
      */
     protected onPathWaypointReached(): void {
         if (!this.pathToFollow || this.pathToFollow.length < 2) {
@@ -258,21 +260,16 @@ export class Player extends Character {
         }
         const gameMapFrontWrapper = this.scene.getGameMapFrontWrapper();
         const body = this.getBody();
-        const bodyYOffset = body.height / 2 + body.offset.y;
-        const blockedIndex = findFirstBlockedWaypointIndex(
-            this.pathToFollow,
+        const blocked = isWaypointBlocked(
+            this.pathToFollow[1],
             gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false }),
             gameMapFrontWrapper.getTileDimensions(),
-            bodyYOffset,
+            body.height / 2 + body.offset.y,
             PathTileType.Collider,
         );
-        if (blockedIndex === -1) {
-            return;
+        if (blocked) {
+            this.finishFollowingPath(true, true);
         }
-        const lastReachable = this.pathToFollow[blockedIndex - 1];
-        this.finishFollowingPath(true, {
-            lastReachablePosition: { x: lastReachable.x, y: lastReachable.y + bodyYOffset },
-        });
     }
 
     public teleportTo(x: number, y: number): void {

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -260,14 +260,15 @@ export class Player extends Character {
         }
         const gameMapFrontWrapper = this.scene.getGameMapFrontWrapper();
         const body = this.getBody();
-        const blocked = isWaypointBlocked(
-            this.pathToFollow[1],
-            gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false }),
-            gameMapFrontWrapper.getTileDimensions(),
-            body.height / 2 + body.offset.y,
-            PathTileType.Collider,
-        );
-        if (blocked) {
+        if (
+            isWaypointBlocked(
+                this.pathToFollow[1],
+                gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false }),
+                gameMapFrontWrapper.getTileDimensions(),
+                body.height / 2 + body.offset.y,
+                PathTileType.Collider,
+            )
+        ) {
             this.finishFollowingPath(true, true);
         }
     }

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -6,6 +6,9 @@ import type { GameScene } from "../Game/GameScene";
 import type { ActiveEventList } from "../UserInput/UserInputManager";
 import { UserInputEvent } from "../UserInput/UserInputManager";
 import { Character } from "../Entity/Character";
+import type { PathBlockedInfo, PathFollowResult } from "../Entity/Character";
+import { PathTileType } from "../../Utils/PathfindingManager";
+import { findFirstBlockedWaypointIndex } from "../../Utils/PathValidation";
 
 import { userMovingStore } from "../../Stores/GameStore";
 import { followStateStore, followRoleStore, followUsersStore } from "../../Stores/FollowStore";
@@ -88,10 +91,7 @@ export class Player extends Character {
         this.scene.connection?.emitFollowConfirmation(get(followUsersStore)[0]);
     }
 
-    public setPathToFollow(
-        path: { x: number; y: number }[],
-        speed?: number,
-    ): Promise<{ x: number; y: number; cancelled: boolean }> {
+    public setPathToFollow(path: { x: number; y: number }[], speed?: number): Promise<PathFollowResult> {
         if (!this.isMoving) {
             this.isMoving = true;
             this.emit(startMovingEventName, { direction: this._lastDirection, x: this.x, y: this.y });
@@ -239,10 +239,42 @@ export class Player extends Character {
         super.moveToPathPosition(x, y);
     }
 
-    public finishFollowingPath(cancelled = false): void {
+    public finishFollowingPath(cancelled = false, blockedInfo?: PathBlockedInfo): void {
         const wasFollowing = this.isFollowingPath();
-        super.finishFollowingPath(cancelled);
+        super.finishFollowingPath(cancelled, blockedInfo);
         this.onPathFinished(wasFollowing);
+    }
+
+    /**
+     * The collision grid can change while a path is being followed (an area gets locked or full, an
+     * entity is dropped...). Since the path following runs with direct body control, colliders would
+     * not stop us: revalidate the remaining path on each tile change and abort as soon as a waypoint
+     * ahead started colliding. GameScene.moveTo() then reroutes to the destination, or walks to the
+     * last reachable waypoint if the destination is not reachable anymore.
+     */
+    protected onPathWaypointReached(): void {
+        if (!this.pathToFollow || this.pathToFollow.length < 2) {
+            return;
+        }
+        const gameMapFrontWrapper = this.scene.getGameMapFrontWrapper();
+        const body = this.getBody();
+        const bodyYOffset = body.height / 2 + body.offset.y;
+        const blockedIndex = findFirstBlockedWaypointIndex(
+            this.pathToFollow,
+            gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false }),
+            gameMapFrontWrapper.getTileDimensions(),
+            bodyYOffset,
+            PathTileType.Collider,
+        );
+        if (blockedIndex === -1) {
+            return;
+        }
+        const lastReachable = this.pathToFollow[blockedIndex - 1];
+        const blocked = this.pathToFollow[blockedIndex];
+        this.finishFollowingPath(true, {
+            lastReachablePosition: { x: lastReachable.x, y: lastReachable.y + bodyYOffset },
+            blockedPosition: { x: blocked.x, y: blocked.y + bodyYOffset },
+        });
     }
 
     public teleportTo(x: number, y: number): void {

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -270,10 +270,8 @@ export class Player extends Character {
             return;
         }
         const lastReachable = this.pathToFollow[blockedIndex - 1];
-        const blocked = this.pathToFollow[blockedIndex];
         this.finishFollowingPath(true, {
             lastReachablePosition: { x: lastReachable.x, y: lastReachable.y + bodyYOffset },
-            blockedPosition: { x: blocked.x, y: blocked.y + bodyYOffset },
         });
     }
 

--- a/play/src/front/Utils/PathValidation.ts
+++ b/play/src/front/Utils/PathValidation.ts
@@ -1,0 +1,24 @@
+/**
+ * Returns the index of the first waypoint of `waypoints` that lands on a colliding tile of `grid`,
+ * or -1 if the whole path is still walkable.
+ *
+ * Waypoints are expressed in the collider-adjusted space used by Character.pathToFollow (their y is
+ * shifted up by the body offset), so `waypointYOffset` is added back before mapping to a tile.
+ * Index 0 is the start of the current segment (the character's own position) and is never checked.
+ */
+export function findFirstBlockedWaypointIndex(
+    waypoints: ReadonlyArray<{ x: number; y: number }>,
+    grid: number[][],
+    tileDimensions: { width: number; height: number },
+    waypointYOffset: number,
+    colliderTileType: number,
+): number {
+    for (let i = 1; i < waypoints.length; i += 1) {
+        const tileX = Math.floor(waypoints[i].x / tileDimensions.width);
+        const tileY = Math.floor((waypoints[i].y + waypointYOffset) / tileDimensions.height);
+        if (grid[tileY]?.[tileX] === colliderTileType) {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/play/src/front/Utils/PathValidation.ts
+++ b/play/src/front/Utils/PathValidation.ts
@@ -1,23 +1,19 @@
 /**
- * Returns the index of the first waypoint of `waypoints` that lands on a colliding tile of `grid`,
- * or -1 if the whole path is still walkable.
+ * Returns true when `waypoint` lands on a colliding tile of `grid`.
  *
  * Waypoints are expressed in the collider-adjusted space used by Character.pathToFollow (their y is
  * shifted up by the body offset), so `waypointYOffset` is added back before mapping to a tile.
- * Index 0 is the start of the current segment (the character's own position) and is never checked.
  */
-export function findFirstBlockedWaypointIndex(
-    waypoints: ReadonlyArray<{ x: number; y: number }>,
+export function isWaypointBlocked(
+    waypoint: { x: number; y: number },
     grid: number[][],
     tileDimensions: { width: number; height: number },
     waypointYOffset: number,
     colliderTileType: number,
-): number {
-    return waypoints.findIndex(
-        (waypoint, i) =>
-            i > 0 &&
-            grid[Math.floor((waypoint.y + waypointYOffset) / tileDimensions.height)]?.[
-                Math.floor(waypoint.x / tileDimensions.width)
-            ] === colliderTileType,
+): boolean {
+    return (
+        grid[Math.floor((waypoint.y + waypointYOffset) / tileDimensions.height)]?.[
+            Math.floor(waypoint.x / tileDimensions.width)
+        ] === colliderTileType
     );
 }

--- a/play/src/front/Utils/PathValidation.ts
+++ b/play/src/front/Utils/PathValidation.ts
@@ -13,12 +13,11 @@ export function findFirstBlockedWaypointIndex(
     waypointYOffset: number,
     colliderTileType: number,
 ): number {
-    for (let i = 1; i < waypoints.length; i += 1) {
-        const tileX = Math.floor(waypoints[i].x / tileDimensions.width);
-        const tileY = Math.floor((waypoints[i].y + waypointYOffset) / tileDimensions.height);
-        if (grid[tileY]?.[tileX] === colliderTileType) {
-            return i;
-        }
-    }
-    return -1;
+    return waypoints.findIndex(
+        (waypoint, i) =>
+            i > 0 &&
+            grid[Math.floor((waypoint.y + waypointYOffset) / tileDimensions.height)]?.[
+                Math.floor(waypoint.x / tileDimensions.width)
+            ] === colliderTileType,
+    );
 }

--- a/play/tests/front/Utils/PathValidation.test.ts
+++ b/play/tests/front/Utils/PathValidation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { findFirstBlockedWaypointIndex } from "../../../src/front/Utils/PathValidation";
+
+const TILE = { width: 32, height: 32 };
+const COLLIDER = 1;
+
+// Waypoints as Character.pathToFollow stores them: tile centers shifted up by the body offset.
+function waypoint(tileX: number, tileY: number, yOffset: number): { x: number; y: number } {
+    return { x: tileX * 32 + 16, y: tileY * 32 + 16 - yOffset };
+}
+
+describe("findFirstBlockedWaypointIndex", () => {
+    const yOffset = 24;
+
+    it("returns -1 when the whole path is walkable", () => {
+        const grid = [
+            [0, 0, 0],
+            [0, 0, 0],
+        ];
+        const path = [waypoint(0, 0, yOffset), waypoint(1, 0, yOffset), waypoint(2, 0, yOffset)];
+        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(-1);
+    });
+
+    it("returns the index of the first waypoint landing on a colliding tile", () => {
+        const grid = [
+            [0, 0, 0, 0],
+            [0, 0, 1, 1],
+        ];
+        const path = [
+            waypoint(0, 1, yOffset),
+            waypoint(1, 1, yOffset),
+            waypoint(2, 1, yOffset),
+            waypoint(3, 1, yOffset),
+        ];
+        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(2);
+    });
+
+    it("never checks index 0, which is the character's own position", () => {
+        const grid = [[1, 0, 0]];
+        const path = [waypoint(0, 0, yOffset), waypoint(1, 0, yOffset), waypoint(2, 0, yOffset)];
+        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(-1);
+    });
+
+    it("adds the body offset back before mapping a waypoint to its tile row", () => {
+        // Adjusted y of tile row 1 is 24, which naively floors to row 0: only row 1 is blocked.
+        const grid = [
+            [0, 0],
+            [0, 1],
+        ];
+        const path = [waypoint(0, 1, yOffset), waypoint(1, 1, yOffset)];
+        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(1);
+        expect(findFirstBlockedWaypointIndex(path, grid, TILE, 0, COLLIDER)).toBe(-1);
+    });
+
+    it("treats non-collider special tiles as walkable", () => {
+        // 2 = Exit, 4 = MeetingRoom in the pathfinding grid.
+        const grid = [[0, 2, 4]];
+        const path = [waypoint(0, 0, yOffset), waypoint(1, 0, yOffset), waypoint(2, 0, yOffset)];
+        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(-1);
+    });
+});

--- a/play/tests/front/Utils/PathValidation.test.ts
+++ b/play/tests/front/Utils/PathValidation.test.ts
@@ -1,61 +1,44 @@
 import { describe, expect, it } from "vitest";
-import { findFirstBlockedWaypointIndex } from "../../../src/front/Utils/PathValidation";
+import { isWaypointBlocked } from "../../../src/front/Utils/PathValidation";
 
 const TILE = { width: 32, height: 32 };
 const COLLIDER = 1;
+const Y_OFFSET = 24;
 
 // Waypoints as Character.pathToFollow stores them: tile centers shifted up by the body offset.
-function waypoint(tileX: number, tileY: number, yOffset: number): { x: number; y: number } {
-    return { x: tileX * 32 + 16, y: tileY * 32 + 16 - yOffset };
+function waypoint(tileX: number, tileY: number): { x: number; y: number } {
+    return { x: tileX * 32 + 16, y: tileY * 32 + 16 - Y_OFFSET };
 }
 
-describe("findFirstBlockedWaypointIndex", () => {
-    const yOffset = 24;
-
-    it("returns -1 when the whole path is walkable", () => {
-        const grid = [
-            [0, 0, 0],
-            [0, 0, 0],
-        ];
-        const path = [waypoint(0, 0, yOffset), waypoint(1, 0, yOffset), waypoint(2, 0, yOffset)];
-        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(-1);
-    });
-
-    it("returns the index of the first waypoint landing on a colliding tile", () => {
-        const grid = [
-            [0, 0, 0, 0],
-            [0, 0, 1, 1],
-        ];
-        const path = [
-            waypoint(0, 1, yOffset),
-            waypoint(1, 1, yOffset),
-            waypoint(2, 1, yOffset),
-            waypoint(3, 1, yOffset),
-        ];
-        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(2);
-    });
-
-    it("never checks index 0, which is the character's own position", () => {
-        const grid = [[1, 0, 0]];
-        const path = [waypoint(0, 0, yOffset), waypoint(1, 0, yOffset), waypoint(2, 0, yOffset)];
-        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(-1);
-    });
-
-    it("adds the body offset back before mapping a waypoint to its tile row", () => {
-        // Adjusted y of tile row 1 is 24, which naively floors to row 0: only row 1 is blocked.
+describe("isWaypointBlocked", () => {
+    it("detects a waypoint landing on a colliding tile", () => {
         const grid = [
             [0, 0],
             [0, 1],
         ];
-        const path = [waypoint(0, 1, yOffset), waypoint(1, 1, yOffset)];
-        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(1);
-        expect(findFirstBlockedWaypointIndex(path, grid, TILE, 0, COLLIDER)).toBe(-1);
+        expect(isWaypointBlocked(waypoint(1, 1), grid, TILE, Y_OFFSET, COLLIDER)).toBe(true);
+        expect(isWaypointBlocked(waypoint(0, 1), grid, TILE, Y_OFFSET, COLLIDER)).toBe(false);
+    });
+
+    it("adds the body offset back before mapping the waypoint to its tile row", () => {
+        // The adjusted y of tile row 1 naively floors to row 0: without the offset, nothing is blocked.
+        const grid = [
+            [0, 0],
+            [0, 1],
+        ];
+        expect(isWaypointBlocked(waypoint(1, 1), grid, TILE, Y_OFFSET, COLLIDER)).toBe(true);
+        expect(isWaypointBlocked(waypoint(1, 1), grid, TILE, 0, COLLIDER)).toBe(false);
     });
 
     it("treats non-collider special tiles as walkable", () => {
         // 2 = Exit, 4 = MeetingRoom in the pathfinding grid.
         const grid = [[0, 2, 4]];
-        const path = [waypoint(0, 0, yOffset), waypoint(1, 0, yOffset), waypoint(2, 0, yOffset)];
-        expect(findFirstBlockedWaypointIndex(path, grid, TILE, yOffset, COLLIDER)).toBe(-1);
+        expect(isWaypointBlocked(waypoint(1, 0), grid, TILE, Y_OFFSET, COLLIDER)).toBe(false);
+        expect(isWaypointBlocked(waypoint(2, 0), grid, TILE, Y_OFFSET, COLLIDER)).toBe(false);
+    });
+
+    it("treats a waypoint outside the grid as walkable", () => {
+        const grid = [[0]];
+        expect(isWaypointBlocked(waypoint(5, 5), grid, TILE, Y_OFFSET, COLLIDER)).toBe(false);
     });
 });

--- a/tests/tests/map_editor/map_editor_lock_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_lock_area.spec.ts
@@ -185,16 +185,18 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         await AreaEditor.addProperty(page, "lockableAreaPropertyData");
         await Menu.closeMapEditor(page);
 
-        // The admin stays inside the area to be able to lock it while Alice walks.
-        await Map.teleportToPosition(page, 4 * 32 + 16, 4 * 32);
+        // The admin stays inside the area to be able to lock it while Alice walks. He stands at the top
+        // of the wall, far from Alice's lane: if the two wokas get close enough, a proximity bubble
+        // forms (even through the wall) and the lock button then opens a picker instead of toggling.
+        await Map.teleportToPosition(page, 4 * 32 + 16, 1 * 32 + 16);
         await expect(page.getByTestId("lock-button")).toBeVisible();
 
         await using page2 = await getPage(browser, "Alice", Map.url("empty"));
-        await Map.teleportToPosition(page2, 16, 4 * 32 + 16);
+        await Map.teleportToPosition(page2, 16, 6 * 32 + 16);
 
         // Alice starts a slow pathfinding walk towards the middle of the area (speed 2 ≈ 40px/s, the
         // area border is ~2s away), and the admin locks the area while she is on her way.
-        await Map.startMoveTo(page2, 4 * 32 + 16, 4 * 32 + 16, 2);
+        await Map.startMoveTo(page2, 4 * 32 + 16, 6 * 32 + 16, 2);
         await page.getByTestId("lock-button").click();
         await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
 
@@ -206,13 +208,13 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         expect(alicePositionAfterStop.x).toBeLessThan(3 * 32);
         await expect(page2.getByText("This area is locked. You cannot enter.")).toBeAttached();
 
-        // The admin unlocks, Alice goes back to her starting point and walks towards the other side
-        // of the wall; the admin locks it again while she is on her way.
+        // Alice goes back to her starting point, then the admin unlocks. She then walks towards the
+        // other side of the wall and the admin locks it again while she is on her way.
+        await Map.teleportToPosition(page2, 16, 6 * 32 + 16);
         await page.getByTestId("lock-button").click();
         await expect(page.getByTestId("lock-button")).not.toHaveClass(/bg-danger/);
-        await Map.teleportToPosition(page2, 16, 4 * 32 + 16);
 
-        await Map.startMoveTo(page2, 8 * 32 + 16, 4 * 32 + 16, 2);
+        await Map.startMoveTo(page2, 8 * 32 + 16, 6 * 32 + 16, 2);
         await page.getByTestId("lock-button").click();
         await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
 

--- a/tests/tests/map_editor/map_editor_lock_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_lock_area.spec.ts
@@ -174,10 +174,7 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         expect(adminPositionAfterUnlock.x).toBeGreaterThan(areaLeftBoundX);
     });
 
-    test("Locking an area mid-walk stops a pathfinding move at the border with a warning", async ({
-        browser,
-        request,
-    }) => {
+    test("Locking an area mid-walk stops or reroutes a pathfinding move", async ({ browser, request }) => {
         await resetWamMaps(request);
         await using page = await getPage(browser, "Admin1", Map.url("empty"));
 
@@ -201,43 +198,28 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         await page.getByTestId("lock-button").click();
         await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
 
-        // Alice walks up to the border, stops there and gets warned.
-        const result = await Map.waitForMoveToResult(page2);
-        expect(result.cancelled).toBe(true);
-
-        // Alice came from the left, so stopping outside the area means stopping left of column 3.
-        const alicePosition = await Map.getPosition(page2);
-        expect(alicePosition.x).toBeLessThan(3 * 32);
+        // Alice walks up to the border, stops there and gets warned. She came from the left, so
+        // stopping outside the area means stopping left of column 3.
+        const stopResult = await Map.waitForMoveToResult(page2);
+        expect(stopResult.cancelled).toBe(true);
+        const alicePositionAfterStop = await Map.getPosition(page2);
+        expect(alicePositionAfterStop.x).toBeLessThan(3 * 32);
         await expect(page2.getByText("This area is locked. You cannot enter.")).toBeAttached();
-    });
 
-    test("Locking an area mid-walk reroutes a pathfinding move around it", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
-
-        // Same vertical wall: a detour exists through row 0 and rows 7-9.
-        await Menu.openMapEditor(page);
-        await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 3 * 32, y: 1 * 32 }, { x: 6 * 32, y: 7 * 32 });
-        await AreaEditor.addProperty(page, "lockableAreaPropertyData");
-        await Menu.closeMapEditor(page);
-
-        await Map.teleportToPosition(page, 4 * 32 + 16, 4 * 32);
-        await expect(page.getByTestId("lock-button")).toBeVisible();
-
-        await using page2 = await getPage(browser, "Alice", Map.url("empty"));
+        // The admin unlocks, Alice goes back to her starting point and walks towards the other side
+        // of the wall; the admin locks it again while she is on her way.
+        await page.getByTestId("lock-button").click();
+        await expect(page.getByTestId("lock-button")).not.toHaveClass(/bg-danger/);
         await Map.teleportToPosition(page2, 16, 4 * 32 + 16);
 
-        // Alice walks towards the other side of the wall; the admin locks it while she is on her way.
         await Map.startMoveTo(page2, 8 * 32 + 16, 4 * 32 + 16, 2);
         await page.getByTestId("lock-button").click();
         await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
 
         // Alice is rerouted around the locked area and still reaches her destination.
-        const result = await Map.waitForMoveToResult(page2);
-        expect(result.cancelled).toBe(false);
-
-        const alicePosition = await Map.getPosition(page2);
-        expect(alicePosition.x).toBeGreaterThan(6 * 32);
+        const rerouteResult = await Map.waitForMoveToResult(page2);
+        expect(rerouteResult.cancelled).toBe(false);
+        const alicePositionAfterReroute = await Map.getPosition(page2);
+        expect(alicePositionAfterReroute.x).toBeGreaterThan(6 * 32);
     });
 });

--- a/tests/tests/map_editor/map_editor_lock_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_lock_area.spec.ts
@@ -173,4 +173,71 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         const adminPositionAfterUnlock = await Map.getPosition(page);
         expect(adminPositionAfterUnlock.x).toBeGreaterThan(areaLeftBoundX);
     });
+
+    test("Locking an area mid-walk stops a pathfinding move at the border with a warning", async ({
+        browser,
+        request,
+    }) => {
+        await resetWamMaps(request);
+        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+
+        // A vertical lockable wall covering columns 3-5, leaving row 0 and rows 7-9 free.
+        await Menu.openMapEditor(page);
+        await MapEditor.openAreaEditor(page);
+        await AreaEditor.drawArea(page, { x: 3 * 32, y: 1 * 32 }, { x: 6 * 32, y: 7 * 32 });
+        await AreaEditor.addProperty(page, "lockableAreaPropertyData");
+        await Menu.closeMapEditor(page);
+
+        // The admin stays inside the area to be able to lock it while Alice walks.
+        await Map.teleportToPosition(page, 4 * 32 + 16, 4 * 32);
+        await expect(page.getByTestId("lock-button")).toBeVisible();
+
+        await using page2 = await getPage(browser, "Alice", Map.url("empty"));
+        await Map.teleportToPosition(page2, 16, 4 * 32 + 16);
+
+        // Alice starts a slow pathfinding walk towards the middle of the area (speed 2 ≈ 40px/s, the
+        // area border is ~2s away), and the admin locks the area while she is on her way.
+        await Map.startMoveTo(page2, 4 * 32 + 16, 4 * 32 + 16, 2);
+        await page.getByTestId("lock-button").click();
+        await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
+
+        // Alice walks up to the border, stops there and gets warned.
+        const result = await Map.waitForMoveToResult(page2);
+        expect(result.cancelled).toBe(true);
+
+        // Alice came from the left, so stopping outside the area means stopping left of column 3.
+        const alicePosition = await Map.getPosition(page2);
+        expect(alicePosition.x).toBeLessThan(3 * 32);
+        await expect(page2.getByText("This area is locked. You cannot enter.")).toBeAttached();
+    });
+
+    test("Locking an area mid-walk reroutes a pathfinding move around it", async ({ browser, request }) => {
+        await resetWamMaps(request);
+        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+
+        // Same vertical wall: a detour exists through row 0 and rows 7-9.
+        await Menu.openMapEditor(page);
+        await MapEditor.openAreaEditor(page);
+        await AreaEditor.drawArea(page, { x: 3 * 32, y: 1 * 32 }, { x: 6 * 32, y: 7 * 32 });
+        await AreaEditor.addProperty(page, "lockableAreaPropertyData");
+        await Menu.closeMapEditor(page);
+
+        await Map.teleportToPosition(page, 4 * 32 + 16, 4 * 32);
+        await expect(page.getByTestId("lock-button")).toBeVisible();
+
+        await using page2 = await getPage(browser, "Alice", Map.url("empty"));
+        await Map.teleportToPosition(page2, 16, 4 * 32 + 16);
+
+        // Alice walks towards the other side of the wall; the admin locks it while she is on her way.
+        await Map.startMoveTo(page2, 8 * 32 + 16, 4 * 32 + 16, 2);
+        await page.getByTestId("lock-button").click();
+        await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
+
+        // Alice is rerouted around the locked area and still reaches her destination.
+        const result = await Map.waitForMoveToResult(page2);
+        expect(result.cancelled).toBe(false);
+
+        const alicePosition = await Map.getPosition(page2);
+        expect(alicePosition.x).toBeGreaterThan(6 * 32);
+    });
 });

--- a/tests/tests/map_editor/map_editor_lock_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_lock_area.spec.ts
@@ -194,9 +194,11 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         await using page2 = await getPage(browser, "Alice", Map.url("empty"));
         await Map.teleportToPosition(page2, 16, 6 * 32 + 16);
 
-        // Alice starts a slow pathfinding walk towards the middle of the area (speed 2 ≈ 40px/s, the
-        // area border is ~2s away), and the admin locks the area while she is on her way.
-        await Map.startMoveTo(page2, 4 * 32 + 16, 6 * 32 + 16, 2);
+        // Alice starts a slow pathfinding walk towards the vertical middle of the wall (speed 2 ≈
+        // 40px/s, the area border is ~2s away): every neighbouring tile of the destination is inside
+        // the wall too, so once locked the destination is unreachable even for the nearest-available
+        // fallback. The admin locks the area while she is on her way.
+        await Map.startMoveTo(page2, 4 * 32 + 16, 3 * 32 + 16, 2);
         await page.getByTestId("lock-button").click();
         await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
 

--- a/tests/tests/utils/map.ts
+++ b/tests/tests/utils/map.ts
@@ -53,6 +53,40 @@ class Map {
         );
     }
 
+    /**
+     * Starts a pathfinding walk without awaiting its completion (a slow `speed` makes mid-walk
+     * scenarios deterministic). Retrieve the outcome later with waitForMoveToResult().
+     */
+    async startMoveTo(page: Page, x: number, y: number, speed?: number) {
+        await evaluateScript(
+            page,
+            async ({ x, y, speed }) => {
+                await WA.onInit();
+                const w = window as unknown as {
+                    moveToResult?: Promise<{ x: number; y: number; cancelled: boolean }>;
+                };
+                w.moveToResult = WA.player.moveTo(x, y, speed);
+            },
+            {
+                x,
+                y,
+                speed,
+            },
+        );
+    }
+
+    async waitForMoveToResult(page: Page): Promise<{ x: number; y: number; cancelled: boolean }> {
+        return await evaluateScript(page, async () => {
+            const w = window as unknown as {
+                moveToResult?: Promise<{ x: number; y: number; cancelled: boolean }>;
+            };
+            if (w.moveToResult === undefined) {
+                throw new Error("No moveTo was started with startMoveTo()");
+            }
+            return await w.moveToResult;
+        });
+    }
+
     async getPosition(page: Page): Promise<{ x: number; y: number }> {
         return await evaluateScript(page, async () => {
             await WA.onInit();


### PR DESCRIPTION
Stacked on #6466 (base branch `fix/locked-area-pathfinding`; GitHub will retarget to `master` once it merges).

## The gap left by #6466

#6466 made the pathfinding grid honor blocked areas, but the grid is snapshotted when `GameScene.moveTo()` starts and the path is never reconsidered. Lock a meeting room *while someone is already walking towards you* (chat's **Talk to**, a right click, `WA.player.moveTo`): they enter anyway. Path following runs with `setDirectControl(true)` and re-applies a `setPosition()` per frame computed from the precomputed path, so the area's collider is overridden frame after frame.

## Behavior

- On each tile change during path following (each waypoint shift in `Character.followPath` — EasyStar emits one waypoint per tile), the **next waypoint** is checked against the **live** collision grid (`getCollisionGrid` is cached and lazy — no rebuild unless something actually changed). Only the next waypoint, on purpose: the woka keeps walking up to the obstacle, so the blocked warning always shows next to the area it talks about, and a lock lifted before the woka reaches the area never interrupts the walk.
- The next waypoint started colliding → the path is aborted right before the blocking tile and `GameScene.moveTo()` computes a new route to the **original destination**. If one exists, the woka follows it **silently**.
- Destination not reachable anymore → the woka stops where it is (right at the border) and the blocked-area warning is displayed above it via `Area.displayBlockedWarningMessage()` — the exact same message and admin unlock affordance as a physical collision with the area. No new i18n keys.
- A cancellation from the user taking over (keyboard input, a new right click, teleport) resolves **without** the internal `blocked` flag and never triggers a reroute.
- `MAX_PATH_REROUTES = 5` caps pathological lock/unlock flapping.
- The scripting contract of `WA.player.moveTo` is unchanged: `{ x, y, cancelled }`.

## Implementation notes

- `Character.followPath` gets a protected `onPathWaypointReached()` hook; only `Player` overrides it. `RemotePlayer` is untouched — its movement mirrors server state and must never be cut.
- `PathFollowResult` gains an optional `blocked` flag, consumed inside `GameScene.moveTo()` and stripped from what callers see. `finishFollowingPath` gains an optional `blocked` parameter, forwarded by the two overrides.
- Stored waypoints are collider-adjusted (y shifted up by the body offset); the tile mapping inverts that offset exactly (`play/src/front/Utils/PathValidation.ts`, pure and Phaser-free).
- `Area.displayWarningMessageOnCollide` is now the public `Area.displayBlockedWarningMessage`, shared between physical collisions and the pathfinding stop.
- A player already **inside** an area when it locks never gets a false abort: their grid does not mark the area (`getAreaBlockReason` returns `locked` only when the player is outside), so their exit path stays valid.

## Tests

- `play/tests/front/Utils/PathValidation.test.ts`: pure vitest cases (green, 4/4).
- One E2E test in `map_editor_lock_area.spec.ts` chaining both mid-walk scenarios on a lockable wall, driven by a slow `WA.player.moveTo(x, y, speed)` (the `speed` param passes through unclamped, making mid-walk locking deterministic): stop-at-the-border + warning (destination at the wall's vertical middle so even the nearest-available fallback finds no reachable tile), then unlock and silent reroute around the wall.

## Verified locally

- Typecheck: 0 errors in the touched files (remaining worktree noise is the pre-existing stale `@workadventure/messages` build, unrelated).
- ESLint: clean on all touched files (play linted in a Linux container).
- Vitest: 4/4.
- E2E: CI runs the full suite on this PR.

## Still out of scope

Enforcement remains 100% client-side: the back returns any user's position on request and never validates a destination. A modified client can still go anywhere.