### PR TITLE
fix(pusher): per-transport resume nonce, retained connections keyed by connection id

### DIFF
--- a/play/src/pusher/models/Websocket/SocketData.ts
+++ b/play/src/pusher/models/Websocket/SocketData.ts
@@ -61,6 +61,9 @@ export type ConnectingSocketData = {
     // Unique identifier of the front WorkAdventureWebSocket instance. A transport resume is only accepted onto the
     // logical connection carrying the same id. Undefined for fronts predating this parameter.
     connectionId?: string;
+    // Set on a transport opened by a client that is resuming: the last nonce it received. Consumed once in the
+    // open handler and never shared with other transports of the same tab.
+    clientLastReceivedNonce?: number;
     attendeesState: boolean;
     // The abort controllers for each queries received
     queryAbortControllers: Map<number, AbortController>;

--- a/play/src/pusher/services/PusherRoomSocketController.ts
+++ b/play/src/pusher/services/PusherRoomSocketController.ts
@@ -38,7 +38,6 @@ type MessageHandler = (socket: PusherWebSocket, message: ClientToServerMessage) 
 type CloseHandler = (socket: PusherWebSocket, code: number, reason: string) => void | Promise<void>;
 
 type RoomWsQuery = {
-    tabId: string;
     connectionId?: string;
 };
 
@@ -57,14 +56,12 @@ type RoomWsConfig<TQuery extends RoomWsQuery> = {
     close: CloseHandler;
 };
 
-type WebSocketContext = {
-    socket?: PusherWebSocket;
-};
-
 export class PusherRoomSocketController {
     private readonly wrappersBySocket = new WeakMap<RawSocket, PusherWebSocket>();
-    private readonly contextByTabKey = new Map<string, WebSocketContext>();
-    private readonly contextCleanupTimeoutsByTabKey = new Map<string, ReturnType<typeof setTimeout>>();
+    // Logical connections a client may resume onto, keyed by the connection id its WorkAdventureWebSocket sent.
+    // A retained connection outlives its transport for CLIENT_DISCONNECTION_RETENTION_MS.
+    private readonly retainedByConnectionId = new Map<string, PusherWebSocket>();
+    private readonly retentionTimeoutsByConnectionId = new Map<string, ReturnType<typeof setTimeout>>();
 
     public constructor(private readonly app: TemplatedApp) {}
 
@@ -126,24 +123,18 @@ export class PusherRoomSocketController {
     private canReplaceTransportWithoutUpgrade<TQuery extends RoomWsQuery>(
         query: TQuery,
         websocketProtocol: string,
-        tabContext: WebSocketContext | undefined,
-    ): tabContext is WebSocketContext & { socket: PusherWebSocket } {
-        if (!tabContext?.socket || tabContext.socket.isDisconnecting()) {
+        retained: PusherWebSocket | undefined,
+    ): retained is PusherWebSocket {
+        if (!retained || retained.isDisconnecting()) {
             return false;
         }
 
-        const socketData = tabContext.socket.getUserData();
+        const socketData = retained.getUserData();
         if (socketData.token !== websocketProtocol) {
             return false;
         }
 
         if ("roomId" in query && typeof query.roomId === "string" && query.roomId !== socketData.roomId) {
-            return false;
-        }
-
-        // A newer connection from the same tab may own the tab context by now: only the WorkAdventureWebSocket
-        // that opened this logical connection is allowed to resume it.
-        if (query.connectionId !== socketData.connectionId) {
             return false;
         }
 
@@ -169,14 +160,14 @@ export class PusherRoomSocketController {
         });
     }
 
-    private clearContextCleanup(tabId: string): void {
-        const timeout = this.contextCleanupTimeoutsByTabKey.get(tabId);
+    private clearRetentionTimeout(connectionId: string): void {
+        const timeout = this.retentionTimeoutsByConnectionId.get(connectionId);
         if (!timeout) {
             return;
         }
 
         clearTimeout(timeout);
-        this.contextCleanupTimeoutsByTabKey.delete(tabId);
+        this.retentionTimeoutsByConnectionId.delete(connectionId);
     }
 
     public ws<TQuery extends RoomWsQuery>(path: string, config: RoomWsConfig<TQuery>): void {
@@ -206,16 +197,19 @@ export class PusherRoomSocketController {
                         urlSearchParams.get("lastReceivedNonce") ?? undefined,
                         "lastReceivedNonce",
                     );
-                    const tabContext = this.contextByTabKey.get(query.tabId);
+                    const retained =
+                        query.connectionId === undefined
+                            ? undefined
+                            : this.retainedByConnectionId.get(query.connectionId);
 
                     if (
                         clientLastReceivedNonce !== undefined &&
-                        this.canReplaceTransportWithoutUpgrade(query, websocketProtocol, tabContext)
+                        this.canReplaceTransportWithoutUpgrade(query, websocketProtocol, retained)
                     ) {
                         this.upgradeSocket(
                             upgradeAborted.aborted,
                             res,
-                            { ...tabContext.socket.getUserData(), clientLastReceivedNonce },
+                            { ...retained.getUserData(), clientLastReceivedNonce },
                             websocketKey,
                             websocketProtocol,
                             websocketExtensions,
@@ -284,42 +278,45 @@ export class PusherRoomSocketController {
 
                     const rawSocket = ws as unknown as RawSocket;
 
-                    const tabId = socketData.tabId;
-                    const context = this.contextByTabKey.get(tabId);
+                    const connectionId = socketData.connectionId;
+                    const retained =
+                        connectionId === undefined ? undefined : this.retainedByConnectionId.get(connectionId);
                     const clientLastReceivedNonce = socketData.clientLastReceivedNonce;
                     socketData.clientLastReceivedNonce = undefined;
 
-                    if (context?.socket && clientLastReceivedNonce !== undefined && !context.socket.isDisconnecting()) {
+                    if (
+                        connectionId !== undefined &&
+                        retained &&
+                        clientLastReceivedNonce !== undefined &&
+                        !retained.isDisconnecting()
+                    ) {
                         console.info("[PusherRoomSocketController] attempting transport replacement", {
-                            tabId,
+                            connectionId,
                             userUuid: socketData.userUuid,
                             clientLastReceivedNonce,
                         });
-                        const replaced = context.socket.replaceSocket(rawSocket, clientLastReceivedNonce);
+                        const replaced = retained.replaceSocket(rawSocket, clientLastReceivedNonce);
 
                         if (replaced) {
-                            this.clearContextCleanup(tabId);
-                            this.wrappersBySocket.set(rawSocket, context.socket);
+                            this.clearRetentionTimeout(connectionId);
+                            this.wrappersBySocket.set(rawSocket, retained);
 
-                            await config.reconnect(context.socket);
+                            await config.reconnect(retained);
                         }
 
                         return;
                     }
 
                     if (clientLastReceivedNonce !== undefined) {
-                        if (!context?.socket) {
-                            this.contextByTabKey.delete(tabId);
-                        }
                         ws.end(1008, "Cannot replace socket: previous connection not retained");
                         return;
                     }
 
-                    this.clearContextCleanup(tabId);
                     const socket = this.getOrCreateWrapper(rawSocket);
-                    this.contextByTabKey.set(tabId, {
-                        socket,
-                    });
+                    if (connectionId !== undefined) {
+                        this.clearRetentionTimeout(connectionId);
+                        this.retainedByConnectionId.set(connectionId, socket);
+                    }
                     await config.open(socket);
                 })().catch((e) => {
                     Sentry.captureException(e);
@@ -382,10 +379,10 @@ export class PusherRoomSocketController {
 
                 socket.handleTransportClosed();
 
-                const tabId = socketData.tabId;
-                const forgetContext = () => {
-                    if (this.contextByTabKey.get(tabId)?.socket === socket) {
-                        this.contextByTabKey.delete(tabId);
+                const connectionId = socketData.connectionId;
+                const forgetRetained = () => {
+                    if (connectionId !== undefined && this.retainedByConnectionId.get(connectionId) === socket) {
+                        this.retainedByConnectionId.delete(connectionId);
                     }
                 };
                 // Terminal teardown: no reconnect retry will replace this transport from here on.
@@ -394,27 +391,28 @@ export class PusherRoomSocketController {
                     return Promise.resolve(config.close(socket, code, reason));
                 };
                 if (code === 1000 || code === 1001) {
-                    closePermanently().then(forgetContext, (e) => {
+                    closePermanently().then(forgetRetained, (e) => {
                         console.error(e);
-                        forgetContext();
+                        forgetRetained();
                     });
                     return;
                 }
 
-                if (this.contextByTabKey.get(tabId)?.socket === socket) {
-                    this.clearContextCleanup(tabId);
+                // Only a connection the client can name (by connection id) is worth retaining for a resume.
+                if (connectionId !== undefined && this.retainedByConnectionId.get(connectionId) === socket) {
+                    this.clearRetentionTimeout(connectionId);
                     const timeout = setTimeout(() => {
-                        this.contextCleanupTimeoutsByTabKey.delete(tabId);
+                        this.retentionTimeoutsByConnectionId.delete(connectionId);
 
-                        if (this.contextByTabKey.get(tabId)?.socket === socket) {
-                            closePermanently().then(forgetContext, (e) => {
+                        if (this.retainedByConnectionId.get(connectionId) === socket) {
+                            closePermanently().then(forgetRetained, (e) => {
                                 console.error(e);
-                                forgetContext();
+                                forgetRetained();
                             });
                         }
                     }, CLIENT_DISCONNECTION_RETENTION_MS);
 
-                    this.contextCleanupTimeoutsByTabKey.set(tabId, timeout);
+                    this.retentionTimeoutsByConnectionId.set(connectionId, timeout);
                     return;
                 }
 

--- a/play/src/pusher/services/PusherRoomSocketController.ts
+++ b/play/src/pusher/services/PusherRoomSocketController.ts
@@ -59,7 +59,6 @@ type RoomWsConfig<TQuery extends RoomWsQuery> = {
 
 type WebSocketContext = {
     socket?: PusherWebSocket;
-    clientLastReceivedNonce?: number;
 };
 
 export class PusherRoomSocketController {
@@ -213,11 +212,10 @@ export class PusherRoomSocketController {
                         clientLastReceivedNonce !== undefined &&
                         this.canReplaceTransportWithoutUpgrade(query, websocketProtocol, tabContext)
                     ) {
-                        tabContext.clientLastReceivedNonce = clientLastReceivedNonce;
                         this.upgradeSocket(
                             upgradeAborted.aborted,
                             res,
-                            { ...tabContext.socket.getUserData() },
+                            { ...tabContext.socket.getUserData(), clientLastReceivedNonce },
                             websocketKey,
                             websocketProtocol,
                             websocketExtensions,
@@ -237,14 +235,12 @@ export class PusherRoomSocketController {
                         },
                         isAborted: () => upgradeAborted.aborted,
                         upgrade: (data) => {
-                            const tabContext = this.contextByTabKey.get(query.tabId) ?? {};
-                            tabContext.clientLastReceivedNonce = clientLastReceivedNonce;
-                            this.contextByTabKey.set(query.tabId, tabContext);
-
+                            // The nonce travels with this transport only: a resume that turns out to be illegitimate
+                            // must not disturb another connection of the same tab that is resuming concurrently.
                             this.upgradeSocket(
                                 upgradeAborted.aborted,
                                 res,
-                                data,
+                                { ...data, clientLastReceivedNonce },
                                 websocketKey,
                                 websocketProtocol,
                                 websocketExtensions,
@@ -290,7 +286,8 @@ export class PusherRoomSocketController {
 
                     const tabId = socketData.tabId;
                     const context = this.contextByTabKey.get(tabId);
-                    const clientLastReceivedNonce = context?.clientLastReceivedNonce;
+                    const clientLastReceivedNonce = socketData.clientLastReceivedNonce;
+                    socketData.clientLastReceivedNonce = undefined;
 
                     if (context?.socket && clientLastReceivedNonce !== undefined && !context.socket.isDisconnecting()) {
                         console.info("[PusherRoomSocketController] attempting transport replacement", {
@@ -298,17 +295,13 @@ export class PusherRoomSocketController {
                             userUuid: socketData.userUuid,
                             clientLastReceivedNonce,
                         });
-                        try {
-                            const replaced = context.socket.replaceSocket(rawSocket, clientLastReceivedNonce);
+                        const replaced = context.socket.replaceSocket(rawSocket, clientLastReceivedNonce);
 
-                            if (replaced) {
-                                this.clearContextCleanup(tabId);
-                                this.wrappersBySocket.set(rawSocket, context.socket);
+                        if (replaced) {
+                            this.clearContextCleanup(tabId);
+                            this.wrappersBySocket.set(rawSocket, context.socket);
 
-                                await config.reconnect(context.socket);
-                            }
-                        } finally {
-                            context.clientLastReceivedNonce = undefined;
+                            await config.reconnect(context.socket);
                         }
 
                         return;

--- a/play/tests/pusher/PusherRoomSocketController.test.ts
+++ b/play/tests/pusher/PusherRoomSocketController.test.ts
@@ -44,19 +44,19 @@ describe("PusherRoomSocketController reconnect retention", () => {
         const socket = createSocket({ tabId: "tab-1" });
         await registeredHandlers?.open(socket);
 
-        expect(getContextMap(controller).has("tab-1")).toBe(true);
+        expect(getContextMap(controller).has("conn-1")).toBe(true);
 
         await registeredHandlers?.close(socket);
         await flushMicrotasks();
 
-        expect(getContextMap(controller).has("tab-1")).toBe(true);
+        expect(getContextMap(controller).has("conn-1")).toBe(true);
 
         vi.advanceTimersByTime(CLIENT_DISCONNECTION_RETENTION_MS - 1);
-        expect(getContextMap(controller).has("tab-1")).toBe(true);
+        expect(getContextMap(controller).has("conn-1")).toBe(true);
 
         vi.advanceTimersByTime(1);
         await flushMicrotasks();
-        expect(getContextMap(controller).has("tab-1")).toBe(false);
+        expect(getContextMap(controller).has("conn-1")).toBe(false);
     });
 
     it("delays logical cleanup so a closed transport can still be replaced", async () => {
@@ -74,7 +74,7 @@ describe("PusherRoomSocketController reconnect retention", () => {
         const initialSocket = createSocket({ tabId: "tab-1" });
         await registeredHandlers?.open(initialSocket);
 
-        const initialContext = getContextMap(controller).get("tab-1");
+        const initialContext = getContextMap(controller).get("conn-1");
         expect(initialContext).toBeDefined();
 
         await registeredHandlers?.close(initialSocket);
@@ -89,7 +89,7 @@ describe("PusherRoomSocketController reconnect retention", () => {
         await flushMicrotasks();
 
         expect(close).not.toHaveBeenCalled();
-        expect(getContextMap(controller).get("tab-1")?.socket).toBe(initialContext?.socket);
+        expect(getContextMap(controller).get("conn-1")).toBe(initialContext);
     });
 
     it("cancels the scheduled cleanup when the same tab reconnects in time", async () => {
@@ -102,7 +102,7 @@ describe("PusherRoomSocketController reconnect retention", () => {
         const initialSocket = createSocket({ tabId: "tab-1" });
         await registeredHandlers?.open(initialSocket);
 
-        const initialContext = getContextMap(controller).get("tab-1");
+        const initialContext = getContextMap(controller).get("conn-1");
         expect(initialContext).toBeDefined();
 
         await registeredHandlers?.close(initialSocket);
@@ -113,7 +113,7 @@ describe("PusherRoomSocketController reconnect retention", () => {
 
         vi.advanceTimersByTime(CLIENT_DISCONNECTION_RETENTION_MS);
 
-        expect(getContextMap(controller).has("tab-1")).toBe(true);
+        expect(getContextMap(controller).has("conn-1")).toBe(true);
     });
 
     it("creates a fresh context after the retention window expires", async () => {
@@ -136,7 +136,7 @@ describe("PusherRoomSocketController reconnect retention", () => {
         await registeredHandlers?.open(reconnectSocket);
 
         expect(open).toHaveBeenCalledTimes(2);
-        expect(getContextMap(controller).get("tab-1")?.socket).toBeDefined();
+        expect(getContextMap(controller).get("conn-1")).toBeDefined();
     });
 
     it("runs logical cleanup when no replacement arrives before retention expires", async () => {
@@ -182,7 +182,7 @@ describe("PusherRoomSocketController reconnect retention", () => {
         await flushMicrotasks();
 
         expect(close).toHaveBeenCalledWith(expect.any(PusherWebSocket), 1000, "Page unloading");
-        expect(getContextMap(controller).has("tab-1")).toBe(false);
+        expect(getContextMap(controller).has("conn-1")).toBe(false);
 
         vi.advanceTimersByTime(CLIENT_DISCONNECTION_RETENTION_MS);
         await flushMicrotasks();
@@ -200,10 +200,10 @@ describe("PusherRoomSocketController reconnect retention", () => {
         const initialSocket = createSocket({ tabId: "tab-1" });
         await registeredHandlers?.open(initialSocket);
 
-        const wrapper = getContextMap(controller).get("tab-1")?.socket as PusherWebSocket;
+        const wrapper = getContextMap(controller).get("conn-1") as PusherWebSocket;
         wrapper.send({ message: undefined });
 
-        const initialContext = getContextMap(controller).get("tab-1");
+        const initialContext = getContextMap(controller).get("conn-1");
         expect(initialContext).toBeDefined();
 
         await registeredHandlers?.close(initialSocket);
@@ -246,7 +246,7 @@ describe("PusherRoomSocketController reconnect retention", () => {
 
         await registeredHandlers?.open(socket);
 
-        const wrapper = getContextMap(controller).get("tab-1")?.socket as PusherWebSocket;
+        const wrapper = getContextMap(controller).get("conn-1") as PusherWebSocket;
         wrapper.send({ message: undefined });
         wrapper.send({ message: undefined });
 
@@ -260,50 +260,78 @@ describe("PusherRoomSocketController reconnect retention", () => {
 
 describe("PusherRoomSocketController transport resume identity", () => {
     afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
         vi.restoreAllMocks();
     });
 
-    const canReplace = (controller: PusherRoomSocketController, query: object, socket: PusherWebSocket) =>
+    const canReplace = (controller: PusherRoomSocketController, query: object, retained?: PusherWebSocket) =>
         (
             controller as unknown as {
-                canReplaceTransportWithoutUpgrade: (query: object, protocol: string, ctx: object) => boolean;
+                canReplaceTransportWithoutUpgrade: (
+                    query: object,
+                    protocol: string,
+                    retained?: PusherWebSocket,
+                ) => boolean;
             }
-        ).canReplaceTransportWithoutUpgrade(query, "token", { socket });
+        ).canReplaceTransportWithoutUpgrade(query, "token", retained);
 
-    it("refuses to resume onto a logical connection opened by another WorkAdventureWebSocket", () => {
+    it("only resumes onto a retained connection with the same token and room", () => {
         const controller = createController(() => {});
-        const retained = createPusherWebSocket(createSocket({ tabId: "tab-1", connectionId: "newer-page-socket" }));
+        const retained = createPusherWebSocket(createSocket({ token: "token", roomId: "room-id" }));
 
-        expect(canReplace(controller, { tabId: "tab-1", connectionId: "stale-page-socket" }, retained)).toBe(false);
-        expect(canReplace(controller, { tabId: "tab-1", connectionId: "newer-page-socket" }, retained)).toBe(true);
+        expect(canReplace(controller, { roomId: "room-id" }, retained)).toBe(true);
+        expect(canReplace(controller, { roomId: "another-room" }, retained)).toBe(false);
+        expect(canReplace(controller, { roomId: "room-id" }, undefined)).toBe(false);
     });
 
-    it("still resumes fronts that do not send a connection id", () => {
-        const controller = createController(() => {});
-        const retained = createPusherWebSocket(createSocket({ tabId: "tab-1", connectionId: undefined }));
-
-        expect(canReplace(controller, { tabId: "tab-1" }, retained)).toBe(true);
-    });
-
-    it("lets the legitimate connection resume after a mismatched resume was refused", async () => {
+    it("refuses a resume from a WorkAdventureWebSocket that never opened a connection here", async () => {
         let handlers: RegisteredHandlers | undefined;
         const controller = createController((h) => {
             handlers = h;
         });
 
-        const initialSocket = createSocket({ tabId: "tab-1", connectionId: "current" });
+        const initialSocket = createSocket({ connectionId: "current" });
         await handlers?.open(initialSocket);
-        const retained = getContextMap(controller).get("tab-1")?.socket;
+        const retained = getContextMap(controller).get("current");
 
-        const stale = createSocket({ tabId: "tab-1", connectionId: "stale", clientLastReceivedNonce: 7 });
+        const stale = createSocket({ connectionId: "stale", clientLastReceivedNonce: 7 });
         await handlers?.open(stale);
-        expect(getEndMock(stale)).toHaveBeenCalledWith(1008, "Cannot replace socket: connection id mismatch");
-        expect(getContextMap(controller).get("tab-1")?.socket).toBe(retained);
+        expect(getEndMock(stale)).toHaveBeenCalledWith(1008, "Cannot replace socket: previous connection not retained");
+        expect(getContextMap(controller).get("current")).toBe(retained);
 
-        const legitimate = createSocket({ tabId: "tab-1", connectionId: "current", clientLastReceivedNonce: 0 });
+        const legitimate = createSocket({ connectionId: "current", clientLastReceivedNonce: 0 });
         await handlers?.open(legitimate);
         expect(getEndMock(legitimate)).not.toHaveBeenCalled();
         expect(getEndMock(initialSocket)).toHaveBeenCalledWith(1008, "Replaced by a reconnected socket");
+    });
+
+    it("does not retain a connection from a front that sends no connection id", async () => {
+        vi.useFakeTimers();
+        let handlers: RegisteredHandlers | undefined;
+        const close = vi.fn();
+        const controller = createController(
+            (h) => {
+                handlers = h;
+            },
+            vi.fn(),
+            close,
+        );
+
+        const socket = createSocket({ connectionId: undefined });
+        await handlers?.open(socket);
+        expect(getContextMap(controller).size).toBe(0);
+
+        await handlers?.close(socket, 1006);
+        await flushMicrotasks();
+        expect(close).toHaveBeenCalledTimes(1);
+
+        const resume = createSocket({ connectionId: undefined, clientLastReceivedNonce: 0 });
+        await handlers?.open(resume);
+        expect(getEndMock(resume)).toHaveBeenCalledWith(
+            1008,
+            "Cannot replace socket: previous connection not retained",
+        );
     });
 
     it("rejects a replacement socket carrying a different connection id", () => {
@@ -378,12 +406,8 @@ function createController(
     return controller;
 }
 
-function getContextMap(controller: PusherRoomSocketController): Map<string, { socket?: unknown }> {
-    return (
-        controller as unknown as {
-            contextByTabKey: Map<string, { socket?: unknown }>;
-        }
-    ).contextByTabKey;
+function getContextMap(controller: PusherRoomSocketController): Map<string, unknown> {
+    return (controller as unknown as { retainedByConnectionId: Map<string, unknown> }).retainedByConnectionId;
 }
 
 function createSocket(overrides: Partial<SocketData> = {}): RawSocket {
@@ -418,6 +442,7 @@ function createSocket(overrides: Partial<SocketData> = {}): RawSocket {
         microphoneState: false,
         cameraState: false,
         tabId: "tab-1",
+        connectionId: "conn-1",
         attendeesState: false,
         queryAbortControllers: new Map(),
         canRecord: false,

--- a/play/tests/pusher/PusherRoomSocketController.test.ts
+++ b/play/tests/pusher/PusherRoomSocketController.test.ts
@@ -76,14 +76,13 @@ describe("PusherRoomSocketController reconnect retention", () => {
 
         const initialContext = getContextMap(controller).get("tab-1");
         expect(initialContext).toBeDefined();
-        initialContext!.clientLastReceivedNonce = 0;
 
         await registeredHandlers?.close(initialSocket);
         await flushMicrotasks();
 
         expect(close).not.toHaveBeenCalled();
 
-        const reconnectSocket = createSocket({ tabId: "tab-1" });
+        const reconnectSocket = createSocket({ tabId: "tab-1", clientLastReceivedNonce: 0 });
         await registeredHandlers?.open(reconnectSocket);
 
         vi.advanceTimersByTime(CLIENT_DISCONNECTION_RETENTION_MS);
@@ -105,12 +104,11 @@ describe("PusherRoomSocketController reconnect retention", () => {
 
         const initialContext = getContextMap(controller).get("tab-1");
         expect(initialContext).toBeDefined();
-        initialContext!.clientLastReceivedNonce = 0;
 
         await registeredHandlers?.close(initialSocket);
         await flushMicrotasks();
 
-        const reconnectSocket = createSocket({ tabId: "tab-1" });
+        const reconnectSocket = createSocket({ tabId: "tab-1", clientLastReceivedNonce: 0 });
         await registeredHandlers?.open(reconnectSocket);
 
         vi.advanceTimersByTime(CLIENT_DISCONNECTION_RETENTION_MS);
@@ -207,7 +205,6 @@ describe("PusherRoomSocketController reconnect retention", () => {
 
         const initialContext = getContextMap(controller).get("tab-1");
         expect(initialContext).toBeDefined();
-        initialContext!.clientLastReceivedNonce = 1;
 
         await registeredHandlers?.close(initialSocket);
         await flushMicrotasks();
@@ -215,7 +212,7 @@ describe("PusherRoomSocketController reconnect retention", () => {
         wrapper.send({ message: undefined });
         expect(getSendMock(initialSocket)).toHaveBeenCalledTimes(1);
 
-        const reconnectSocket = createSocket({ tabId: "tab-1" });
+        const reconnectSocket = createSocket({ tabId: "tab-1", clientLastReceivedNonce: 1 });
         await registeredHandlers?.open(reconnectSocket);
 
         expect(getSendMock(reconnectSocket)).toHaveBeenCalledTimes(1);
@@ -225,13 +222,11 @@ describe("PusherRoomSocketController reconnect retention", () => {
         vi.useFakeTimers();
 
         const open = vi.fn();
-        const controller = createController((handlers) => {
+        createController((handlers) => {
             registeredHandlers = handlers;
         }, open);
 
-        getContextMap(controller).set("tab-1", { clientLastReceivedNonce: 4 });
-
-        const reconnectSocket = createSocket({ tabId: "tab-1" });
+        const reconnectSocket = createSocket({ tabId: "tab-1", clientLastReceivedNonce: 4 });
         await registeredHandlers?.open(reconnectSocket);
 
         expect(open).not.toHaveBeenCalled();
@@ -288,6 +283,27 @@ describe("PusherRoomSocketController transport resume identity", () => {
         const retained = createPusherWebSocket(createSocket({ tabId: "tab-1", connectionId: undefined }));
 
         expect(canReplace(controller, { tabId: "tab-1" }, retained)).toBe(true);
+    });
+
+    it("lets the legitimate connection resume after a mismatched resume was refused", async () => {
+        let handlers: RegisteredHandlers | undefined;
+        const controller = createController((h) => {
+            handlers = h;
+        });
+
+        const initialSocket = createSocket({ tabId: "tab-1", connectionId: "current" });
+        await handlers?.open(initialSocket);
+        const retained = getContextMap(controller).get("tab-1")?.socket;
+
+        const stale = createSocket({ tabId: "tab-1", connectionId: "stale", clientLastReceivedNonce: 7 });
+        await handlers?.open(stale);
+        expect(getEndMock(stale)).toHaveBeenCalledWith(1008, "Cannot replace socket: connection id mismatch");
+        expect(getContextMap(controller).get("tab-1")?.socket).toBe(retained);
+
+        const legitimate = createSocket({ tabId: "tab-1", connectionId: "current", clientLastReceivedNonce: 0 });
+        await handlers?.open(legitimate);
+        expect(getEndMock(legitimate)).not.toHaveBeenCalled();
+        expect(getEndMock(initialSocket)).toHaveBeenCalledWith(1008, "Replaced by a reconnected socket");
     });
 
     it("rejects a replacement socket carrying a different connection id", () => {
@@ -362,12 +378,10 @@ function createController(
     return controller;
 }
 
-function getContextMap(
-    controller: PusherRoomSocketController,
-): Map<string, { socket?: unknown; clientLastReceivedNonce?: number }> {
+function getContextMap(controller: PusherRoomSocketController): Map<string, { socket?: unknown }> {
     return (
         controller as unknown as {
-            contextByTabKey: Map<string, { socket?: unknown; clientLastReceivedNonce?: number }>;
+            contextByTabKey: Map<string, { socket?: unknown }>;
         }
     ).contextByTabKey;
 }


### PR DESCRIPTION
Stacked on #6487. Addresses the Copilot finding there, then goes one step further.

## Why

A transport resume stored the client's `lastReceivedNonce` on the tab-wide `WebSocketContext` during upgrade and cleared it in `open`. A resume refused for a connection id mismatch still went through that shared field, so it could race with a legitimate resume of the same tab: one request's `open` could replay from the other's nonce, or find it cleared and treat a real resume as a fresh connection.

Once the nonce moved off the context, `WebSocketContext` only wrapped a socket, and since #6487 identifies a resume by connection id the tab id had no role left on the pusher side.

## What

- The nonce travels with the candidate transport's own socket data (`ConnectingSocketData.clientLastReceivedNonce`) on both upgrade paths and is consumed once in `open`.
- `WebSocketContext` is gone. Resumable connections live in `retainedByConnectionId: Map<string, PusherWebSocket>`, retention timers are keyed the same way, and `canReplaceTransportWithoutUpgrade` no longer compares connection ids because the lookup already implies it. Nothing a stale client sends can touch another connection any more.
- A connection from a front that sends no connection id (predating #6487) is not retained: its transport close runs the logical cleanup immediately and a resume attempt gets 1008, so it joins fresh. This only matters during a rolling deploy.
- Side effect worth knowing: a retained connection is no longer silently overwritten by a newer connection of the same tab, so its retention timer always ends in a proper cleanup instead of leaving the logical socket to the back's ghost kill.

`wrappersBySocket` stays: it maps a live raw uWS socket to its wrapper for the `message`, `drain` and `close` callbacks, which is a different lookup from "find the retained connection a resuming client names".

## Tests

`tests/pusher/PusherRoomSocketController.test.ts`: existing resume tests now set the nonce on the reconnecting socket and read the retained map by connection id; new tests cover the token and room guard, a stale connection id being refused while the legitimate one still resumes, and a front without connection id being cleaned up immediately and refused a resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
