### PR TITLE
fix(front): close a failed room connection before retrying

### DIFF
--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -436,15 +436,17 @@ class ConnectionManager {
         retryAttempt = 0,
     ): Promise<OnConnectInterface> {
         Sentry.setTag("roomId", roomUrl);
-        let connection: RoomConnection | undefined;
+        let pendingConnection: RoomConnection | undefined;
         return new Promise<OnConnectInterface>((resolve, reject) => {
-            connection = new RoomConnection(
+            const connection = new RoomConnection(
                 this.authToken,
                 roomUrl,
                 characterTextureIds,
                 companionTextureId,
                 lastCommandId,
             );
+
+            pendingConnection = connection;
 
             // The websocketErrorStream stream is completed in the RoomConnection. No need to unsubscribe.
             //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
@@ -518,7 +520,7 @@ class ConnectionManager {
 
             // The failed connection must not outlive this attempt: its WorkAdventureWebSocket would otherwise keep
             // trying to resume its transport (with the same tab id) next to the fresh connection created by the retry.
-            connection?.closeConnection();
+            pendingConnection?.closeConnection();
 
             errorScreenStore.setError(
                 ErrorScreenMessage.fromPartial({

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -436,8 +436,9 @@ class ConnectionManager {
         retryAttempt = 0,
     ): Promise<OnConnectInterface> {
         Sentry.setTag("roomId", roomUrl);
+        let connection: RoomConnection | undefined;
         return new Promise<OnConnectInterface>((resolve, reject) => {
-            const connection = new RoomConnection(
+            connection = new RoomConnection(
                 this.authToken,
                 roomUrl,
                 characterTextureIds,
@@ -514,6 +515,10 @@ class ConnectionManager {
                 });
         }).catch((err) => {
             console.info("connectToRoomSocket => catch => new Promise[OnConnectInterface] => err", err);
+
+            // The failed connection must not outlive this attempt: its WorkAdventureWebSocket would otherwise keep
+            // trying to resume its transport (with the same tab id) next to the fresh connection created by the retry.
+            connection?.closeConnection();
 
             errorScreenStore.setError(
                 ErrorScreenMessage.fromPartial({


### PR DESCRIPTION
## Why

`ConnectionManager.connectToRoomSocket` rejects on `websocketErrorStream` and retries with a brand-new `RoomConnection`, but never closes the one that failed. Its `WorkAdventureWebSocket` is not marked as manually closed, so once the browser reports the error close (code 1006) it keeps trying to resume its transport, with the same tab id, for up to `CLIENT_DISCONNECTION_RETENTION_MS`, right next to the fresh connection created by the retry.

Two live sockets from one page then fight over the tab id: the back kills one on each join, and the pusher can graft the stale socket's resume onto the new logical session. A page must never have more than one live room socket.

## What

Hoist the `connection` variable and call `closeConnection()` in the retry `catch` before scheduling the next attempt. `closeConnection()` closes the socket with 1000, which stops any resume attempt.

No unit test: `ConnectionManager` is a singleton pulling in the game manager and most stores, and the change is a single guarded call. The regression is covered by the pusher-side check in the companion PR.

## Related

Part of a series of independent fixes for the same staging incident (see #6484).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
