### PR TITLE
feat(front): walk up to an already locked area instead of silently not moving

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -72,7 +72,7 @@ import { TextUtils } from "../Components/TextUtils";
 import { joystickBaseImg, joystickBaseKey, joystickThumbImg, joystickThumbKey } from "../Components/MobileJoystick";
 import { PropertyUtils } from "../Map/PropertyUtils";
 import { analyticsClient } from "../../Administration/AnalyticsClient";
-import { PathfindingManager } from "../../Utils/PathfindingManager";
+import { PathfindingManager, PathTileType } from "../../Utils/PathfindingManager";
 import type {
     GroupCreatedUpdatedMessageInterface,
     MessageUserMovedInterface,
@@ -3903,7 +3903,11 @@ ${escapedMessage}
                 tryFindingNearestAvailable,
             );
             if (path.length === 0) {
-                if (attempt === 0) throw new Error("No path found");
+                if (attempt === 0) {
+                    // The destination is unreachable from the start (typically an already locked area):
+                    // still walk towards it instead of silently doing nothing.
+                    return this.walkTowardsBlockedDestination(position, tryFindingNearestAvailable, speed);
+                }
                 break;
             }
             // eslint-disable-next-line no-await-in-loop
@@ -3916,6 +3920,64 @@ ${escapedMessage}
 
         // The path got blocked mid-walk and the destination is not reachable anymore. The woka already
         // stands right before the blocking tile: warn about the area blocking the destination.
+        this.displayPathBlockedWarning(position);
+        return { x: this.CurrentPlayer.x, y: this.CurrentPlayer.y, cancelled: true };
+    }
+
+    /**
+     * The destination is not reachable right now (typically inside an already locked area). Rather than
+     * doing nothing, walks towards it on a path computed as if the blocking areas were walkable: the live
+     * next-waypoint check (see Player.onPathWaypointReached) stops the woka right before the first tile
+     * that really collides, where the blocked-area warning is displayed. If the area gets unlocked while
+     * the woka is walking, it simply reaches the destination.
+     */
+    private async walkTowardsBlockedDestination(
+        position: { x: number; y: number },
+        tryFindingNearestAvailable: boolean,
+        speed: number | undefined,
+    ): Promise<{ x: number; y: number; cancelled: boolean }> {
+        const areasManager = this.gameMapFrontWrapper.areasManager;
+        if (!areasManager) {
+            throw new Error("No path found");
+        }
+
+        // Suggestion grid only: real walls stay, and reality is enforced tile by tile while walking.
+        const pathfindingManager = this.getPathfindingManager();
+        const liveGrid = this.gameMapFrontWrapper.getCollisionGrid({ emitMapChangedEvent: false });
+        const tileDimensions = this.gameMapFrontWrapper.getTileDimensions();
+        const suggestionGrid = liveGrid.map((row) => [...row]);
+        for (const area of areasManager.getCollidingAreas()) {
+            const xStart = Math.max(0, Math.floor(area.x / tileDimensions.width));
+            const xEnd = Math.ceil((area.x + area.width) / tileDimensions.width);
+            const yStart = Math.max(0, Math.floor(area.y / tileDimensions.height));
+            const yEnd = Math.ceil((area.y + area.height) / tileDimensions.height);
+            for (let y = yStart; y < Math.min(yEnd, suggestionGrid.length); y += 1) {
+                for (let x = xStart; x < Math.min(xEnd, suggestionGrid[y].length); x += 1) {
+                    suggestionGrid[y][x] = PathTileType.Walkable;
+                }
+            }
+        }
+
+        pathfindingManager.setCollisionGrid(suggestionGrid);
+        const path = await pathfindingManager
+            .findPathFromGameCoordinates(
+                {
+                    x: this.CurrentPlayer.x,
+                    y: this.CurrentPlayer.y,
+                },
+                position,
+                tryFindingNearestAvailable,
+            )
+            .finally(() => pathfindingManager.setCollisionGrid(liveGrid));
+        if (path.length === 0) {
+            throw new Error("No path found");
+        }
+
+        const result = await this.CurrentPlayer.setPathToFollow(path, speed ?? this.CurrentPlayer.walkingSpeed);
+        if (!result.blocked) {
+            // The area got unlocked while walking and the woka arrived, or the user took over.
+            return { x: result.x, y: result.y, cancelled: result.cancelled };
+        }
         this.displayPathBlockedWarning(position);
         return { x: this.CurrentPlayer.x, y: this.CurrentPlayer.y, cancelled: true };
     }

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3952,9 +3952,7 @@ ${escapedMessage}
             const yStart = Math.max(0, Math.floor(area.y / tileDimensions.height));
             const yEnd = Math.ceil((area.y + area.height) / tileDimensions.height);
             for (let y = yStart; y < Math.min(yEnd, suggestionGrid.length); y += 1) {
-                for (let x = xStart; x < Math.min(xEnd, suggestionGrid[y].length); x += 1) {
-                    suggestionGrid[y][x] = PathTileType.Walkable;
-                }
+                suggestionGrid[y].fill(PathTileType.Walkable, xStart, xEnd);
             }
         }
 

--- a/tests/tests/map_editor/map_editor_lock_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_lock_area.spec.ts
@@ -225,5 +225,17 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         expect(rerouteResult.cancelled).toBe(false);
         const alicePositionAfterReroute = await Map.getPosition(page2);
         expect(alicePositionAfterReroute.x).toBeGreaterThan(6 * 32);
+
+        // Walking towards an ALREADY locked area must not be a silent no-op: Alice goes back to her
+        // starting point and walks towards the middle of the wall (still locked). She walks up to the
+        // border, stops there and gets the warning.
+        await Map.teleportToPosition(page2, 16, 6 * 32 + 16);
+        await Map.startMoveTo(page2, 4 * 32 + 16, 3 * 32 + 16, 2);
+        const alreadyLockedResult = await Map.waitForMoveToResult(page2);
+        expect(alreadyLockedResult.cancelled).toBe(true);
+        const alicePositionAfterPreLockedWalk = await Map.getPosition(page2);
+        expect(alicePositionAfterPreLockedWalk.x).toBeGreaterThan(1 * 32);
+        expect(alicePositionAfterPreLockedWalk.x).toBeLessThan(3 * 32);
+        await expect(page2.getByText("This area is locked. You cannot enter.")).toBeAttached();
     });
 });


### PR DESCRIPTION
Stacked on #6472 (base branch `feat/reroute-path-on-collision-change`), which is itself stacked on #6466.

## The gap

#6466 + #6472 handle the grid and the mid-walk locking, but the *already locked* case was a dead end: **Talk to** (or a right click, or `WA.player.moveTo`) towards a locked area found no path, threw `No path found`, and the callers swallow it — the woka did not move a pixel and no message was displayed. To the user it looks like a broken button.

## Behavior

When the initial pathfinding finds no route to the destination, the move now **walks towards it anyway**:

- A *suggestion* path is computed on a copy of the collision grid where the tiles covered by blocking areas are cleared — **real walls are kept**, so a destination that is unreachable even without the areas still rejects with `No path found`, unchanged.
- The suggestion is only a suggestion: reality stays enforced tile by tile by the live next-waypoint check from #6472 (`Player.onPathWaypointReached`), so the woka stops right before the area border, where the usual blocked-area warning (`Area.displayBlockedWarningMessage`, admin unlock affordance included) is displayed.
- If the area gets unlocked while the woka is on its way, the next-waypoint check never fires and the woka simply reaches the destination — consistent with the mid-walk semantics of #6472.
- A user cancellation (keyboard, new right click, teleport) during the walk resolves `cancelled: true` with no warning, as everywhere else.

Everything reuses the #6472 machinery; the whole change is one private method in `GameScene` plus a 5-line hook in the `moveTo()` loop.

## Tests

Third scenario appended to the mid-walk E2E test (`map_editor_lock_area.spec.ts`): with the wall still locked, Alice starts a slow walk towards its middle — she must actually move (position advanced past column 1), stop before the wall (left of column 3), resolve `cancelled: true`, and get the "This area is locked" warning.

## Verified locally

- Typecheck: 0 errors on the touched files; ESLint clean (play linted in a Linux container); Prettier clean.
- E2E: CI runs the full suite on this PR.