### PR TITLE
feat(recording): tell the admin when an egress ends

### DIFF
--- a/back/src/Model/CommunicationManager.ts
+++ b/back/src/Model/CommunicationManager.ts
@@ -7,6 +7,7 @@ import {
     type SpaceUser,
 } from "@workadventure/messages";
 import { MAX_USERS_FOR_WEBRTC } from "../Enum/EnvironmentVariable";
+import { adminApi, type RecordingEventPayload } from "../Services/AdminApi";
 import type { ICommunicationSpace } from "./Interfaces/ICommunicationSpace";
 import type { ICommunicationManager } from "./Interfaces/ICommunicationManager";
 import type { ICommunicationState, IRecordableState } from "./Interfaces/ICommunicationState";
@@ -69,6 +70,8 @@ export interface CommunicationManagerDependencies {
     initialStateFactory?: InitialStateFactory;
     livekitToWebRTCDelayMs?: number;
     recordingManager?: IRecordingManager;
+    /** Where recording lifecycle events go; the admin API by default. */
+    recordingEventNotifier?: (payload: RecordingEventPayload) => Promise<void>;
 }
 
 /**
@@ -89,6 +92,7 @@ export class CommunicationManager implements ICommunicationManager {
     private readonly lifecycleManager: IStateLifecycleManager;
     private readonly space: ICommunicationSpace;
     private readonly _recordingManager: IRecordingManager;
+    private readonly recordingEventNotifier: (payload: RecordingEventPayload) => Promise<void>;
 
     private static readonly DEFAULT_LIVEKIT_TO_WEBRTC_DELAY_MS = 20_000; // 20 seconds
 
@@ -128,6 +132,8 @@ export class CommunicationManager implements ICommunicationManager {
         this._recordingManager =
             dependencies.recordingManager ??
             new RecordingManager(this.space, this.orchestrator, this.userRegistry, this.lifecycleManager);
+        this.recordingEventNotifier =
+            dependencies.recordingEventNotifier ?? ((payload) => adminApi.notifyRecordingEvent(payload));
 
         // Initialize transition policy with LiveKit availability checker
         this.policy =
@@ -356,11 +362,17 @@ export class CommunicationManager implements ICommunicationManager {
     public handleNormalizedRecordingWebhook(request: HandleRecordingWebhookRequest): void {
         switch (request.phase) {
             case RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_STARTED: {
-                this._recordingManager.confirmRecordingStartedByWebhook(
+                // Read the recorder before confirming: the manager only exposes
+                // it while the session exists.
+                const recorder = this._recordingManager.getSessionRecorder(request.recordingSessionId);
+                const confirmed = this._recordingManager.confirmRecordingStartedByWebhook(
                     request.recordingSessionId,
                     request.egressId,
                     request.roomName,
                 );
+                if (confirmed && recorder) {
+                    this.notifyRecordingEvent(request, recorder, "started");
+                }
                 return;
             }
             case RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_ENDED: {
@@ -372,6 +384,8 @@ export class CommunicationManager implements ICommunicationManager {
                 if (!result.processed || !result.recorder) {
                     return;
                 }
+
+                this.notifyRecordingEvent(request, result.recorder, "ended");
 
                 if (result.unexpected) {
                     this.space.dispatchPrivateEvent({
@@ -396,6 +410,41 @@ export class CommunicationManager implements ICommunicationManager {
             case RecordingWebhookPhase.UNRECOGNIZED:
                 return;
         }
+    }
+
+    /**
+     * Fire-and-forget: the admin turning this into customer webhooks must
+     * never delay or fail the recording flow itself.
+     */
+    private notifyRecordingEvent(
+        request: HandleRecordingWebhookRequest,
+        recorder: SpaceUser,
+        phase: RecordingEventPayload["phase"],
+    ): void {
+        const payload: RecordingEventPayload = {
+            phase,
+            status: request.status,
+            egressId: request.egressId,
+            recordingSessionId: request.recordingSessionId,
+            playUri: recorder.playUri,
+            recorder: { uuid: recorder.uuid, spaceUserId: recorder.spaceUserId },
+            startedAt: request.startedAtMs ? new Date(request.startedAtMs).toISOString() : null,
+            endedAt: request.endedAtMs ? new Date(request.endedAtMs).toISOString() : null,
+            error: request.error || null,
+            files: request.fileResults.map((file) => ({
+                filename: file.filename,
+                sizeBytes: file.sizeBytes,
+                durationSeconds: Math.round(file.durationMs / 1_000),
+            })),
+        };
+
+        this.recordingEventNotifier(payload).catch((error) => {
+            console.error(
+                `Failed to notify the admin of a recording ${phase} event (egress ${request.egressId}):`,
+                error,
+            );
+            Sentry.captureException(error);
+        });
     }
 
     private scheduleTransitionAfterRecordingStops(user: SpaceUser): void {

--- a/back/src/Model/CommunicationManager.ts
+++ b/back/src/Model/CommunicationManager.ts
@@ -362,17 +362,11 @@ export class CommunicationManager implements ICommunicationManager {
     public handleNormalizedRecordingWebhook(request: HandleRecordingWebhookRequest): void {
         switch (request.phase) {
             case RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_STARTED: {
-                // Read the recorder before confirming: the manager only exposes
-                // it while the session exists.
-                const recorder = this._recordingManager.getSessionRecorder(request.recordingSessionId);
-                const confirmed = this._recordingManager.confirmRecordingStartedByWebhook(
+                this._recordingManager.confirmRecordingStartedByWebhook(
                     request.recordingSessionId,
                     request.egressId,
                     request.roomName,
                 );
-                if (confirmed && recorder) {
-                    this.notifyRecordingEvent(request, recorder, "started");
-                }
                 return;
             }
             case RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_ENDED: {
@@ -385,7 +379,7 @@ export class CommunicationManager implements ICommunicationManager {
                     return;
                 }
 
-                this.notifyRecordingEvent(request, result.recorder, "ended");
+                this.notifyRecordingEnded(request, result.recorder);
 
                 if (result.unexpected) {
                     this.space.dispatchPrivateEvent({
@@ -414,15 +408,13 @@ export class CommunicationManager implements ICommunicationManager {
 
     /**
      * Fire-and-forget: the admin turning this into customer webhooks must
-     * never delay or fail the recording flow itself.
+     * never delay or fail the recording flow itself. Only the end of an
+     * egress is reported; the admin reads the status to tell a usable
+     * recording from a failed one.
      */
-    private notifyRecordingEvent(
-        request: HandleRecordingWebhookRequest,
-        recorder: SpaceUser,
-        phase: RecordingEventPayload["phase"],
-    ): void {
+    private notifyRecordingEnded(request: HandleRecordingWebhookRequest, recorder: SpaceUser): void {
         const payload: RecordingEventPayload = {
-            phase,
+            phase: "ended",
             status: request.status,
             egressId: request.egressId,
             recordingSessionId: request.recordingSessionId,
@@ -439,10 +431,7 @@ export class CommunicationManager implements ICommunicationManager {
         };
 
         this.recordingEventNotifier(payload).catch((error) => {
-            console.error(
-                `Failed to notify the admin of a recording ${phase} event (egress ${request.egressId}):`,
-                error,
-            );
+            console.error(`Failed to notify the admin of a recording end (egress ${request.egressId}):`, error);
             Sentry.captureException(error);
         });
     }

--- a/back/src/Model/RecordingManager.ts
+++ b/back/src/Model/RecordingManager.ts
@@ -43,7 +43,6 @@ export interface IRecordingManager {
         roomName: string,
     ): { processed: boolean; recorder: SpaceUser | null; unexpected: boolean; hasActiveSessions: boolean };
     hasRecordingSession(recordingSessionId: string): boolean;
-    getSessionRecorder(recordingSessionId: string): SpaceUser | null;
     handleAddUser(user: SpaceUser): void;
     isRecording: boolean;
     destroy(): void;
@@ -135,10 +134,6 @@ export class RecordingManager implements IRecordingManager {
 
     public hasRecordingSession(recordingSessionId: string): boolean {
         return this.sessions.has(recordingSessionId);
-    }
-
-    public getSessionRecorder(recordingSessionId: string): SpaceUser | null {
-        return this.sessions.get(recordingSessionId)?.recorder ?? null;
     }
 
     public getRecordingState(): ManagedRecordingState {

--- a/back/src/Model/RecordingManager.ts
+++ b/back/src/Model/RecordingManager.ts
@@ -43,6 +43,7 @@ export interface IRecordingManager {
         roomName: string,
     ): { processed: boolean; recorder: SpaceUser | null; unexpected: boolean; hasActiveSessions: boolean };
     hasRecordingSession(recordingSessionId: string): boolean;
+    getSessionRecorder(recordingSessionId: string): SpaceUser | null;
     handleAddUser(user: SpaceUser): void;
     isRecording: boolean;
     destroy(): void;
@@ -134,6 +135,10 @@ export class RecordingManager implements IRecordingManager {
 
     public hasRecordingSession(recordingSessionId: string): boolean {
         return this.sessions.has(recordingSessionId);
+    }
+
+    public getSessionRecorder(recordingSessionId: string): SpaceUser | null {
+        return this.sessions.get(recordingSessionId)?.recorder ?? null;
     }
 
     public getRecordingState(): ManagedRecordingState {

--- a/back/src/Model/Services/LivekitService.ts
+++ b/back/src/Model/Services/LivekitService.ts
@@ -308,7 +308,25 @@ export class LiveKitService {
             status: this.toStatusName(egressInfo.status),
             error: egressInfo.error,
             createdAt: Number(event.createdAt),
+            startedAtMs: this.nanosecondsToMilliseconds(egressInfo.startedAt),
+            endedAtMs: this.nanosecondsToMilliseconds(egressInfo.endedAt),
+            fileResults: (egressInfo.fileResults ?? []).map((file) => ({
+                filename: file.filename,
+                sizeBytes: Number(file.size),
+                durationMs: this.nanosecondsToMilliseconds(file.duration),
+            })),
         });
+    }
+
+    /**
+     * LiveKit reports timestamps and durations as nanosecond bigints. Divide
+     * before converting: a nanosecond epoch does not fit in a double.
+     */
+    private nanosecondsToMilliseconds(nanoseconds: bigint | undefined): number {
+        if (nanoseconds === undefined) {
+            return 0;
+        }
+        return Number(nanoseconds / BigInt(1_000_000));
     }
 
     private async receiveWebhook(rawBody: Buffer | Uint8Array, authHeader: string | undefined): Promise<WebhookEvent> {

--- a/back/src/Services/AdminApi.ts
+++ b/back/src/Services/AdminApi.ts
@@ -5,7 +5,63 @@ import * as Sentry from "@sentry/node";
 import { ADMIN_API_TOKEN, ADMIN_API_URL } from "../Enum/EnvironmentVariable";
 import { LivekitCredentialsResponse } from "./Repository/LivekitCredentialsResponse";
 
+/**
+ * What the admin learns when a recording egress starts or ends. It turns
+ * this into customer webhooks (recording.started / completed / failed).
+ */
+export interface RecordingEventPayload {
+    phase: "started" | "ended";
+    status: string;
+    egressId: string;
+    recordingSessionId: string;
+    playUri: string;
+    recorder: { uuid: string; spaceUserId: string };
+    startedAt: string | null;
+    endedAt: string | null;
+    error: string | null;
+    files: { filename: string; sizeBytes: number; durationSeconds: number }[];
+}
+
+const RECORDING_EVENT_RETRY_DELAYS_MS = [250, 1_000, 4_000];
+
 class AdminApi {
+    /**
+     * Tells the admin about a recording lifecycle event. Retried a few times on
+     * transport or server errors; a 4xx means the admin rejected the payload
+     * and is not retried. Resolves silently when no admin is configured.
+     */
+    async notifyRecordingEvent(payload: RecordingEventPayload): Promise<void> {
+        if (!ADMIN_API_URL) {
+            return;
+        }
+
+        const url = new URL("api/recordings/events", ADMIN_API_URL).toString();
+        const send = async (attempt: number): Promise<void> => {
+            try {
+                await axios.post(url, payload, {
+                    headers: {
+                        Authorization: `${ADMIN_API_TOKEN ?? ""}`,
+                        Accept: "application/json",
+                    },
+                    timeout: 5_000,
+                });
+            } catch (error) {
+                const status = isAxiosError(error) ? error.response?.status : undefined;
+                const rejected =
+                    status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 429;
+                if (rejected || attempt >= RECORDING_EVENT_RETRY_DELAYS_MS.length) {
+                    throw error;
+                }
+                await new Promise<void>((resolve) => {
+                    setTimeout(resolve, RECORDING_EVENT_RETRY_DELAYS_MS[attempt]);
+                });
+                return send(attempt + 1);
+            }
+        };
+
+        return send(0);
+    }
+
     async fetchLivekitCredentials(spaceId: string, playUri: string): Promise<LivekitCredentialsResponse> {
         if (!ADMIN_API_URL) {
             return Promise.reject(new Error("No admin backoffice set!"));

--- a/back/src/Services/AdminApi.ts
+++ b/back/src/Services/AdminApi.ts
@@ -6,11 +6,11 @@ import { ADMIN_API_TOKEN, ADMIN_API_URL } from "../Enum/EnvironmentVariable";
 import { LivekitCredentialsResponse } from "./Repository/LivekitCredentialsResponse";
 
 /**
- * What the admin learns when a recording egress starts or ends. It turns
- * this into customer webhooks (recording.started / completed / failed).
+ * What the admin learns when a recording egress ends. It turns a completed
+ * one into a customer webhook (recording.completed).
  */
 export interface RecordingEventPayload {
-    phase: "started" | "ended";
+    phase: "ended";
     status: string;
     egressId: string;
     recordingSessionId: string;
@@ -26,7 +26,7 @@ const RECORDING_EVENT_RETRY_DELAYS_MS = [250, 1_000, 4_000];
 
 class AdminApi {
     /**
-     * Tells the admin about a recording lifecycle event. Retried a few times on
+     * Tells the admin that a recording egress ended. Retried a few times on
      * transport or server errors; a 4xx means the admin rejected the payload
      * and is not retried. Resolves silently when no admin is configured.
      */

--- a/back/tests/AdminApi.test.ts
+++ b/back/tests/AdminApi.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import axios, { AxiosError, AxiosHeaders } from "axios";
+import type { RecordingEventPayload } from "../src/Services/AdminApi";
+
+vi.mock("../src/Enum/EnvironmentVariable", () => ({
+    ADMIN_API_URL: "http://admin.test/",
+    ADMIN_API_TOKEN: "admin-token",
+}));
+
+const { adminApi } = await import("../src/Services/AdminApi");
+
+const payload: RecordingEventPayload = {
+    phase: "ended",
+    status: "EGRESS_COMPLETE",
+    egressId: "egress-1",
+    recordingSessionId: "session-1",
+    playUri: "http://play.test/@/team/world/room",
+    recorder: { uuid: "recorder-uuid", spaceUserId: "1" },
+    startedAt: "2023-11-14T22:13:20.000Z",
+    endedAt: "2023-11-14T22:23:30.000Z",
+    error: null,
+    files: [{ filename: "recorder-uuid/recording-1.mp4", sizeBytes: 123, durationSeconds: 610 }],
+};
+
+function httpError(status: number): AxiosError {
+    return new AxiosError("failed", "ERR_BAD_RESPONSE", undefined, undefined, {
+        status,
+        statusText: "",
+        data: {},
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+    });
+}
+
+describe("AdminApi.notifyRecordingEvent", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it("posts the payload to the admin recordings endpoint with the admin token", async () => {
+        const post = vi.spyOn(axios, "post");
+        post.mockResolvedValue({ status: 202 });
+
+        await adminApi.notifyRecordingEvent(payload);
+
+        expect(post).toHaveBeenCalledTimes(1);
+        expect(post).toHaveBeenCalledWith(
+            "http://admin.test/api/recordings/events",
+            payload,
+            expect.objectContaining({
+                headers: expect.objectContaining({ Authorization: "admin-token" }),
+            }),
+        );
+    });
+
+    it("retries transport and server errors, then gives up", async () => {
+        const post = vi.spyOn(axios, "post");
+        post.mockRejectedValue(httpError(503));
+
+        const promise = adminApi.notifyRecordingEvent(payload);
+        // Keep the rejection handled while the fake timers advance through the backoff.
+        promise.catch(() => undefined);
+        await vi.runAllTimersAsync();
+        await expect(promise).rejects.toBeInstanceOf(AxiosError);
+
+        expect(post).toHaveBeenCalledTimes(4);
+    });
+
+    it("does not retry when the admin rejects the payload", async () => {
+        const post = vi.spyOn(axios, "post");
+        post.mockRejectedValue(httpError(422));
+
+        await expect(adminApi.notifyRecordingEvent(payload)).rejects.toBeInstanceOf(AxiosError);
+
+        expect(post).toHaveBeenCalledTimes(1);
+    });
+});

--- a/back/tests/CommunicationManager.test.ts
+++ b/back/tests/CommunicationManager.test.ts
@@ -85,7 +85,6 @@ describe("CommunicationManager", () => {
             stopRecordingByServer: vi.fn().mockResolvedValue(null),
             stopRecordingIfRecorderMatches: vi.fn().mockResolvedValue(null),
             hasRecordingSession: vi.fn().mockReturnValue(false),
-            getSessionRecorder: vi.fn().mockReturnValue(null),
             confirmRecordingStartedByWebhook: vi.fn().mockReturnValue(false),
             finishRecordingByWebhook: vi
                 .fn()
@@ -101,7 +100,6 @@ describe("CommunicationManager", () => {
             stopRecordingByServer: mocks.stopRecordingByServer,
             stopRecordingIfRecorderMatches: mocks.stopRecordingIfRecorderMatches,
             hasRecordingSession: mocks.hasRecordingSession,
-            getSessionRecorder: mocks.getSessionRecorder,
             confirmRecordingStartedByWebhook: mocks.confirmRecordingStartedByWebhook,
             finishRecordingByWebhook: mocks.finishRecordingByWebhook,
             handleAddUser: mocks.handleAddUser,
@@ -856,11 +854,16 @@ describe("CommunicationManager", () => {
             expect(recordingEventNotifier).not.toHaveBeenCalled();
         });
 
-        it("should notify the admin when a started webhook confirms a session, and survive a failing admin", async () => {
+        it("should not notify the admin when a started webhook arrives, and survive a failing admin on end", async () => {
             const recordingManager = createRecordingManager();
             const recorder = createSpaceUser("recorder_1");
-            recordingManager.mocks.getSessionRecorder.mockReturnValue(recorder);
             recordingManager.mocks.confirmRecordingStartedByWebhook.mockReturnValue(true);
+            recordingManager.mocks.finishRecordingByWebhook.mockReturnValue({
+                processed: true,
+                recorder,
+                unexpected: false,
+                hasActiveSessions: true,
+            });
             const recordingEventNotifier = vi.fn().mockRejectedValue(new Error("admin down"));
 
             const manager = new CommunicationManager(createSpace(), {
@@ -871,14 +874,26 @@ describe("CommunicationManager", () => {
                 recordingEventNotifier,
             });
 
+            manager.handleNormalizedRecordingWebhook(
+                HandleRecordingWebhookRequest.fromPartial({
+                    recordingSessionId: "session-1",
+                    egressId: "egress-1",
+                    roomName: "test-space",
+                    phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_STARTED,
+                    status: "EGRESS_ACTIVE",
+                })
+            );
+            expect(recordingEventNotifier).not.toHaveBeenCalled();
+
             expect(() =>
                 manager.handleNormalizedRecordingWebhook(
                     HandleRecordingWebhookRequest.fromPartial({
                         recordingSessionId: "session-1",
                         egressId: "egress-1",
                         roomName: "test-space",
-                        phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_STARTED,
-                        status: "EGRESS_ACTIVE",
+                        phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_ENDED,
+                        status: "EGRESS_FAILED",
+                        error: "upload failed",
                     })
                 )
             ).not.toThrow();
@@ -886,8 +901,9 @@ describe("CommunicationManager", () => {
 
             expect(recordingEventNotifier).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    phase: "started",
-                    egressId: "egress-1",
+                    phase: "ended",
+                    status: "EGRESS_FAILED",
+                    error: "upload failed",
                     recorder: { uuid: "uuid-recorder_1", spaceUserId: "recorder_1" },
                     startedAt: null,
                     files: [],

--- a/back/tests/CommunicationManager.test.ts
+++ b/back/tests/CommunicationManager.test.ts
@@ -85,6 +85,7 @@ describe("CommunicationManager", () => {
             stopRecordingByServer: vi.fn().mockResolvedValue(null),
             stopRecordingIfRecorderMatches: vi.fn().mockResolvedValue(null),
             hasRecordingSession: vi.fn().mockReturnValue(false),
+            getSessionRecorder: vi.fn().mockReturnValue(null),
             confirmRecordingStartedByWebhook: vi.fn().mockReturnValue(false),
             finishRecordingByWebhook: vi
                 .fn()
@@ -100,6 +101,7 @@ describe("CommunicationManager", () => {
             stopRecordingByServer: mocks.stopRecordingByServer,
             stopRecordingIfRecorderMatches: mocks.stopRecordingIfRecorderMatches,
             hasRecordingSession: mocks.hasRecordingSession,
+            getSessionRecorder: mocks.getSessionRecorder,
             confirmRecordingStartedByWebhook: mocks.confirmRecordingStartedByWebhook,
             finishRecordingByWebhook: mocks.finishRecordingByWebhook,
             handleAddUser: mocks.handleAddUser,
@@ -777,6 +779,119 @@ describe("CommunicationManager", () => {
                 }),
                 expect.any(Function),
                 expect.any(Function)
+            );
+        });
+
+        it("should notify the admin once when an ended webhook is processed", async () => {
+            const state = createState(CommunicationType.LIVEKIT);
+            const recordingManager = createRecordingManager();
+            const recorder = createSpaceUser("recorder_1", "http://play.test/@/team/world/room");
+            const recordingEventNotifier = vi.fn().mockResolvedValue(undefined);
+
+            recordingManager.mocks.finishRecordingByWebhook.mockReturnValue({
+                processed: true,
+                recorder,
+                unexpected: false,
+                hasActiveSessions: true,
+            });
+
+            const manager = new CommunicationManager(createSpace(), {
+                orchestrator: createOrchestrator(),
+                lifecycleManager: createLifecycleManager(state),
+                recordingManager,
+                policy: createPolicy(false),
+                recordingEventNotifier,
+            });
+
+            manager.handleNormalizedRecordingWebhook(
+                HandleRecordingWebhookRequest.fromPartial({
+                    recordingSessionId: "session-1",
+                    egressId: "egress-1",
+                    roomName: "test-space",
+                    phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_ENDED,
+                    status: "EGRESS_COMPLETE",
+                    startedAtMs: 1_700_000_000_000,
+                    endedAtMs: 1_700_000_610_000,
+                    fileResults: [{ filename: "uuid-recorder_1/recording-1.mp4", sizeBytes: 123, durationMs: 610_400 }],
+                })
+            );
+            await Promise.resolve();
+
+            expect(recordingEventNotifier).toHaveBeenCalledTimes(1);
+            expect(recordingEventNotifier).toHaveBeenCalledWith({
+                phase: "ended",
+                status: "EGRESS_COMPLETE",
+                egressId: "egress-1",
+                recordingSessionId: "session-1",
+                playUri: "http://play.test/@/team/world/room",
+                recorder: { uuid: "uuid-recorder_1", spaceUserId: "recorder_1" },
+                startedAt: "2023-11-14T22:13:20.000Z",
+                endedAt: "2023-11-14T22:23:30.000Z",
+                error: null,
+                files: [{ filename: "uuid-recorder_1/recording-1.mp4", sizeBytes: 123, durationSeconds: 610 }],
+            });
+        });
+
+        it("should not notify the admin when the ended webhook matches no session", () => {
+            const recordingManager = createRecordingManager();
+            const recordingEventNotifier = vi.fn().mockResolvedValue(undefined);
+
+            const manager = new CommunicationManager(createSpace(), {
+                orchestrator: createOrchestrator(),
+                lifecycleManager: createLifecycleManager(createState(CommunicationType.LIVEKIT)),
+                recordingManager,
+                policy: createPolicy(false),
+                recordingEventNotifier,
+            });
+
+            manager.handleNormalizedRecordingWebhook(
+                HandleRecordingWebhookRequest.fromPartial({
+                    recordingSessionId: "unknown",
+                    egressId: "egress-1",
+                    roomName: "test-space",
+                    phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_ENDED,
+                })
+            );
+
+            expect(recordingEventNotifier).not.toHaveBeenCalled();
+        });
+
+        it("should notify the admin when a started webhook confirms a session, and survive a failing admin", async () => {
+            const recordingManager = createRecordingManager();
+            const recorder = createSpaceUser("recorder_1");
+            recordingManager.mocks.getSessionRecorder.mockReturnValue(recorder);
+            recordingManager.mocks.confirmRecordingStartedByWebhook.mockReturnValue(true);
+            const recordingEventNotifier = vi.fn().mockRejectedValue(new Error("admin down"));
+
+            const manager = new CommunicationManager(createSpace(), {
+                orchestrator: createOrchestrator(),
+                lifecycleManager: createLifecycleManager(createState(CommunicationType.LIVEKIT)),
+                recordingManager,
+                policy: createPolicy(false),
+                recordingEventNotifier,
+            });
+
+            expect(() =>
+                manager.handleNormalizedRecordingWebhook(
+                    HandleRecordingWebhookRequest.fromPartial({
+                        recordingSessionId: "session-1",
+                        egressId: "egress-1",
+                        roomName: "test-space",
+                        phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_STARTED,
+                        status: "EGRESS_ACTIVE",
+                    })
+                )
+            ).not.toThrow();
+            await Promise.resolve();
+
+            expect(recordingEventNotifier).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    phase: "started",
+                    egressId: "egress-1",
+                    recorder: { uuid: "uuid-recorder_1", spaceUserId: "recorder_1" },
+                    startedAt: null,
+                    files: [],
+                })
             );
         });
 

--- a/back/tests/LivekitService.test.ts
+++ b/back/tests/LivekitService.test.ts
@@ -153,6 +153,16 @@ describe("LiveKitService", () => {
                 roomName: "test-space",
                 status: EgressStatus.EGRESS_ABORTED,
                 error: "egress stopped remotely",
+                // LiveKit reports nanoseconds.
+                startedAt: 1_700_000_000_000_000_000n,
+                endedAt: 1_700_000_610_000_000_000n,
+                fileResults: [
+                    {
+                        filename: "recorder-uuid/recording-2023-11-14T22:13:20.mp4",
+                        size: 4_096n,
+                        duration: 610_400_000_000n,
+                    },
+                ],
             },
         });
         const service = createService(vi.fn(), vi.fn(), receive);
@@ -170,6 +180,30 @@ describe("LiveKitService", () => {
             status: "EGRESS_ABORTED",
             error: "egress stopped remotely",
             createdAt: 1234,
+            startedAtMs: 1_700_000_000_000,
+            endedAtMs: 1_700_000_610_000,
+            fileResults: [
+                { filename: "recorder-uuid/recording-2023-11-14T22:13:20.mp4", sizeBytes: 4096, durationMs: 610_400 },
+            ],
+        });
+    });
+
+    it("leaves timestamps at zero and files empty when LiveKit reports none", async () => {
+        const receive = vi.fn().mockResolvedValue({
+            event: "egress_started",
+            id: "event-2",
+            createdAt: 1n,
+            egressInfo: { egressId: "egress-1", roomName: "test-space", status: EgressStatus.EGRESS_ACTIVE },
+        });
+        const service = createService(vi.fn(), vi.fn(), receive);
+
+        const result = await service.handleLivekitWebhook(Buffer.from("{}"), "jwt-token", "space-name", "session-1");
+
+        expect(result).toMatchObject({
+            phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_STARTED,
+            startedAtMs: 0,
+            endedAtMs: 0,
+            fileResults: [],
         });
     });
 

--- a/back/tests/TransitionPolicy.test.ts
+++ b/back/tests/TransitionPolicy.test.ts
@@ -22,6 +22,7 @@ describe("TransitionPolicy", () => {
         stopRecordingByServer: () => Promise.resolve(null),
         stopRecordingIfRecorderMatches: () => Promise.resolve(null),
         hasRecordingSession: () => false,
+        getSessionRecorder: () => null,
         confirmRecordingStartedByWebhook: () => false,
         finishRecordingByWebhook: () => ({
             processed: false,

--- a/back/tests/TransitionPolicy.test.ts
+++ b/back/tests/TransitionPolicy.test.ts
@@ -22,7 +22,6 @@ describe("TransitionPolicy", () => {
         stopRecordingByServer: () => Promise.resolve(null),
         stopRecordingIfRecorderMatches: () => Promise.resolve(null),
         hasRecordingSession: () => false,
-        getSessionRecorder: () => null,
         confirmRecordingStartedByWebhook: () => false,
         finishRecordingByWebhook: () => ({
             processed: false,

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -898,6 +898,18 @@ message HandleRecordingWebhookRequest {
   string status = 7;
   string error = 8;
   int64 createdAt = 9;
+  // Milliseconds since the epoch, 0 when LiveKit did not report them.
+  int64 startedAtMs = 10;
+  int64 endedAtMs = 11;
+  // The files LiveKit wrote for this egress (empty until the egress ended).
+  repeated RecordingFileResult fileResults = 12;
+}
+
+message RecordingFileResult {
+  // Object key in the recording bucket, as LiveKit reports it.
+  string filename = 1;
+  int64 sizeBytes = 2;
+  int64 durationMs = 3;
 }
 
 message HandleLivekitWebhookRequest {


### PR DESCRIPTION
## What

The back notifies the admin API when a LiveKit recording egress **ends**, so the admin can turn a completed one into a customer-facing webhook (`recording.completed`, see the SaaS webhooks feature).

- `POST /api/recordings/events` on the admin, only when `ADMIN_API_URL` is set. Payload: `phase` (always `ended`), `status` (`EGRESS_COMPLETE`, `EGRESS_FAILED`, …), `egressId`, `recordingSessionId`, `playUri`, `recorder` (`uuid`, `spaceUserId`), ISO `startedAt` / `endedAt`, `error`, and the files LiveKit wrote (`filename`, `sizeBytes`, `durationSeconds`). The admin reads the status to tell a usable recording from a failed one.
- Retried 3 times on transport / 5xx errors (250 ms, 1 s, 4 s); a 4xx is not retried. Fire-and-forget from `CommunicationManager`: a failing admin never delays or breaks the recording flow (logged + Sentry).
- `HandleRecordingWebhookRequest` gains `startedAtMs`, `endedAtMs` and `fileResults`, copied from the LiveKit `EgressInfo` (nanosecond bigints divided before conversion). Used only inside the back.
- Nothing is sent when an egress starts.

## Why

Today the admin only ever discovers recordings by listing the S3 bucket once a day. Customers asked to be notified on their own server when a recording is ready, with a download link.

## Tests

- `back/tests/CommunicationManager.test.ts`: notifier called once with the full payload when an egress ends, not called on start nor for an unknown session, a rejecting notifier does not throw.
- `back/tests/LivekitService.test.ts`: timestamps and file results copied (and zero/empty when absent).
- `back/tests/AdminApi.test.ts` (new): URL + token, retry then give up, no retry on 4xx.
- `npm run typecheck`, `npm run lint` and `npm run pretty-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)