### PR TITLE
Tolerate the Firefox 153 SessionStore crash on context teardown

### DIFF
--- a/tests/tests/utils/auth.ts
+++ b/tests/tests/utils/auth.ts
@@ -22,23 +22,42 @@ import { dismissNoBrowserSoundInfoToast } from "./doNotDisturbInfoToast";
  * `Page` already implements `Symbol.asyncDispose` as `close()`, so patching `close` is all it takes
  * for `await using page = await getPage(...)` to tear the context down as well.
  */
+/**
+ * Firefox 153 (bundled with Playwright 1.62) intermittently throws out of `context.close()`:
+ *
+ *     Protocol error (Browser.removeBrowserContext): can't access property
+ *     "_maybeDontRestoreTabs", this._windows[aWindow.__SSi] is undefined
+ *
+ * `SessionStore.maybeDontRestoreTabs()` indexes `this._windows[aWindow.__SSi]` with no guard, so it
+ * throws when juggler closes the last tab of a window SessionStore is no longer tracking. It is
+ * purely teardown-time bookkeeping for session restore, which tests never use, and every assertion
+ * in the test has already run by the time it fires — but it still fails the test.
+ *
+ * This is a workaround, not a fix. Firefox bails out of `closeWindow()` before it reaches
+ * `window.close()`, so the window it failed to close leaks for the rest of the worker. That happens
+ * whether or not we rethrow, so swallowing costs nothing beyond hiding the leak. Drop this once the
+ * upstream bug is fixed.
+ */
+async function closeContext(context: BrowserContext): Promise<void> {
+    try {
+        await context.close();
+    } catch (e) {
+        if (!(e instanceof Error)) {
+            throw e;
+        }
+        if (e.message.includes("has been closed") || e.message.includes("_maybeDontRestoreTabs")) {
+            return;
+        }
+        throw e;
+    }
+}
+
 function disposeWithContext(page: Page): Page {
     const context = page.context();
     let closePromise: Promise<void> | undefined;
 
-    const closeContext = async () => {
-        try {
-            await context.close();
-        } catch (e) {
-            if (e instanceof Error && e.message.includes("has been closed")) {
-                return;
-            }
-            throw e;
-        }
-    };
-
     page.close = () => {
-        closePromise ??= closeContext();
+        closePromise ??= closeContext(context);
         return closePromise;
     };
 
@@ -147,7 +166,7 @@ async function createUser(
 
     // Closing the context closes its pages; closing the page first is the redundant second teardown
     // that Firefox 153 chokes on. See `disposeWithContext`.
-    await context.close();
+    await closeContext(context);
 }
 
 export async function getPage(


### PR DESCRIPTION
Stacked on top of #6481, which is stacked on #6259.

## What still fails

#6481 cut the teardown crashes from 64 to 12, but firefox 1/4 still fails on the same two tests: `api_players.spec.ts:313` ("variable persistence for anonymous users") and `:319` ("variable persistence for logged users").

## What the traces show

I pulled the traces for both failing tests. They have the identical shape:

| | anonymous | logged (@oidc) |
|---|---|---|
| Bob's context closes (`page2`, inside `runPersistenceTest`) | 5.82s ✓ | 36.76s ✓ |
| Alice's context closes (`await using page`) | 6.21s **✗** | 37.90s **✗** |
| third context closes (After Hooks) | 6.29s ✓ | 38.05s ✓ |

So it is **the second of two context closes in quick succession** that trips — 0.4s apart in one, 1.1s in the other. Not a specific page, and not a double close: #6481 already removed the redundant `page.close()`, and this still fires from a lone `await context.close()` at `auth.ts:31`.

Both tests are among the few that create two `getPage()` contexts and tear them down close together, which is why they are the ones left failing.

## Why this is a workaround, not a fix

The fault is in Firefox, and reachable from a single well-formed `context.close()`:

```js
// SessionStore.sys.mjs
maybeDontRestoreTabs(aWindow) {
  this._windows[aWindow.__SSi]._maybeDontRestoreTabs = true;   // no guard
},
```

```js
// globalOverlay.js — closeWindow()
if (aClose) {
  window.SessionStore?.maybeDontRestoreTabs(window);   // throws here
}
...
if (aClose) {
  window.close();      // never reached
  return window.closed;
}
```

`window.SessionStore?.` guards the object, not `this._windows[aWindow.__SSi]` inside it. When juggler closes the last tab of a window SessionStore is no longer tracking, this throws.

There is nothing to fix on our side: it is session-restore bookkeeping, which tests never use, and every assertion in the test has already run by the time it fires.

Note it also means **Firefox never reaches `window.close()`**, so the window leaks — but that is true whether or not we rethrow. Swallowing costs nothing beyond hiding a leak that already exists, and it stops a browser bug from failing otherwise-passing tests.

## Change

One helper, used at both context-close sites (`disposeWithContext` and `createUser` — the latter was closing its context bare and accounted for 6 of the original 38 occurrences). It tolerates exactly two messages: the pre-existing `has been closed`, and `_maybeDontRestoreTabs`. Everything else still throws.

Worth reporting upstream to Playwright; I have a clean signature and a 0-on-Firefox-150 / 64-on-Firefox-153 A/B for the report.

## Unrelated finding, not included here

All **22** spec files with a `test.beforeEach(async ({ page, ... }))` use that `page` fixture for exactly one thing: `isMobile(page)`, which only reads `page.viewportSize()` — pure config. Destructuring `page` makes Playwright build a whole extra browser context and page for every test in those files, purely to read a configured viewport. That is the third context in the table above. Switching those hooks to the `viewport` test option would drop it. Left out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)