### PR TITLE
Read the viewport option instead of building a page to measure it

### DIFF
--- a/tests/tests/api_players.spec.ts
+++ b/tests/tests/api_players.spec.ts
@@ -6,11 +6,11 @@ import { evaluateScript } from "./utils/scripting";
 import { oidcLogin, oidcLogout } from "./utils/oidc";
 import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.describe("API WA.players @nomobile @nowebkit", () => {
-    test.beforeEach(async ({ page, browserName }) => {
-        test.skip(isMobile(page) || browserName === "webkit", "Skip on mobile and WebKit");
+    test.beforeEach(async ({ viewport, browserName }) => {
+        test.skip(isMobileViewport(viewport) || browserName === "webkit", "Skip on mobile and WebKit");
     });
 
     test("enter leave events are received", async ({ browser }) => {

--- a/tests/tests/areas.spec.ts
+++ b/tests/tests/areas.spec.ts
@@ -3,12 +3,12 @@ import { evaluateScript } from "./utils/scripting";
 import { publicTestMapUrl } from "./utils/urls";
 import Menu from "./utils/menu";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 import Map from "./utils/map";
 
 test.describe("Areas @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     test("can edit Tiled area from scripting API", async ({ browser }) => {

--- a/tests/tests/banner_script.spec.ts
+++ b/tests/tests/banner_script.spec.ts
@@ -3,11 +3,11 @@ import { evaluateScript } from "./utils/scripting";
 import { expectInViewport } from "./utils/viewport";
 import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.describe("Modal @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     test("Open banner", async ({ browser }) => {

--- a/tests/tests/browser_not_supported.spec.ts
+++ b/tests/tests/browser_not_supported.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { RENDERER_MODE } from "./utils/environment";
 import { publicTestMapUrl } from "./utils/urls";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.describe("Browser Not Supported Page", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     test("should display browser not supported page when structuredClone is not available", async ({

--- a/tests/tests/buttonactionbar_script.spec.ts
+++ b/tests/tests/buttonactionbar_script.spec.ts
@@ -2,12 +2,12 @@ import { expect, test } from "@playwright/test";
 import { evaluateScript } from "./utils/scripting";
 import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 import Menu from "./utils/menu";
 
 test.describe("action bar @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     test("Buttons in action bar and sub-menus", async ({ browser }) => {

--- a/tests/tests/error_pages.spec.ts
+++ b/tests/tests/error_pages.spec.ts
@@ -2,14 +2,15 @@ import { expect, test } from "@playwright/test";
 import { RENDERER_MODE } from "./utils/environment";
 import { publicTestMapUrl } from "./utils/urls";
 import Map from "./utils/map";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 import { dismissDuplicateUserConnectedModalIfShown } from "./utils/duplicateUserModal";
 import { dismissPwaInstallScreenIfShown } from "./utils/pwaInstall";
 
 test.describe("Error pages @nowebkit", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
+
     test("successfully displayed for unsupported URLs", async ({ page }) => {
         await page.goto(`/@/not/supported?phaserMode=${RENDERER_MODE}`);
         await expect(page.getByText("Unsupported URL format")).toBeVisible();

--- a/tests/tests/iframe_script.spec.ts
+++ b/tests/tests/iframe_script.spec.ts
@@ -3,12 +3,12 @@ import { evaluateScript } from "./utils/scripting";
 import { publicTestMapUrl } from "./utils/urls";
 import Menu from "./utils/menu";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 import Map from "./utils/map";
 
 test.describe("Iframe API @nowebkit", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     test("can be called from an iframe loading a script", async ({ browser }) => {

--- a/tests/tests/map_storage_upload.spec.ts
+++ b/tests/tests/map_storage_upload.spec.ts
@@ -5,15 +5,15 @@ import { createZipFromDirectory } from "./utils/zip";
 import { RENDERER_MODE } from "./utils/environment";
 import { map_storage_url, maps_domain } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.use({
     baseURL: map_storage_url,
 });
 
 test.describe("Map-storage Upload API @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     test("users are asked to reconnect when a map is updated", async ({ request, browser }) => {

--- a/tests/tests/metadata.spec.ts
+++ b/tests/tests/metadata.spec.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "@playwright/test";
 import { maps_domain } from "./utils/urls";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.describe("Meta tags @nomobile @nofirefox @nowebkit", () => {
-    test.beforeEach(async ({ page, browserName }) => {
+    test.beforeEach(async ({ viewport, browserName }) => {
         // Skip test for mobile device
-        test.skip(isMobile(page) || browserName !== "chromium", "Skip on mobile non-Chromium");
+        test.skip(isMobileViewport(viewport) || browserName !== "chromium", "Skip on mobile non-Chromium");
     });
+
     test("check they are populated when the user-agent is a bot. @selfsigned", async ({ request }) => {
         const result = await request.get(`/_/global/${maps_domain}/tests/Properties/mapProperties.json`, {
             headers: {

--- a/tests/tests/mobile/iframe_script.spec.ts
+++ b/tests/tests/mobile/iframe_script.spec.ts
@@ -2,12 +2,12 @@ import { expect, test } from "@playwright/test";
 import { evaluateScript } from "../utils/scripting";
 import { publicTestMapUrl } from "../utils/urls";
 import { getPage } from "../utils/auth";
-import { isMobile } from "../utils/isMobile";
+import { isMobileViewport } from "../utils/isMobile";
 import Menu from "../utils/menu";
 
 test.describe("Iframe API @nodesktop", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(!isMobile(page), "Run only on mobile");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(!isMobileViewport(viewport), "Run only on mobile");
     });
 
     test("disable invite user button", async ({ browser }) => {

--- a/tests/tests/mobile/mobile.spec.ts
+++ b/tests/tests/mobile/mobile.spec.ts
@@ -3,7 +3,7 @@ import Menu from "../utils/menu";
 import Map from "../utils/map";
 import { play_url, publicTestMapUrl } from "../utils/urls";
 import { getPage } from "../utils/auth";
-import { isMobile } from "../utils/isMobile";
+import { isMobileViewport } from "../utils/isMobile";
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -11,8 +11,8 @@ test.use({
 });
 
 test.describe("Mobile @nowebkit @nodesktop", () => {
-    test.beforeEach(async ({ page, browserName }) => {
-        test.skip(!isMobile(page) || browserName === "webkit", "Run only on mobile Chromium");
+    test.beforeEach(async ({ viewport, browserName }) => {
+        test.skip(!isMobileViewport(viewport) || browserName === "webkit", "Run only on mobile Chromium");
     });
 
     test("Successfully bubble discussion with mobile device", async ({ browser }) => {

--- a/tests/tests/mobile/oidc.spec.ts
+++ b/tests/tests/mobile/oidc.spec.ts
@@ -3,14 +3,14 @@ import { oidcLogin, oidcLogout } from "../utils/oidc";
 import { evaluateScript } from "../utils/scripting";
 import { publicTestMapUrl } from "../utils/urls";
 import { getPage } from "../utils/auth";
-import { isMobile } from "../utils/isMobile";
+import { isMobileViewport } from "../utils/isMobile";
 import Menu from "../utils/menu";
 
 test.describe("OpenId connect @oidc mobile @nofirefox @nodesktop", () => {
-    test.beforeEach(async ({ page, browserName }) => {
+    test.beforeEach(async ({ viewport, browserName }) => {
         // skip on firefox because the browser is too slow
         // (this is specific to mobile format make sur it work on a regular format)
-        test.skip(!isMobile(page) || browserName === "firefox", "Run only on mobile non-Firefox");
+        test.skip(!isMobileViewport(viewport) || browserName === "firefox", "Run only on mobile non-Firefox");
     });
 
     // https://github.com/element-hq/synapse/issues/19303 - skip webkit due to synapse v1.144.0 OIDC issues

--- a/tests/tests/modal_script.spec.ts
+++ b/tests/tests/modal_script.spec.ts
@@ -3,12 +3,13 @@ import { evaluateScript } from "./utils/scripting";
 import { expectInViewport } from "./utils/viewport";
 import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.describe("Modal @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
+
     test("Modal script test", async ({ browser }) => {
         // Go to
         await using page = await getPage(browser, "Alice", publicTestMapUrl("tests/E2E/empty.json", "modal_script"));

--- a/tests/tests/modules.spec.ts
+++ b/tests/tests/modules.spec.ts
@@ -2,12 +2,13 @@ import { test } from "@playwright/test";
 import { assertLogMessage, startRecordLogs } from "./utils/log";
 import { getPage } from "./utils/auth";
 import { publicTestMapUrl } from "./utils/urls";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.describe("Module @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
+
     test("loading should work out of the box", async ({ browser }, { project }) => {
         await using page = await getPage(
             browser,

--- a/tests/tests/oidc.spec.ts
+++ b/tests/tests/oidc.spec.ts
@@ -3,12 +3,13 @@ import { oidcLogin, oidcLogout } from "./utils/oidc";
 import { evaluateScript } from "./utils/scripting";
 import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.describe("OpenID connect @oidc @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
+
     // https://github.com/element-hq/synapse/issues/19303 - skip webkit due to synapse v1.144.0 OIDC issues
     test("can login and logout @nomobile @nowebkit", async ({ browser }) => {
         await using page = await getPage(browser, "Alice", publicTestMapUrl("tests/E2E/empty.json", "oidc"));

--- a/tests/tests/reconnect.spec.ts
+++ b/tests/tests/reconnect.spec.ts
@@ -3,13 +3,16 @@ import { publicTestMapUrl } from "./utils/urls";
 import Map from "./utils/map";
 import Menu from "./utils/menu";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.setTimeout(180_000);
 
 test.describe("Connection @nomobile @nowebkit", () => {
-    test.beforeEach(async ({ page, browserName }) => {
-        test.skip(isMobile(page) || browserName === "webkit", "Skip on mobile and WebKit due to limitations");
+    test.beforeEach(async ({ viewport, browserName }) => {
+        test.skip(
+            isMobileViewport(viewport) || browserName === "webkit",
+            "Skip on mobile and WebKit due to limitations",
+        );
     });
 
     test("can succeed even if WorkAdventure starts while pusher is down @slow", async ({ browser }) => {

--- a/tests/tests/responsive_actionbar.spec.ts
+++ b/tests/tests/responsive_actionbar.spec.ts
@@ -2,12 +2,12 @@ import { expect, test } from "@playwright/test";
 import { evaluateScript } from "./utils/scripting";
 import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 import Menu from "./utils/menu";
 
 test.describe("Action bar responsiveness @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     test("Check items in the action bar go in the menu one by one @oidc", async ({ browser }) => {

--- a/tests/tests/scripting_events.spec.ts
+++ b/tests/tests/scripting_events.spec.ts
@@ -2,11 +2,11 @@ import { expect, test } from "@playwright/test";
 import { evaluateScript } from "./utils/scripting";
 import { play_url, publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.describe("Scripting API Events @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     test("events", async ({ browser, request }) => {

--- a/tests/tests/spaces.spec.ts
+++ b/tests/tests/spaces.spec.ts
@@ -1,15 +1,18 @@
 import { expect, test } from "@playwright/test";
 import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 import { getBackDump, getPusherDump } from "./utils/debug";
 import { rebootBack } from "./utils/containers";
 
 test.setTimeout(180_000);
 
 test.describe("Spaces @nomobile @nowebkit", () => {
-    test.beforeEach(async ({ page, browserName }) => {
-        test.skip(isMobile(page) || browserName === "webkit", "Skip on mobile and WebKit, this is a mostly back test");
+    test.beforeEach(async ({ viewport, browserName }) => {
+        test.skip(
+            isMobileViewport(viewport) || browserName === "webkit",
+            "Skip on mobile and WebKit, this is a mostly back test",
+        );
     });
 
     test("purges spaces if back restarts @docker @slow", async ({ browser, request }) => {

--- a/tests/tests/translate.spec.ts
+++ b/tests/tests/translate.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 
 test.describe("Translation @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     test("can be switched to French", async ({ browser }) => {

--- a/tests/tests/userlist.spec.ts
+++ b/tests/tests/userlist.spec.ts
@@ -3,11 +3,11 @@ import Map from "./utils/map";
 import { publicTestMapUrl } from "./utils/urls";
 import chatUtils from "./utils/chat";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobile, isMobileViewport } from "./utils/isMobile";
 
 test.describe("Walk to @nomobile @nowebkit", () => {
-    test.beforeEach(async ({ page, browserName }) => {
-        test.skip(browserName === "webkit" || isMobile(page), "Skip on WebKit and mobile");
+    test.beforeEach(async ({ viewport, browserName }) => {
+        test.skip(browserName === "webkit" || isMobileViewport(viewport), "Skip on WebKit and mobile");
     });
 
     // FIXME: for some reason, this test fails in Helm. Find why

--- a/tests/tests/utils/isMobile.ts
+++ b/tests/tests/utils/isMobile.ts
@@ -1,10 +1,20 @@
-import type { Page } from "@playwright/test";
+import type { Page, ViewportSize } from "@playwright/test";
 
-export function isMobile(page: Page) {
-    /*
-    a width of 1280 and a height of 720 is default on playwright if below it must be a phone
-    return True if it's a phone
-    TODO adapt do make the difference between tablet and phone
-     */
-    return page.viewportSize().width < 1280 && page.viewportSize().height < 750;
+/*
+ * A width of 1280 and a height of 720 is Playwright's desktop default; anything smaller is a phone.
+ * TODO adapt to make the difference between tablet and phone
+ */
+
+/**
+ * Prefer this over `isMobile()` in `test.beforeEach` hooks and test signatures: `viewport` is a test
+ * option, so reading it costs nothing, whereas destructuring `page` makes Playwright build a whole
+ * browser context and page for every test in the file just to read its configured size.
+ */
+export function isMobileViewport(viewport: ViewportSize | null): boolean {
+    return viewport !== null && viewport.width < 1280 && viewport.height < 750;
+}
+
+/** Returns true if the page is sized like a phone. */
+export function isMobile(page: Page): boolean {
+    return isMobileViewport(page.viewportSize());
 }

--- a/tests/tests/variables.spec.ts
+++ b/tests/tests/variables.spec.ts
@@ -14,7 +14,7 @@ import { getBackDump, getPusherDump, getPusherRooms } from "./utils/debug";
 import { assertLogMessage, startRecordLogs } from "./utils/log";
 import { maps_domain, maps_test_url, play_url, publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
-import { isMobile } from "./utils/isMobile";
+import { isMobileViewport } from "./utils/isMobile";
 import { evaluateScript } from "./utils/scripting";
 
 async function setVariable(page: Page, value: string) {
@@ -47,8 +47,8 @@ async function expectVariableToBe(page: Page, value: string) {
 test.setTimeout(360000);
 
 test.describe("Variables @nomobile", () => {
-    test.beforeEach(async ({ page }) => {
-        test.skip(isMobile(page), "Skip on mobile devices");
+    test.beforeEach(async ({ viewport }) => {
+        test.skip(isMobileViewport(viewport), "Skip on mobile devices");
     });
 
     // WARNING: Since this test restarts Traefik and other components, it might fail when run against the vite dev server.


### PR DESCRIPTION
Stacked on #6486 → #6481 → #6259.

## The waste

All **22** spec files with a `test.beforeEach(async ({ page, ... }))` used that `page` fixture for exactly one thing:

```ts
test.beforeEach(async ({ page, browserName }) => {
    test.skip(isMobile(page) || browserName === "webkit", "Skip on mobile and WebKit");
});
```

`isMobile(page)` only reads `page.viewportSize()` — static project configuration. But destructuring `page` makes Playwright instantiate the `page` fixture, which builds a **whole browser context and page for every test in those files**, purely to read a value already in the config.

This showed up while tracing the teardown crash in #6486: those tests had three contexts, and the third was this one — created, never navigated, torn down.

## The change

`viewport` is a test option, so reading it costs nothing:

```ts
test.beforeEach(async ({ viewport, browserName }) => {
    test.skip(isMobileViewport(viewport) || browserName === "webkit", "Skip on mobile and WebKit");
});
```

`isMobileViewport()` takes the viewport directly. `isMobile(page)` stays as a one-line wrapper for the 45 call sites inside tests, where the page already exists and is free — those are untouched.

## Verification

The risk here is silently changing which tests skip, so I checked that directly with a temporary probe asserting `isMobileViewport(viewport) === isMobile(page)`, run on every project:

| project | viewport | `isMobile(page)` | `isMobileViewport(viewport)` |
|---|---|---|---|
| chromium | 1280x720 | false | false |
| firefox | 1280x720 | false | false |
| webkit | 1280x720 | false | false |
| mobilechromium | 393x727 | true | true |
| mobilefirefox | 393x727 | true | true |
| mobilewebkit | 375x667 | true | true |

All six agree, so no skip decision changes. The probe was removed before committing.

Also fixes a latent null dereference: `page.viewportSize()` returns `null` when there is no viewport emulation, and the old code indexed `.width` on it unguarded. Running `tsc --strict` over the changed files goes from 39 pre-existing errors to 37, with none added.

Note `npx playwright test --list` cannot run locally in this checkout (`Cannot find package 'nice-grpc'`, an unbuilt local dep unrelated to this change), so full test collection is verified by CI rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)