### PR TITLE
fix(pusher): dedicated close code when the pusher destroys a session

### DIFF
--- a/play/src/common/WebSocketCloseCodes.ts
+++ b/play/src/common/WebSocketCloseCodes.ts
@@ -1,0 +1,10 @@
+/**
+ * Application-level WebSocket close codes shared by the front and the pusher.
+ * RFC 6455 reserves 4000-4999 for private use.
+ */
+
+/**
+ * Sent by the pusher once it has destroyed the logical session (left the room and the spaces).
+ * A transport resume is pointless after it; the front must open a fresh connection.
+ */
+export const WS_CLOSE_CODE_SESSION_DESTROYED = 4000;

--- a/play/src/front/Connection/WorkAdventureWebSocket.ts
+++ b/play/src/front/Connection/WorkAdventureWebSocket.ts
@@ -6,6 +6,7 @@ import {
 } from "@workadventure/messages";
 import { BehaviorSubject } from "rxjs";
 import { NoncedMessageStore } from "../../common/NoncedMessageStore";
+import { WS_CLOSE_CODE_SESSION_DESTROYED } from "../../common/WebSocketCloseCodes";
 import { CLIENT_DISCONNECTION_RETENTION_MS } from "../Enum/EnvironmentVariable";
 import { analyticsClient } from "../Administration/AnalyticsClient";
 
@@ -181,8 +182,9 @@ export class WorkAdventureWebSocket {
     }
 
     private shouldReconnect(event: CloseEvent): boolean {
-        // Do not reconnect if handshake/auth was refused.
-        if (event.code === 1000 || event.code === 1008) {
+        // Do not reconnect if handshake/auth was refused, or if the pusher destroyed the session: a resume could only
+        // land on a session that is not ours (another connection of the same tab). The caller reconnects from scratch.
+        if (event.code === 1000 || event.code === 1008 || event.code === WS_CLOSE_CODE_SESSION_DESTROYED) {
             return false;
         }
         if (this.reconnectStartedAt !== undefined) {

--- a/play/src/pusher/models/PusherRoom.ts
+++ b/play/src/pusher/models/PusherRoom.ts
@@ -8,6 +8,7 @@ import { GRPC_MAX_MESSAGE_SIZE } from "../enums/EnvironmentVariable";
 import { apiClientRepository } from "../services/ApiClientRepository";
 import { socketManager } from "../services/SocketManager";
 import type { PusherWebSocket } from "../services/PusherWebSocket";
+import { WS_CLOSE_CODE_SESSION_DESTROYED } from "../../common/WebSocketCloseCodes";
 import { PositionDispatcher } from "./PositionDispatcher";
 import type { ViewportInterface } from "./Websocket/ViewportMessage";
 import type { ZoneEventListener } from "./Zone";
@@ -224,7 +225,7 @@ export class PusherRoom {
                 // Let's close all connections linked to that room
                 for (const listener of this.listeners) {
                     socketManager.cleanupSocket(listener);
-                    listener.end(1011, "Connection error between pusher and back server");
+                    listener.end(WS_CLOSE_CODE_SESSION_DESTROYED, "Connection error between pusher and back server");
                     console.error("Connection error between pusher and back server", err);
                 }
                 this.backConnectionClosedAbortController.abort();
@@ -239,7 +240,7 @@ export class PusherRoom {
                 for (const listener of this.listeners) {
                     socketManager.cleanupSocket(listener);
                     listener.end(
-                        1011,
+                        WS_CLOSE_CODE_SESSION_DESTROYED,
                         "Room connection closed between pusher and back server " +
                             this.roomUrl +
                             " " +

--- a/play/src/pusher/services/PusherRoomSocketController.ts
+++ b/play/src/pusher/services/PusherRoomSocketController.ts
@@ -10,6 +10,7 @@ import { asError } from "catch-unknown";
 import { CLIENT_DISCONNECTION_RETENTION_MS } from "../enums/EnvironmentVariable";
 import type { ConnectingSocketData } from "../models/Websocket/SocketData";
 import type { UpgradeFailedData } from "../controllers/IoSocketController";
+import { WS_CLOSE_CODE_SESSION_DESTROYED } from "../../common/WebSocketCloseCodes";
 import { PusherWebSocket } from "./PusherWebSocket";
 import type { RawSocket } from "./PusherWebSocket";
 import { validateWebsocketQuery } from "./QueryValidator";
@@ -393,7 +394,7 @@ export class PusherRoomSocketController {
                     socket.markPermanentlyDisconnected();
                     return Promise.resolve(config.close(socket, code, reason));
                 };
-                if (code === 1000 || code === 1001) {
+                if (code === 1000 || code === 1001 || code === WS_CLOSE_CODE_SESSION_DESTROYED) {
                     closePermanently().then(forgetContext, (e) => {
                         console.error(e);
                         forgetContext();

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -66,6 +66,7 @@ import { SpaceConnection } from "../models/SpaceConnection";
 import { ClientNotPartOfSpaceError, SpaceDestroyedError } from "../models/SpaceValidationErrors";
 import type { UpgradeFailedData } from "../controllers/IoSocketController";
 import { eventProcessor } from "../models/eventProcessorInit";
+import { WS_CLOSE_CODE_SESSION_DESTROYED } from "../../common/WebSocketCloseCodes";
 import { clientEventsEmitter } from "./ClientEventsEmitter";
 import { gaugeManager } from "./GaugeManager";
 import { apiClientRepository } from "./ApiClientRepository";
@@ -302,7 +303,11 @@ export class SocketManager implements ZoneEventListener {
                             } else {
                                 console.warn(logMessage);
                             }
-                            this.closeWebsocketConnection(client, 1011, `Back lost: ${connectionCloseReason}`);
+                            this.closeWebsocketConnection(
+                                client,
+                                WS_CLOSE_CODE_SESSION_DESTROYED,
+                                `Back lost: ${connectionCloseReason}`,
+                            );
                         }
                     } catch (e: unknown) {
                         console.error("Error while handling ended connection to back", e);
@@ -322,7 +327,11 @@ export class SocketManager implements ZoneEventListener {
                             err,
                         );
                         if (!client.isDisconnecting()) {
-                            this.closeWebsocketConnection(client, 1011, "Error while connecting to back server");
+                            this.closeWebsocketConnection(
+                                client,
+                                WS_CLOSE_CODE_SESSION_DESTROYED,
+                                "Error while connecting to back server",
+                            );
                         }
                     } catch (e: unknown) {
                         console.error("Error while handling error event in connection to back", e);
@@ -356,7 +365,11 @@ export class SocketManager implements ZoneEventListener {
             }
 
             // Let's close the websocket connection with an error code
-            this.closeWebsocketConnection(client, 1011, "Error while connecting to back server");
+            this.closeWebsocketConnection(
+                client,
+                WS_CLOSE_CODE_SESSION_DESTROYED,
+                "Error while connecting to back server",
+            );
         }
     }
 
@@ -436,7 +449,11 @@ export class SocketManager implements ZoneEventListener {
             }
 
             // Let's close the websocket connection with an error code
-            this.closeWebsocketConnection(client, 1011, "Error while connecting to back server");
+            this.closeWebsocketConnection(
+                client,
+                WS_CLOSE_CODE_SESSION_DESTROYED,
+                "Error while connecting to back server",
+            );
         }
     }
 

--- a/play/tests/front/Connection/WorkAdventureWebSocket.test.ts
+++ b/play/tests/front/Connection/WorkAdventureWebSocket.test.ts
@@ -28,6 +28,8 @@ class FakeWebSocket extends EventTarget {
 }
 
 describe("WorkAdventureWebSocket close codes", () => {
+    let socket: WorkAdventureWebSocket | undefined;
+
     beforeEach(() => {
         vi.useFakeTimers();
         FakeWebSocket.instances = [];
@@ -35,13 +37,16 @@ describe("WorkAdventureWebSocket close codes", () => {
     });
 
     afterEach(() => {
+        // Detaches the window listeners of whichever fake transport is current.
+        socket?.close();
+        socket = undefined;
         WorkAdventureWebSocket.setWebsocketFactory(null);
         vi.useRealTimers();
         vi.restoreAllMocks();
     });
 
     it("resumes the transport after a transient close", () => {
-        const socket = new WorkAdventureWebSocket("ws://pusher/ws/room?tabId=tab");
+        socket = new WorkAdventureWebSocket("ws://pusher/ws/room?tabId=tab");
         const onclose = vi.fn();
         socket.onclose = onclose;
 
@@ -54,7 +59,7 @@ describe("WorkAdventureWebSocket close codes", () => {
     });
 
     it("does not resume after the pusher destroyed the session", () => {
-        const socket = new WorkAdventureWebSocket("ws://pusher/ws/room?tabId=tab");
+        socket = new WorkAdventureWebSocket("ws://pusher/ws/room?tabId=tab");
         const onclose = vi.fn();
         socket.onclose = onclose;
 

--- a/play/tests/front/Connection/WorkAdventureWebSocket.test.ts
+++ b/play/tests/front/Connection/WorkAdventureWebSocket.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/front/Enum/EnvironmentVariable.ts", () => import("../mocks/frontEnvironmentVariableMock"));
+vi.mock("../../../src/front/Administration/AnalyticsClient", () => ({
+    analyticsClient: { socketReconnected: vi.fn(), socketReconnecting: vi.fn() },
+}));
+
+import { WS_CLOSE_CODE_SESSION_DESTROYED } from "../../../src/common/WebSocketCloseCodes";
+import { WorkAdventureWebSocket } from "../../../src/front/Connection/WorkAdventureWebSocket";
+
+class FakeWebSocket extends EventTarget {
+    public static instances: FakeWebSocket[] = [];
+    public readyState: number = WebSocket.CONNECTING;
+    public binaryType = "blob";
+    public send = vi.fn();
+    public close = vi.fn();
+
+    constructor(public readonly url: string) {
+        super();
+        FakeWebSocket.instances.push(this);
+    }
+
+    public serverCloses(code: number): void {
+        this.readyState = WebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close", { code, reason: "", wasClean: true }));
+    }
+}
+
+describe("WorkAdventureWebSocket close codes", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        FakeWebSocket.instances = [];
+        WorkAdventureWebSocket.setWebsocketFactory((url) => new FakeWebSocket(url) as unknown as WebSocket);
+    });
+
+    afterEach(() => {
+        WorkAdventureWebSocket.setWebsocketFactory(null);
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it("resumes the transport after a transient close", () => {
+        const socket = new WorkAdventureWebSocket("ws://pusher/ws/room?tabId=tab");
+        const onclose = vi.fn();
+        socket.onclose = onclose;
+
+        FakeWebSocket.instances[0].serverCloses(1006);
+        vi.advanceTimersByTime(10_000);
+
+        expect(onclose).not.toHaveBeenCalled();
+        expect(FakeWebSocket.instances).toHaveLength(2);
+        expect(new URL(FakeWebSocket.instances[1].url).searchParams.get("lastReceivedNonce")).toBe("0");
+    });
+
+    it("does not resume after the pusher destroyed the session", () => {
+        const socket = new WorkAdventureWebSocket("ws://pusher/ws/room?tabId=tab");
+        const onclose = vi.fn();
+        socket.onclose = onclose;
+
+        FakeWebSocket.instances[0].serverCloses(WS_CLOSE_CODE_SESSION_DESTROYED);
+        vi.advanceTimersByTime(10_000);
+
+        expect(onclose).toHaveBeenCalledOnce();
+        expect(onclose.mock.calls[0][0].code).toBe(WS_CLOSE_CODE_SESSION_DESTROYED);
+        expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+});

--- a/play/tests/pusher/PusherRoomSocketController.test.ts
+++ b/play/tests/pusher/PusherRoomSocketController.test.ts
@@ -14,6 +14,7 @@ vi.mock("@workadventure/messages", () => ({
 }));
 
 import { CLIENT_DISCONNECTION_RETENTION_MS } from "../../src/pusher/enums/EnvironmentVariable";
+import { WS_CLOSE_CODE_SESSION_DESTROYED } from "../../src/common/WebSocketCloseCodes";
 import type { SocketData } from "../../src/pusher/models/Websocket/SocketData";
 import { PusherRoomSocketController } from "../../src/pusher/services/PusherRoomSocketController";
 import { PusherWebSocket, type RawSocket } from "../../src/pusher/services/PusherWebSocket";
@@ -190,6 +191,31 @@ describe("PusherRoomSocketController reconnect retention", () => {
         await flushMicrotasks();
 
         expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retain the tab context after the pusher destroyed the session", async () => {
+        vi.useFakeTimers();
+
+        const close = vi.fn();
+        const controller = createController(
+            (handlers) => {
+                registeredHandlers = handlers;
+            },
+            vi.fn(),
+            close,
+        );
+
+        const socket = createSocket({ tabId: "tab-1" });
+        await registeredHandlers?.open(socket);
+        await registeredHandlers?.close(
+            socket,
+            WS_CLOSE_CODE_SESSION_DESTROYED,
+            new TextEncoder().encode("Back lost").buffer,
+        );
+        await flushMicrotasks();
+
+        expect(close).toHaveBeenCalledWith(expect.any(PusherWebSocket), WS_CLOSE_CODE_SESSION_DESTROYED, "Back lost");
+        expect(getContextMap(controller).has("tab-1")).toBe(false);
     });
 
     it("queues outgoing messages while a transport is closed and flushes them after replacement", async () => {


### PR DESCRIPTION
## Why

The pusher closes a client with 1011 after tearing its logical session down: back connection lost (`SocketManager`, 4 sites) and room stream broken (`PusherRoom`, 2 sites). 1011 is the generic "unexpected server condition" code and the front treats it as resumable: `WorkAdventureWebSocket` reconnects with `lastReceivedNonce`. After a teardown a resume can only be refused (extra round trip) or, when another connection of the same tab owns the tab context, grafted onto that connection. That graft is the mechanism behind the staging incident where a front kept `userId 187` while the pusher knew it as `207`.

## What

- `play/src/common/WebSocketCloseCodes.ts`: `WS_CLOSE_CODE_SESSION_DESTROYED = 4000` (RFC 6455 private range), shared by front and pusher.
- Pusher: the six front-facing sites use it. The two admin-socket sites keep 1011, the admin client is not a `WorkAdventureWebSocket`.
- Pusher `PusherRoomSocketController`: the code joins 1000/1001 in the "close permanently" branch, so the tab context is dropped immediately instead of being retained for the reconnection window.
- Front `shouldReconnect`: the code is terminal, like 1000 and 1008. This does not stop retrying: the close reaches `RoomConnection.handleSocketClose`, which either rejects the connect promise (ConnectionManager retry loop) or emits `serverDisconnected` (successor scene). It only skips the doomed resume.

Rolling deploys are safe in both orders: an old front seeing 4000 resumes, is refused with 1008 and joins fresh (today's behaviour); a new front seeing an old pusher's 1011 recovers the same way.

## Tests

- `tests/front/Connection/WorkAdventureWebSocket.test.ts` (new): 1006 schedules a resume with `lastReceivedNonce`; 4000 fires `onclose` and schedules nothing.
- `tests/pusher/PusherRoomSocketController.test.ts`: a 4000 close runs the logical cleanup immediately and drops the tab context.

## Related

Part of a series of independent fixes for the same incident (see #6484, #6485, #6487).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
