### PR TITLE
fix(spaces): stop duplicate unregister from tearing down a departed user

### DIFF
--- a/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
@@ -231,7 +231,17 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     private sendWebRTCDisconnect(senderId: string, receiverId: string): void {
+        if (!this._connections.hasConnection(senderId, receiverId)) {
+            // Nothing to tear down: don't notify the receiver of a connection that does not exist.
+            return;
+        }
         this._connections.removeConnection(senderId, receiverId);
+        if (!this._space.getUser(senderId)) {
+            // The sender already left the space (its removal is what triggered this teardown).
+            // dispatchPrivateEvent would throw because it needs the sender, and the receiver is
+            // already told to drop the peer by the removeSpaceUserMessage broadcast.
+            return;
+        }
         this._space.dispatchPrivateEvent({
             spaceName: this._space.getSpaceName(),
             receiverUserId: receiverId,

--- a/back/tests/WebRTCCommunicationStrategy.test.ts
+++ b/back/tests/WebRTCCommunicationStrategy.test.ts
@@ -22,9 +22,9 @@ function createUser(spaceUserId: string): SpaceUser {
     });
 }
 
-function createSpace(dispatchPrivateEvent = vi.fn()): ICommunicationSpace {
+function createSpace(dispatchPrivateEvent = vi.fn(), usersInSpace: SpaceUser[] = []): ICommunicationSpace {
     return {
-        getAllUsers: () => [],
+        getAllUsers: () => usersInSpace,
         getUsersInFilter: () => [],
         getUsersToNotify: () => [],
         getRecordingState: () => ({ isRecording: false }),
@@ -34,8 +34,14 @@ function createSpace(dispatchPrivateEvent = vi.fn()): ICommunicationSpace {
         getPropertiesToSync: () => [],
         publishMetadata: vi.fn(),
         stopRecordingByServer: vi.fn().mockResolvedValue(undefined),
-        getUser: vi.fn(),
+        getUser: (spaceUserId: string) => usersInSpace.find((user) => user.spaceUserId === spaceUserId),
     } as unknown as ICommunicationSpace;
+}
+
+function webRtcDisconnectDispatches(dispatchPrivateEvent: ReturnType<typeof vi.fn>): WebRtcStartDispatch[] {
+    return dispatchPrivateEvent.mock.calls
+        .map((call) => call[0] as WebRtcStartDispatch)
+        .filter((event) => event.spaceEvent.event.$case === "webRtcDisconnectMessage");
 }
 
 function webRtcStartDispatches(dispatchPrivateEvent: ReturnType<typeof vi.fn>): WebRtcStartDispatch[] {
@@ -50,9 +56,10 @@ function webRtcStartDispatches(dispatchPrivateEvent: ReturnType<typeof vi.fn>): 
  */
 async function setupStrategyWithConnection() {
     const dispatchPrivateEvent = vi.fn();
-    const space = createSpace(dispatchPrivateEvent);
     const userA = createUser("user-a");
     const userB = createUser("user-b");
+    const usersInSpace = [userA, userB];
+    const space = createSpace(dispatchPrivateEvent, usersInSpace);
     const users = new Map([
         [userA.spaceUserId, userA],
         [userB.spaceUserId, userB],
@@ -69,7 +76,7 @@ async function setupStrategyWithConnection() {
 
     dispatchPrivateEvent.mockClear();
 
-    return { strategy, dispatchPrivateEvent, connectionId };
+    return { strategy, dispatchPrivateEvent, connectionId, userA, userB, usersInSpace };
 }
 
 describe("WebRTCCommunicationStrategy.handleMeetingConnectionRestartMessage", () => {
@@ -122,7 +129,7 @@ describe("WebRTCCommunicationStrategy.handleMeetingConnectionRestartMessage", ()
         expect(webRtcStartDispatches(dispatchPrivateEvent)).toHaveLength(2);
     });
 
-    it("ignores a restart when no connection exists between the peers", async () => {
+    it("ignores a restart when no connection exists between the peers", () => {
         const dispatchPrivateEvent = vi.fn();
         const space = createSpace(dispatchPrivateEvent);
         const strategy = new WebRTCCommunicationStrategy(space, new Map(), new Map());
@@ -141,5 +148,37 @@ describe("WebRTCCommunicationStrategy.handleMeetingConnectionRestartMessage", ()
         strategy.handleMeetingConnectionRestartMessage(MeetingConnectionRestartMessage.fromPartial({}), "user-a");
 
         expect(dispatchPrivateEvent).not.toHaveBeenCalled();
+    });
+});
+
+describe("WebRTCCommunicationStrategy disconnect teardown", () => {
+    it("sends one disconnect per direction of a tracked connection, and nothing on a repeated teardown", async () => {
+        const { strategy, dispatchPrivateEvent, userA } = await setupStrategyWithConnection();
+
+        strategy.deleteUserFromNotify(userA);
+
+        const disconnects = webRtcDisconnectDispatches(dispatchPrivateEvent);
+        expect(disconnects.map((event) => [event.senderUserId, event.receiverUserId])).toEqual([
+            ["user-a", "user-b"],
+            ["user-b", "user-a"],
+        ]);
+
+        dispatchPrivateEvent.mockClear();
+        // A duplicate delete-to-notify (e.g. an explicit leave overlapping with the socket close) has nothing
+        // left to tear down: it must not spam the remaining peers with disconnects.
+        strategy.deleteUserFromNotify(userA);
+        expect(dispatchPrivateEvent).not.toHaveBeenCalled();
+    });
+
+    it("does not dispatch on behalf of a sender that already left the space", async () => {
+        const { strategy, dispatchPrivateEvent, userA, usersInSpace } = await setupStrategyWithConnection();
+        // user-a was removed from the space before its delete-to-notify arrived (Sentry BACK-2B).
+        usersInSpace.splice(usersInSpace.indexOf(userA), 1);
+
+        expect(() => strategy.deleteUserFromNotify(userA)).not.toThrow();
+
+        const disconnects = webRtcDisconnectDispatches(dispatchPrivateEvent);
+        // Only the direction whose sender is still in the space is dispatched.
+        expect(disconnects.map((event) => [event.senderUserId, event.receiverUserId])).toEqual([["user-b", "user-a"]]);
     });
 });

--- a/play/src/pusher/models/SpaceToBackForwarder.ts
+++ b/play/src/pusher/models/SpaceToBackForwarder.ts
@@ -149,7 +149,24 @@ export class SpaceToBackForwarder implements SpaceToBackForwarderInterface {
         });
     }
 
-    async unregisterUser(socket: PusherWebSocket): Promise<void> {
+    // Unregistering awaits a round trip to the back. A second call for the same socket during that
+    // await (e.g. an explicit leave overlapping with the socket-close sweep) must not resend the
+    // delete-to-notify / remove messages: the back would receive them after the user is gone.
+    private readonly unregisteringSockets = new Map<PusherWebSocket, Promise<void>>();
+
+    unregisterUser(socket: PusherWebSocket): Promise<void> {
+        const inFlight = this.unregisteringSockets.get(socket);
+        if (inFlight) {
+            return inFlight;
+        }
+        const promise = this.doUnregisterUser(socket).finally(() => {
+            this.unregisteringSockets.delete(socket);
+        });
+        this.unregisteringSockets.set(socket, promise);
+        return promise;
+    }
+
+    private async doUnregisterUser(socket: PusherWebSocket): Promise<void> {
         const userData = socket.getUserData();
 
         const spaceUserId = userData.spaceUserId;

--- a/play/tests/pusher/SpaceToBackForwarder.test.ts
+++ b/play/tests/pusher/SpaceToBackForwarder.test.ts
@@ -47,7 +47,7 @@ describe("SpaceToBackForwarder", () => {
             const spaceForwarder = new SpaceToBackForwarder(mockSpace, eventProcessor);
 
             await expect(
-                async () => await spaceForwarder.registerUser(mockSocket, FilterType.ALL_USERS)
+                async () => await spaceForwarder.registerUser(mockSocket, FilterType.ALL_USERS),
             ).rejects.toThrow();
         });
 
@@ -64,7 +64,7 @@ describe("SpaceToBackForwarder", () => {
             const spaceForwarder = new SpaceToBackForwarder(mockSpace, eventProcessor);
 
             await expect(
-                async () => await spaceForwarder.registerUser(mockSocket, FilterType.ALL_USERS)
+                async () => await spaceForwarder.registerUser(mockSocket, FilterType.ALL_USERS),
             ).rejects.toThrow();
         });
 
@@ -309,7 +309,7 @@ describe("SpaceToBackForwarder", () => {
                         updateSpaceUserMessage: { spaceName: "test", user: spaceUser, updateMask: ["name"] },
                     },
                 },
-                expect.any(Function)
+                expect.any(Function),
             );
             expect(mockWriteFunction).toHaveBeenCalledOnce();
         });
@@ -506,6 +506,79 @@ describe("SpaceToBackForwarder", () => {
             expect(mockSendQuery).toHaveBeenCalledOnce();
         });
 
+        it("should send a single removeSpaceUserQuery when unregisterUser is called twice concurrently", async () => {
+            const mockWriteFunction = vi.fn();
+
+            const mockBackSpaceConnection = mock<BackSpaceConnection>({
+                write: mockWriteFunction,
+                closed: false,
+                on: vi.fn().mockReturnThis(),
+            });
+
+            const mockSocket = mock<PusherWebSocket>({
+                getUserData: vi.fn().mockReturnValue({
+                    spaceUserId: "foo_1",
+                    spaces: new Set<string>(["test"]),
+                }),
+            });
+
+            const spaceUser = SpaceUser.fromPartial({ spaceUserId: "foo_1", uuid: "uuid-foo_1", name: "foo" });
+
+            let resolveRemoveQuery: (answer: unknown) => void = () => {};
+            const mockSendQuery = vi.fn().mockImplementation(
+                () =>
+                    new Promise((resolve) => {
+                        resolveRemoveQuery = resolve;
+                    }),
+            );
+
+            const mockCleanup = vi.fn();
+            const mockSpace = {
+                name: "test",
+                _localConnectedUser: new Map<string, PusherWebSocket>([["foo_1", mockSocket]]),
+                _localConnectedUserWithSpaceUser: new Map<PusherWebSocket, SpaceUser>([[mockSocket, spaceUser]]),
+                _localWatchers: new Set<string>(["foo_1"]),
+                spaceStreamToBackPromise: Promise.resolve(mockBackSpaceConnection),
+                metadata: new Map(),
+                query: mock<Query>({
+                    send: mockSendQuery,
+                }),
+                cleanup: mockCleanup,
+                isEmpty: vi.fn().mockReturnValue(true),
+            } as unknown as Space;
+
+            const spaceForwarder = new SpaceToBackForwarder(mockSpace, eventProcessor);
+
+            // An explicit leave and the socket-close sweep both unregister the same socket while the
+            // first removeSpaceUserQuery is still pending.
+            const first = spaceForwarder.unregisterUser(mockSocket);
+            const second = spaceForwarder.unregisterUser(mockSocket);
+            await flushPromises();
+
+            resolveRemoveQuery({
+                $case: "removeSpaceUserAnswer",
+                removeSpaceUserAnswer: { spaceName: "test", spaceUserId: "foo_1" },
+            });
+            await Promise.all([first, second]);
+            await flushPromises();
+
+            expect(mockSendQuery).toHaveBeenCalledOnce();
+            const deleteToNotifyWrites = mockWriteFunction.mock.calls.filter(
+                (call) =>
+                    (call[0] as { message: { $case: string } }).message.$case === "deleteSpaceUserToNotifyMessage",
+            );
+            expect(deleteToNotifyWrites).toHaveLength(1);
+            expect(mockCleanup).toHaveBeenCalledOnce();
+
+            // Once the first unregistration settled, a later call is a fresh attempt again.
+            mockSendQuery.mockResolvedValue({
+                $case: "removeSpaceUserAnswer",
+                removeSpaceUserAnswer: { spaceName: "test", spaceUserId: "foo_1" },
+            });
+            await expect(spaceForwarder.unregisterUser(mockSocket)).resolves.toBeUndefined();
+            expect(mockSendQuery).toHaveBeenCalledTimes(2);
+        });
+
         it("shouldn't call cleanup when there are still local connected users", async () => {
             const callbackMap = new Map<string, (...args: unknown[]) => void>();
 
@@ -625,7 +698,7 @@ describe("SpaceToBackForwarder", () => {
                         },
                     },
                 },
-                expect.any(Function)
+                expect.any(Function),
             );
             expect(mockWriteFunction).toHaveBeenCalledOnce();
         });
@@ -665,7 +738,7 @@ describe("SpaceToBackForwarder", () => {
                             "metadata-1": "value-1",
                         }),
                     },
-                })
+                }),
             ).toThrow();
         });
 
@@ -713,7 +786,7 @@ describe("SpaceToBackForwarder", () => {
                 {
                     spaceName: "test",
                     messageCase: "updateSpaceMetadataPusherToBackMessage",
-                }
+                },
             );
 
             consoleWarnSpy.mockRestore();
@@ -766,7 +839,7 @@ describe("SpaceToBackForwarder", () => {
                         syncSpaceUsersMessage: { spaceName: "test", users: [spaceUser] },
                     },
                 },
-                expect.any(Function)
+                expect.any(Function),
             );
             expect(mockWriteFunction).toHaveBeenCalledOnce();
         });


### PR DESCRIPTION
## Problem

Sentry [BACK-2B](https://workadventure-e6.sentry.io/issues/BACK-2B) (`Sender <user> not found in space <space>`, ~200 events/day) and its sibling [BACK-28](https://workadventure-e6.sentry.io/issues/BACK-28).

`Space.dispatchPrivateEvent` requires the sender to still be a member of the space, but the WebRTC strategy tears down connections by sending a `webRtcDisconnectMessage` *from* the departing user. Whenever the back processes the user's removal before the matching `deleteSpaceUserToNotifyMessage`, it throws once per remaining peer.

Production logs (6 h, all back and play pods) show why the messages arrive in that order: every one of the 44 error clusters is followed within 1 ms by a second `removeSpaceUser` for the same user, and the pusher logs a matching `SpaceDestroyedError: Query "removeSpaceUserAnswer" cancelled ... (pending for 0-4ms)` from `leaveSpaces` 3 ms earlier. `unregisterUser` awaits the back's answer and only cleans local state in its `finally`, so a second call for the same socket during that window (explicit leave overlapping with the socket-close sweep) resends both messages after the remove. About 680 such duplicate removes per 6 h, most of them silent.

## Fix

- **Pusher** `SpaceToBackForwarder.unregisterUser`: return the in-flight promise when called again for the same socket. One delete-to-notify and one remove per departure; the second caller still awaits the real result.
- **Back** `WebRTCCommunicationStrategy.sendWebRTCDisconnect`: only tear down a connection that is actually tracked (no more N-1 spurious disconnects on a repeated teardown), and skip the dispatch when the sender already left the space. The receiver is already told to drop the peer by the `removeSpaceUserMessage` broadcast, and the front's `Space.removeUser` destroys that user's streams.

## Tests

- `back/tests/WebRTCCommunicationStrategy.test.ts`: one disconnect per direction, nothing on a repeated teardown; no throw and no dispatch on behalf of a departed sender.
- `play/tests/pusher/SpaceToBackForwarder.test.ts`: two concurrent `unregisterUser` calls send a single `removeSpaceUserQuery` and a single `deleteSpaceUserToNotifyMessage`.

Ran the related back suites (CommunicationManager, Space, TransitionOrchestrator, LivekitCommunicationStrategy), lint, prettier and typecheck on both packages.

Not addressed here: the front path that issues leave queries a few milliseconds before closing the socket was not identified (scene cleanup order has been unchanged since v1.30). With the pusher now idempotent, it no longer matters for correctness.

Fixes BACK-2B
Fixes BACK-28

🤖 Generated with [Claude Code](https://claude.com/claude-code)
