### PR TITLE
refactor(play): drop the inert isMobile branch in GlobalCommunicationModal

### DIFF
--- a/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
+++ b/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-    import { onDestroy, onMount } from "svelte";
-    import { isMediaBreakpointUp } from "../../Utils/BreakpointsUtils";
+    import { onDestroy } from "svelte";
     import { showModalGlobalComminucationVisibilityStore } from "../../Stores/ModalStore";
     import { requestedScreenSharingState } from "../../Stores/ScreenSharingStore";
     import {
@@ -37,36 +36,19 @@
     import Button from "../UI/Button.svelte";
     import { IconAlertTriangle, IconInfoCircle, IconMessageShare, IconMusicShare, IconSpeakerPhone } from "@wa-icons";
 
-    let mainModal: HTMLDivElement;
-
     let inputSendTextActive = $state(false);
     let uploadAudioActive = $state(false);
     let broadcastToWorld = $state(false);
     let handleSendText: TextGlobalMessageHandle | undefined = $state();
     let handleSendAudio: AudioGlobalMessageHandle | undefined = $state();
-    let videoElement: HTMLVideoElement | undefined = $state();
     let stream: MediaStream | undefined = $state();
-    let aspectRatio = $state(1);
-
-    let isMobile = $state(isMediaBreakpointUp("md"));
-    const resizeObserver = new ResizeObserver(() => {
-        isMobile = isMediaBreakpointUp("md");
-    });
 
     const unsubscribeLocalStreamStore = localStreamStore.subscribe((value) => {
         if (value.type === "success") {
             stream = value.stream;
-            // TODO: remove this hack
-            setTimeout(() => {
-                aspectRatio = videoElement != undefined ? videoElement.videoWidth / videoElement.videoHeight : 1;
-            }, 100);
         } else {
             stream = undefined;
         }
-    });
-
-    onMount(() => {
-        resizeObserver.observe(mainModal);
     });
 
     onDestroy(() => {
@@ -194,7 +176,6 @@
 
 <div
     class="absolute z-[308] rounded-xxl w-full h-full top-0 left-0 right-0 bottom-0 flex items-center justify-center overflow-hidden"
-    bind:this={mainModal}
 >
     <div
         class="h-full md:h-auto md:top-auto md:left-auto md:right-auto md:bottom-auto bg-contrast/80 backdrop-blur rounded-md max-h-screen overflow-y-auto w-full lg:w-11/12"
@@ -437,9 +418,8 @@
                     <div class="flex flex-col md:flex-row justify-center">
                         <div class="flex flex-col mr-5">
                             <video
-                                bind:this={videoElement}
                                 class="h-full w-full md:object-cover rounded"
-                                class:object-contain={stream && (isMobile || aspectRatio < 1)}
+                                class:object-contain={stream}
                                 class:max-h-[230px]={stream}
                                 style="-webkit-transform: scaleX(-1);transform: scaleX(-1);"
                                 use:srcObject={stream}


### PR DESCRIPTION
## What

The megaphone preview video carried a breakpoint check that cannot affect what is rendered:

```svelte
class="h-full w-full md:object-cover rounded"
class:object-contain={stream && (isMobile || aspectRatio < 1)}
```

`object-contain` and `md:object-cover` are both single-class selectors, so specificity is equal and source order decides. Tailwind emits responsive variants after unvariant utilities, so `md:object-cover` wins at every width >= 768px.

`isMobile` is `isMediaBreakpointUp("md")`, i.e. `window.innerWidth < 992`. It can therefore only flip the outcome below 768px — where it is already unconditionally `true`. Walking the cases:

| viewport | before | after | rendered |
|---|---|---|---|
| `stream` falsy | no class | no class | — |
| < 768 | `isMobile` true → `object-contain` | `object-contain` | `object-contain` |
| 768–992 | `object-contain`, overridden | `object-contain`, overridden | `object-cover` |
| >= 992 | `object-contain` iff `aspectRatio < 1`, overridden | `object-contain`, overridden | `object-cover` |

Identical in every case, so the condition collapses to `stream`.

## What that removes

`aspectRatio` had no other reader, so with it go the `videoElement` binding and the `setTimeout(..., 100)` marked `// TODO: remove this hack` that existed only to populate it. `isMobile` had no other reader either, so the `ResizeObserver` goes too — along with the `mainModal` binding and the `onMount` block that were only there to drive it. That observer was never disconnected.

**No visual change**, at any viewport width.

## Checks

- Confirmed the emission order rather than assuming it: compiled `md:object-cover object-contain` with this repo's Tailwind (v4.3.3). `.object-contain` lands at line 2970; `.md\:object-cover` at line 5114, inside `@media (width >= 48rem)`.
- `npm run svelte-check` — 4964 files, 0 errors, 0 warnings
- `npx tsc --noEmit` — clean
- eslint + prettier — clean

## Note

`isMediaBreakpointUp` stays in use at four other call sites where it drives real behaviour (which map-editor tools exist, whether proximity chat auto-opens, the Phaser companion-select zoom, the chat sidebar's initial pixel width). Those are not CSS-replaceable.

`Modal.svelte` is the other genuinely presentational user of it and can move to a `@container main-layout` query, but that shifts the threshold from 992px viewport to 1024px container inline-size, so it wants a visual check and is left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)