### PR TITLE
fix(front): keep the tab id in memory instead of sessionStorage

### DIFF
--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -41,8 +41,6 @@ const connectionRetryJitterMs = 500;
 const websocketReconnectingToastId = "websocket-reconnecting-toast";
 
 class ConnectionManager {
-    private static readonly TAB_ID_STORAGE_KEY = "workadventure_tab_id";
-
     private localUser!: LocalUser;
 
     private connexionType?: GameConnexionTypes;
@@ -56,8 +54,11 @@ class ConnectionManager {
     private readonly _roomConnectionStream = new Subject<RoomConnection>();
     public readonly roomConnectionStream = this._roomConnectionStream.asObservable();
 
-    // Unique identifier for this browser tab, kept across reloads but remains scoped to the tab context.
-    private readonly _tabId: string = ConnectionManager.getOrCreateTabId();
+    // Unique identifier for this page load, used by the back to kill the stale connection of a previous
+    // RoomConnection from the same tab. Deliberately NOT persisted in sessionStorage: "Duplicate tab" and
+    // "Reopen closed tab" copy sessionStorage, which would give two live pages the same id and make them
+    // kill each other's connection in a loop.
+    private readonly _tabId: string = uuidv4();
 
     get unloading() {
         return this._unloading;
@@ -70,21 +71,6 @@ class ConnectionManager {
             this._unloading = true;
             if (this.reconnectingTimeout) clearTimeout(this.reconnectingTimeout);
         });
-    }
-
-    private static getOrCreateTabId(): string {
-        try {
-            const existingTabId = sessionStorage.getItem(ConnectionManager.TAB_ID_STORAGE_KEY);
-            if (existingTabId) {
-                return existingTabId;
-            }
-
-            const tabId = uuidv4();
-            sessionStorage.setItem(ConnectionManager.TAB_ID_STORAGE_KEY, tabId);
-            return tabId;
-        } catch {
-            return uuidv4();
-        }
     }
 
     /**


### PR DESCRIPTION
## Why

The tab id exists so the back can immediately kill the stale connection of a previous `RoomConnection` from the same page (`GameRoom.join`). Since #6108 it is persisted in `sessionStorage`. That brings no benefit: the transport-resume mechanism only lives inside one `WorkAdventureWebSocket` instance, and analytics merely display the id. It has a real cost though: "Duplicate tab" and "Reopen closed tab" copy `sessionStorage`, so two live pages end up with the same tab id.

We hit this on staging: the back killed each page's connection in turn, the pusher grafted the old page's resumed transport onto the new page's logical session, and the surviving front kept a `userId` that no longer matched the pusher's. Every `updateSpaceUserMessage` from that user was then rejected with `spaceUser not found`, so screen sharing in a P2P bubble was never visible to the other participant.

## What

Revert `ConnectionManager` to a per-page-load `uuidv4()` tab id, with a comment explaining why it must not be persisted.

## Related

Part of a series of independent fixes for the same incident:
- this PR: tab id in memory
- close the failed connection before retrying (`ConnectionManager`)
- per-connection id checked before a transport resume (pusher)
- dedicated close code when the pusher destroys a session
- pusher `Space` update lookup by socket instead of uuid fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
