### PR TITLE
fix(pusher): only resume a transport onto the connection it left

### DIFF
--- a/play/src/front/Connection/WorkAdventureWebSocket.ts
+++ b/play/src/front/Connection/WorkAdventureWebSocket.ts
@@ -5,6 +5,7 @@ import {
     type ServerToClientMessage,
 } from "@workadventure/messages";
 import { BehaviorSubject } from "rxjs";
+import { v4 as uuidv4 } from "uuid";
 import { NoncedMessageStore } from "../../common/NoncedMessageStore";
 import { CLIENT_DISCONNECTION_RETENTION_MS } from "../Enum/EnvironmentVariable";
 import { analyticsClient } from "../Administration/AnalyticsClient";
@@ -30,6 +31,9 @@ export class WorkAdventureWebSocket {
 
     private readonly url: URL;
     private readonly protocols: string[] | undefined;
+    // Identifies this logical connection to the pusher. Successive RoomConnections of one page share the tab id,
+    // so the pusher needs this to make sure a resumed transport lands on the session it left and not on a newer one.
+    private readonly connectionId = uuidv4();
     private manuallyClosed = false;
     private reconnectAttempted = false;
     private reconnectAttempt = 0;
@@ -167,6 +171,7 @@ export class WorkAdventureWebSocket {
 
     private createSocket(): WebSocket {
         const socketUrl = new URL(this.url.toString());
+        socketUrl.searchParams.set("connectionId", this.connectionId);
         if (this.reconnectAttempted) {
             socketUrl.searchParams.set("lastReceivedNonce", this.lastReceivedNonce.toString());
         }

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -275,6 +275,7 @@ export class IoSocketController {
                 cameraState: z.string().transform((val) => val === "true"),
                 microphoneState: z.string().transform((val) => val === "true"),
                 tabId: z.string(),
+                connectionId: z.string().optional(),
             }),
             upgrade: async ({ query, request, isAborted, upgrade, reject }) => {
                 debug(
@@ -466,6 +467,7 @@ export class IoSocketController {
                         microphoneState,
                         cameraState,
                         tabId: query.tabId,
+                        connectionId: query.connectionId,
                         attendeesState: false,
                         queryAbortControllers: new Map<number, AbortController>(),
                         canRecord: userData.canRecord ?? false,

--- a/play/src/pusher/models/Websocket/SocketData.ts
+++ b/play/src/pusher/models/Websocket/SocketData.ts
@@ -58,6 +58,9 @@ export type ConnectingSocketData = {
     cameraState: boolean;
     // Unique identifier for the browser tab, captured as early as websocket upgrade.
     tabId: string;
+    // Unique identifier of the front WorkAdventureWebSocket instance. A transport resume is only accepted onto the
+    // logical connection carrying the same id. Undefined for fronts predating this parameter.
+    connectionId?: string;
     attendeesState: boolean;
     // The abort controllers for each queries received
     queryAbortControllers: Map<number, AbortController>;

--- a/play/src/pusher/services/PusherRoomSocketController.ts
+++ b/play/src/pusher/services/PusherRoomSocketController.ts
@@ -39,6 +39,7 @@ type CloseHandler = (socket: PusherWebSocket, code: number, reason: string) => v
 
 type RoomWsQuery = {
     tabId: string;
+    connectionId?: string;
 };
 
 type RoomWsQueryValidator<TQuery extends RoomWsQuery> = ZodObject<ZodRawShape, "strip", ZodTypeAny, TQuery>;
@@ -138,6 +139,12 @@ export class PusherRoomSocketController {
         }
 
         if ("roomId" in query && typeof query.roomId === "string" && query.roomId !== socketData.roomId) {
+            return false;
+        }
+
+        // A newer connection from the same tab may own the tab context by now: only the WorkAdventureWebSocket
+        // that opened this logical connection is allowed to resume it.
+        if (query.connectionId !== socketData.connectionId) {
             return false;
         }
 

--- a/play/src/pusher/services/PusherWebSocket.ts
+++ b/play/src/pusher/services/PusherWebSocket.ts
@@ -231,6 +231,14 @@ export class PusherWebSocket {
             return false;
         }
 
+        if (previousSocketData.connectionId !== newSocketData.connectionId) {
+            console.warn(
+                `Cannot replace WebSocket transport for user ${socketData.userUuid} on tab ${socketData.tabId}: connection id mismatch (previous=${previousSocketData.connectionId}, new=${newSocketData.connectionId})`,
+            );
+            newSocket.end(1008, "Cannot replace socket: connection id mismatch");
+            return false;
+        }
+
         // Keep logical connection state (room/back stream/subscriptions) while swapping only the transport.
         Object.assign(newSocketData, previousSocketData);
 

--- a/play/tests/pusher/PusherRoomSocketController.test.ts
+++ b/play/tests/pusher/PusherRoomSocketController.test.ts
@@ -263,6 +263,42 @@ describe("PusherRoomSocketController reconnect retention", () => {
     });
 });
 
+describe("PusherRoomSocketController transport resume identity", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const canReplace = (controller: PusherRoomSocketController, query: object, socket: PusherWebSocket) =>
+        (
+            controller as unknown as {
+                canReplaceTransportWithoutUpgrade: (query: object, protocol: string, ctx: object) => boolean;
+            }
+        ).canReplaceTransportWithoutUpgrade(query, "token", { socket });
+
+    it("refuses to resume onto a logical connection opened by another WorkAdventureWebSocket", () => {
+        const controller = createController(() => {});
+        const retained = createPusherWebSocket(createSocket({ tabId: "tab-1", connectionId: "newer-page-socket" }));
+
+        expect(canReplace(controller, { tabId: "tab-1", connectionId: "stale-page-socket" }, retained)).toBe(false);
+        expect(canReplace(controller, { tabId: "tab-1", connectionId: "newer-page-socket" }, retained)).toBe(true);
+    });
+
+    it("still resumes fronts that do not send a connection id", () => {
+        const controller = createController(() => {});
+        const retained = createPusherWebSocket(createSocket({ tabId: "tab-1", connectionId: undefined }));
+
+        expect(canReplace(controller, { tabId: "tab-1" }, retained)).toBe(true);
+    });
+
+    it("rejects a replacement socket carrying a different connection id", () => {
+        const previous = createPusherWebSocket(createSocket({ connectionId: "a" }));
+        const replacement = createSocket({ connectionId: "b" });
+
+        expect(previous.replaceSocket(replacement, 0)).toBe(false);
+        expect(getEndMock(replacement)).toHaveBeenCalledWith(1008, "Cannot replace socket: connection id mismatch");
+    });
+});
+
 describe("PusherWebSocket backpressure", () => {
     afterEach(() => {
         vi.useRealTimers();


### PR DESCRIPTION
## Why

The pusher keys transport resumes by tab id alone (`contextByTabKey`). Successive `RoomConnection`s of one page share that id by design (the back's ghost kill needs it), and a fresh connection overwrites the tab context while the previous logical session is still alive. A stale `WorkAdventureWebSocket` resuming with `lastReceivedNonce` was therefore grafted onto whichever session currently owned the tab id:

- `hasEveryNonceAfter(2408)` is vacuously true for a session that has only sent 14 messages;
- `replaceSocket` copies the retained session's socket data (including its `userId`) under a front that still believes it is the old user.

On staging this left a user whose front said `wa-village_187` while the pusher said `wa-village_207`. Every `updateSpaceUserMessage` was rejected, so their screen share never reached the other peer.

## What

- Front: `WorkAdventureWebSocket` generates one `connectionId` per instance and sends it as a query param on every connect and resume.
- Pusher: the id is stored in `SocketData` and a resume is refused when it differs, in `canReplaceTransportWithoutUpgrade` (query vs retained session, so the old socket data is not copied onto the new transport) and in `replaceSocket` (previous vs new socket data, covering the open-path replacement).
- Fronts that do not send the id keep today's behaviour: `undefined === undefined`.

## Tests

`tests/pusher/PusherRoomSocketController.test.ts`: refuses a mismatched id before upgrade, accepts a matching or absent one, and `replaceSocket` ends a mismatched replacement with 1008.

## Related

Part of a series of independent fixes for the same incident (see #6484, #6485).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
