### PR TITLE
fix(pusher): apply updateSpaceUserMessage to the sending socket's user

### DIFF
--- a/play/src/pusher/models/Space.ts
+++ b/play/src/pusher/models/Space.ts
@@ -336,39 +336,23 @@ export class Space implements SpaceForSpaceConnectionInterface {
             return null;
         }
 
-        // Use the spaceUserId from the message to find the correct user
-        // This is important when the same userUuid has multiple connections (e.g., multiple tabs)
-        const messageSpaceUserId = updateSpaceUserMessage.user.spaceUserId;
-        const spaceUser = Array.from(this._localConnectedUserWithSpaceUser.values()).find(
-            (user) => user.spaceUserId === messageSpaceUserId,
-        );
+        // The sending socket is the only identity the pusher can trust. The spaceUserId carried by the message
+        // comes from the front and can be stale, and a lookup by uuid could pick another tab of the same user.
+        const spaceUser = this._localConnectedUserWithSpaceUser.get(client);
         if (!spaceUser) {
-            // Fallback to userUuid for backward compatibility
-            const userUuid = client.getUserData().userUuid;
-            const spaceUserByUuid = Array.from(this._localConnectedUserWithSpaceUser.values()).find(
-                (user) => user.uuid === userUuid,
-            );
-            if (!spaceUserByUuid) {
-                throw new Error(`spaceUser not found by spaceUserId ${messageSpaceUserId} or userUuid ${userUuid}`);
-            }
-            console.warn(
-                `[Space.applyFromUpdateSpaceUserMessage] User found by userUuid fallback, not by spaceUserId. ` +
-                    `messageSpaceUserId: ${messageSpaceUserId}, foundSpaceUserId: ${spaceUserByUuid.spaceUserId}`,
-            );
+            throw new Error(`spaceUser not found for socket ${client.getUserData().spaceUserId} in space ${this.name}`);
         }
 
-        const targetUser =
-            spaceUser ??
-            Array.from(this._localConnectedUserWithSpaceUser.values()).find(
-                (user) => user.uuid === client.getUserData().userUuid,
+        const messageSpaceUserId = updateSpaceUserMessage.user.spaceUserId;
+        if (messageSpaceUserId !== spaceUser.spaceUserId) {
+            console.warn(
+                `[Space.extractUpdatedFieldsFromUpdateSpaceUserMessage] Message spaceUserId ${messageSpaceUserId} does not match the socket's ${spaceUser.spaceUserId}. Applying the update to the socket's user.`,
             );
-        if (!targetUser) {
-            throw new Error(`spaceUser not found for message spaceUserId ${messageSpaceUserId}`);
         }
 
         return {
             changedFields: updateSpaceUserMessage.updateMask,
-            partialSpaceUser: updateSpaceUserMessage.user,
+            partialSpaceUser: { ...updateSpaceUserMessage.user, spaceUserId: spaceUser.spaceUserId },
         };
     }
 

--- a/play/tests/pusher/Space.test.ts
+++ b/play/tests/pusher/Space.test.ts
@@ -234,17 +234,24 @@ describe("Space.extractUpdatedFieldsFromUpdateSpaceUserMessage", () => {
             ...SpaceUser.fromPartial({ spaceUserId: "room_207", uuid: "uuid" }),
             lowercaseName: "fabio",
         });
-        vi.spyOn(console, "warn").mockImplementation(() => {});
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-        const result = space.extractUpdatedFieldsFromUpdateSpaceUserMessage(socket, {
-            spaceName: "test",
-            user: SpaceUser.fromPartial({ spaceUserId: "room_187", screenSharingState: true }),
-            updateMask: ["screenSharingState"],
-        });
+        try {
+            const result = space.extractUpdatedFieldsFromUpdateSpaceUserMessage(socket, {
+                spaceName: "test",
+                user: SpaceUser.fromPartial({ spaceUserId: "room_187", screenSharingState: true }),
+                updateMask: ["screenSharingState"],
+            });
 
-        expect(result?.changedFields).toEqual(["screenSharingState"]);
-        expect(result?.partialSpaceUser.spaceUserId).toBe("room_207");
-        expect(result?.partialSpaceUser.screenSharingState).toBe(true);
+            expect(result?.changedFields).toEqual(["screenSharingState"]);
+            expect(result?.partialSpaceUser.spaceUserId).toBe("room_207");
+            expect(result?.partialSpaceUser.screenSharingState).toBe(true);
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining("room_187 does not match the socket's room_207"),
+            );
+        } finally {
+            warnSpy.mockRestore();
+        }
     });
 
     it("rejects an update from a socket that is not in the space", () => {

--- a/play/tests/pusher/Space.test.ts
+++ b/play/tests/pusher/Space.test.ts
@@ -207,6 +207,64 @@ describe("Space", () => {
     });
 });
 
+describe("Space.extractUpdatedFieldsFromUpdateSpaceUserMessage", () => {
+    const createSpace = () =>
+        new Space(
+            "test",
+            "test",
+            new EventProcessor(),
+            FilterType.ALL_USERS,
+            vi.fn(),
+            mock<SpaceConnectionInterface>(),
+            "world",
+            [],
+            () => ({}) as unknown as SpaceToBackForwarder,
+            () => ({}) as unknown as SpaceToFrontDispatcher,
+        );
+
+    const createSocket = (spaceUserId: string) =>
+        mock<PusherWebSocket>({
+            getUserData: vi.fn().mockReturnValue({ spaceUserId, userUuid: "uuid" }),
+        });
+
+    it("applies the update to the socket's user even when the message carries a stale spaceUserId", () => {
+        const space = createSpace();
+        const socket = createSocket("room_207");
+        space._localConnectedUserWithSpaceUser.set(socket, {
+            ...SpaceUser.fromPartial({ spaceUserId: "room_207", uuid: "uuid" }),
+            lowercaseName: "fabio",
+        });
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        const result = space.extractUpdatedFieldsFromUpdateSpaceUserMessage(socket, {
+            spaceName: "test",
+            user: SpaceUser.fromPartial({ spaceUserId: "room_187", screenSharingState: true }),
+            updateMask: ["screenSharingState"],
+        });
+
+        expect(result?.changedFields).toEqual(["screenSharingState"]);
+        expect(result?.partialSpaceUser.spaceUserId).toBe("room_207");
+        expect(result?.partialSpaceUser.screenSharingState).toBe(true);
+    });
+
+    it("rejects an update from a socket that is not in the space", () => {
+        const space = createSpace();
+        const stranger = createSocket("room_1");
+        space._localConnectedUserWithSpaceUser.set(createSocket("room_2"), {
+            ...SpaceUser.fromPartial({ spaceUserId: "room_2", uuid: "uuid" }),
+            lowercaseName: "other",
+        });
+
+        expect(() =>
+            space.extractUpdatedFieldsFromUpdateSpaceUserMessage(stranger, {
+                spaceName: "test",
+                user: SpaceUser.fromPartial({ spaceUserId: "room_2", cameraState: true }),
+                updateMask: ["cameraState"],
+            }),
+        ).toThrow("spaceUser not found");
+    });
+});
+
 describe("SpaceConnection", () => {
     describe("getSpaceStreamToBackPromise", () => {
         it("should create a new spaceStreamToBack if there is no spaceStreamToBack for the backId", async () => {


### PR DESCRIPTION
## Why

`Space.extractUpdatedFieldsFromUpdateSpaceUserMessage` looked the user up by the `spaceUserId` carried in the message, across every socket of the space, and fell back to a uuid match. The fallback was half-implemented: it found a user but returned the message untouched, so `SpaceToBackForwarder.updateUser` then failed with `spaceUser not found` on the stale id. On staging this is what kept a user's `screenSharingState=true` from ever reaching the back, so their P2P screen share was never shown to the other peer:

```
[Space.applyFromUpdateSpaceUserMessage] User found by userUuid fallback, not by spaceUserId. messageSpaceUserId: …/wa-village_187, foundSpaceUserId: …/wa-village_207
Error: spaceUser not found
    at SpaceToBackForwarder.updateUser (SpaceToBackForwarder.ts:139)
```

The message-wide lookup also let a client update another user's fields by sending their id, and the uuid fallback could pick another tab of the same user.

## What

Look the user up by the sending socket (`_localConnectedUserWithSpaceUser.get(client)`), the only identity the pusher can trust, and stamp its `spaceUserId` on the returned partial user. A mismatch with the message's id is still logged so a desynchronised front stays visible in the pusher logs. Net effect is a deletion: one `Map.get` replaces two scans and a fallback.

## Tests

`tests/pusher/Space.test.ts`: an update carrying a stale `spaceUserId` is applied to the socket's user; an update from a socket that is not in the space is rejected.

## Related

Part of a series of independent fixes for the same incident (see #6484, #6485, #6487, #6488). This one alone would have kept screen sharing working for the desynchronised user; the others remove the desynchronisation itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
