### PR TITLE
refactor(play): simplify BreakpointsUtils and drop its dead helpers

### DIFF
--- a/play/src/front/Utils/BreakpointsUtils.test.ts
+++ b/play/src/front/Utils/BreakpointsUtils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { isMediaBreakpointUp } from "./BreakpointsUtils";
+
+function withWindowWidth(width: number, callback: () => void): void {
+    vi.stubGlobal("window", { innerWidth: width });
+    try {
+        callback();
+    } finally {
+        vi.unstubAllGlobals();
+    }
+}
+
+describe("isMediaBreakpointUp", () => {
+    it("is true below the next breakpoint and false at or above it", () => {
+        withWindowWidth(991, () => expect(isMediaBreakpointUp("md")).toBe(true));
+        withWindowWidth(992, () => expect(isMediaBreakpointUp("md")).toBe(false));
+    });
+
+    it("is always true for the largest breakpoint", () => {
+        withWindowWidth(4000, () => expect(isMediaBreakpointUp("xxl")).toBe(true));
+    });
+});

--- a/play/src/front/Utils/BreakpointsUtils.ts
+++ b/play/src/front/Utils/BreakpointsUtils.ts
@@ -1,112 +1,22 @@
-type InternalBreakpoint = {
-    beforeBreakpoint: InternalBreakpoint | undefined;
-    nextBreakpoint: InternalBreakpoint | undefined;
-    pixels: number;
-};
+// If this changes, also update the matching CSS breakpoints.
+const breakpoints = {
+    xs: 0,
+    sm: 576,
+    md: 768,
+    lg: 992,
+    xl: 1200,
+    xxl: 1400,
+} as const;
 
-function generateBreakpointsMap(): Map<string, InternalBreakpoint> {
-    // If this changes, also update the matching CSS breakpoints.
-    const breakpoints: { [key: string]: number } = {
-        xs: 0,
-        sm: 576,
-        md: 768,
-        lg: 992,
-        xl: 1200,
-        xxl: 1400,
-    };
+export type Breakpoint = keyof typeof breakpoints;
 
-    let beforeBreakpoint: InternalBreakpoint | undefined;
-    let beforeBreakpointTag: string | undefined;
-    const mapRender = new Map<string, InternalBreakpoint>();
+const orderedBreakpoints = Object.keys(breakpoints) as Breakpoint[];
 
-    for (const breakpoint in breakpoints) {
-        const newBreakpoint = {
-            beforeBreakpoint: beforeBreakpoint,
-            nextBreakpoint: undefined,
-            pixels: breakpoints[breakpoint],
-        };
-
-        if (beforeBreakpointTag && beforeBreakpoint) {
-            beforeBreakpoint.nextBreakpoint = newBreakpoint;
-            mapRender.set(beforeBreakpointTag, beforeBreakpoint);
-        }
-
-        mapRender.set(breakpoint, {
-            beforeBreakpoint: beforeBreakpoint,
-            nextBreakpoint: undefined,
-            pixels: breakpoints[breakpoint],
-        });
-
-        beforeBreakpointTag = breakpoint;
-        beforeBreakpoint = newBreakpoint;
-    }
-
-    return mapRender;
-}
-
-const breakpoints = generateBreakpointsMap();
-
-export type Breakpoint = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
-
+/**
+ * Returns true when the viewport is narrower than the breakpoint sitting right above `breakpoint`
+ * (in other words: when the viewport is still in `breakpoint` range or below).
+ */
 export function isMediaBreakpointUp(breakpoint: Breakpoint): boolean {
-    if (breakpoint === "xxl") {
-        return true;
-    }
-
-    const breakpointObject = breakpoints.get(breakpoint);
-
-    if (!breakpointObject) {
-        throw new Error(`Unknown breakpoint: ${breakpoint}`);
-    }
-
-    if (!breakpointObject.nextBreakpoint) {
-        return false;
-    }
-
-    return breakpointObject.nextBreakpoint.pixels - 1 >= window.innerWidth;
-}
-
-export function isMediaBreakpointDown(breakpoint: Breakpoint): boolean {
-    if (breakpoint === "xs") {
-        return true;
-    }
-
-    const breakpointObject = breakpoints.get(breakpoint);
-
-    if (!breakpointObject) {
-        throw new Error(`Unknown breakpoint: ${breakpoint}`);
-    }
-
-    return breakpointObject.pixels <= window.innerWidth;
-}
-
-export function isMediaBreakpointOnly(breakpoint: Breakpoint): boolean {
-    const breakpointObject = breakpoints.get(breakpoint);
-
-    if (!breakpointObject) {
-        throw new Error(`Unknown breakpoint: ${breakpoint}`);
-    }
-
-    return (
-        breakpointObject.pixels <= window.innerWidth &&
-        (!breakpointObject.nextBreakpoint || breakpointObject.nextBreakpoint.pixels - 1 >= window.innerWidth)
-    );
-}
-
-export function isMediaBreakpointBetween(startBreakpoint: Breakpoint, endBreakpoint: Breakpoint): boolean {
-    const startBreakpointObject = breakpoints.get(startBreakpoint);
-    const endBreakpointObject = breakpoints.get(endBreakpoint);
-
-    if (!startBreakpointObject) {
-        throw new Error(`Unknown start breakpoint: ${startBreakpointObject}`);
-    }
-
-    if (!endBreakpointObject) {
-        throw new Error(`Unknown end breakpoint: ${endBreakpointObject}`);
-    }
-
-    return (
-        startBreakpointObject.pixels <= innerWidth &&
-        (!endBreakpointObject.nextBreakpoint || endBreakpointObject.nextBreakpoint.pixels - 1 >= window.innerWidth)
-    );
+    const nextBreakpoint = orderedBreakpoints[orderedBreakpoints.indexOf(breakpoint) + 1];
+    return nextBreakpoint === undefined || window.innerWidth < breakpoints[nextBreakpoint];
 }


### PR DESCRIPTION
## What

`play/src/front/Utils/BreakpointsUtils.ts` was 113 lines. Only one of its four exported functions is ever called — `isMediaBreakpointUp`, and always with `"md"`. `isMediaBreakpointDown`, `isMediaBreakpointOnly` and `isMediaBreakpointBetween` had zero call sites.

They shared a hand-built doubly-linked list of breakpoints, produced by a generator that wrote every entry into the map twice (once as a throwaway object with `nextBreakpoint: undefined`, then overwritten on the next iteration by the real one).

This replaces the whole thing with a plain record and an index lookup:

```ts
export function isMediaBreakpointUp(breakpoint: Breakpoint): boolean {
    const nextBreakpoint = orderedBreakpoints[orderedBreakpoints.indexOf(breakpoint) + 1];
    return nextBreakpoint === undefined || window.innerWidth < breakpoints[nextBreakpoint];
}
```

-110 / +42 lines, including the new test.

## Behaviour

Unchanged. The old check was `next.pixels - 1 >= window.innerWidth`, which is `window.innerWidth < next.pixels`; `"xxl"` still short-circuits to `true` (no breakpoint above it).

The `Breakpoint` type is now derived from the breakpoint record instead of being a hand-maintained duplicate of its keys.

## Test

Added `BreakpointsUtils.test.ts` pinning the boundary (991 → true, 992 → false for `"md"`) and the `"xxl"` case.

## Checks

- `npx vitest run src/front/Utils/BreakpointsUtils.test.ts` — 2 passed
- `npx tsc --noEmit` in `play/` — clean
- eslint + prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)