### PR TITLE
fix(back): stop sending WEBRTC to the user who tips a bubble into LiveKit

### DIFF
--- a/back/src/Model/CommunicationManager.ts
+++ b/back/src/Model/CommunicationManager.ts
@@ -241,9 +241,25 @@ export class CommunicationManager implements ICommunicationManager {
         type: CommunicationType,
         context: TransitionContext,
     ): Promise<void> {
-        // Hold the transition lock so a handler arriving mid-creation (typically the joiner's watch)
-        // waits for this transition instead of cancelling it and creating a second LiveKit state.
-        const transition = (async () => {
+        // Hold the transition lock while the next state is created, so a handler arriving mid-creation
+        // (typically the joiner's watch) waits for this transition instead of cancelling it and creating
+        // a second LiveKit state. The lock is released as soon as the new state is current and the switch
+        // has been dispatched, NOT after init(): a user joining during init() must be notified through
+        // the new state right away, before init() sends them their LiveKit invitation.
+        let released = false;
+        let release!: () => void;
+        this.orchestrator.setTransitionLock(
+            new Promise<void>((resolve) => {
+                release = resolve;
+            }),
+        );
+        const releaseLock = () => {
+            if (released) return;
+            released = true;
+            this.orchestrator.clearTransitionLock();
+            release();
+        };
+        try {
             const nextState = await this.orchestrator.executeImmediateTransition(type, context);
 
             if (!nextState) {
@@ -263,13 +279,12 @@ export class CommunicationManager implements ICommunicationManager {
                 return;
             }
 
-            await this.lifecycleManager.transitionTo(nextState);
-        })();
-        this.orchestrator.setTransitionLock(transition);
-        try {
+            // transitionTo() swaps the current state and dispatches the switch synchronously, then awaits init().
+            const transition = this.lifecycleManager.transitionTo(nextState);
+            releaseLock();
             await transition;
         } finally {
-            this.orchestrator.clearTransitionLock();
+            releaseLock();
         }
     }
 

--- a/back/src/Model/CommunicationManager.ts
+++ b/back/src/Model/CommunicationManager.ts
@@ -144,8 +144,14 @@ export class CommunicationManager implements ICommunicationManager {
         this.userRegistry.addUser(user);
         this.cancelPendingTransitionIfNeeded();
 
-        await this.lifecycleManager.getCurrentState().handleUserAdded(user);
+        // Decide the strategy before telling the joiner which one to use. If this join tips the
+        // bubble into LiveKit, the old state's switchState() already told the joiner (the registry
+        // maps are shared with the states) and the new state's init() already added them.
+        const stateBefore = this.lifecycleManager.getCurrentState();
         await this.evaluateAndHandleTransition(user);
+        if (this.lifecycleManager.getCurrentState() === stateBefore) {
+            await stateBefore.handleUserAdded(user);
+        }
     }
 
     public async handleUserDeleted(user: SpaceUser): Promise<void> {
@@ -164,8 +170,12 @@ export class CommunicationManager implements ICommunicationManager {
         this.userRegistry.addUserToNotify(user);
         this.cancelPendingTransitionIfNeeded();
 
-        await this.lifecycleManager.getCurrentState().handleUserToNotifyAdded(user);
+        // Same ordering as handleUserAdded.
+        const stateBefore = this.lifecycleManager.getCurrentState();
         await this.evaluateAndHandleTransition(user);
+        if (this.lifecycleManager.getCurrentState() === stateBefore) {
+            await stateBefore.handleUserToNotifyAdded(user);
+        }
     }
 
     public async handleUserToNotifyDeleted(user: SpaceUser): Promise<void> {
@@ -231,26 +241,36 @@ export class CommunicationManager implements ICommunicationManager {
         type: CommunicationType,
         context: TransitionContext,
     ): Promise<void> {
-        const nextState = await this.orchestrator.executeImmediateTransition(type, context);
+        // Hold the transition lock so a handler arriving mid-creation (typically the joiner's watch)
+        // waits for this transition instead of cancelling it and creating a second LiveKit state.
+        const transition = (async () => {
+            const nextState = await this.orchestrator.executeImmediateTransition(type, context);
 
-        if (!nextState) {
-            return;
+            if (!nextState) {
+                return;
+            }
+
+            // Final validation before setting state
+            const currentType = this.lifecycleManager.getCurrentState().communicationType as CommunicationType;
+            const userCount = this.space.getAllUsers().length;
+
+            if (!this.policy.shouldTransition(currentType, userCount)) {
+                return;
+            }
+
+            const expectedNextType = this.policy.getNextStateType(currentType, userCount);
+            if (expectedNextType && nextState.communicationType !== expectedNextType) {
+                return;
+            }
+
+            await this.lifecycleManager.transitionTo(nextState);
+        })();
+        this.orchestrator.setTransitionLock(transition);
+        try {
+            await transition;
+        } finally {
+            this.orchestrator.clearTransitionLock();
         }
-
-        // Final validation before setting state
-        const currentType = this.lifecycleManager.getCurrentState().communicationType as CommunicationType;
-        const userCount = this.space.getAllUsers().length;
-
-        if (!this.policy.shouldTransition(currentType, userCount)) {
-            return;
-        }
-
-        const expectedNextType = this.policy.getNextStateType(currentType, userCount);
-        if (expectedNextType && nextState.communicationType !== expectedNextType) {
-            return;
-        }
-
-        await this.lifecycleManager.transitionTo(nextState);
     }
 
     /**

--- a/back/tests/CommunicationManager.test.ts
+++ b/back/tests/CommunicationManager.test.ts
@@ -34,7 +34,7 @@ describe("CommunicationManager", () => {
 
     // Real state object (minimal implementation)
     const createState = (
-        type: CommunicationType
+        type: CommunicationType,
     ): ICommunicationState<ICommunicationStrategy> & { mocks: Record<string, ReturnType<typeof vi.fn>> } => {
         const mocks = {
             init: vi.fn().mockResolvedValue(undefined),
@@ -112,7 +112,7 @@ describe("CommunicationManager", () => {
     // Real policy implementation (simple, testable)
     const createPolicy = (
         shouldTransitionResult = false,
-        nextStateType: CommunicationType | null = null
+        nextStateType: CommunicationType | null = null,
     ): ITransitionPolicy & { mocks: Record<string, ReturnType<typeof vi.fn>> } => {
         const mocks = {
             shouldTransition: vi.fn().mockReturnValue(shouldTransitionResult),
@@ -152,7 +152,7 @@ describe("CommunicationManager", () => {
 
     // Real lifecycle manager implementation
     const createLifecycleManager = (
-        initialState: ICommunicationState<ICommunicationStrategy>
+        initialState: ICommunicationState<ICommunicationStrategy>,
     ): IStateLifecycleManager & { mocks: Record<string, ReturnType<typeof vi.fn>> } => {
         const mocks = {
             getCurrentState: vi.fn().mockReturnValue(initialState),
@@ -171,7 +171,7 @@ describe("CommunicationManager", () => {
 
     // Initial state factory
     const createInitialStateFactory = (
-        state: ICommunicationState<ICommunicationStrategy>
+        state: ICommunicationState<ICommunicationStrategy>,
     ): InitialStateFactory & { mocks: Record<string, ReturnType<typeof vi.fn>> } => {
         const mocks = {
             createInitialState: vi.fn().mockReturnValue(state),
@@ -235,7 +235,7 @@ describe("CommunicationManager", () => {
             expect(initialStateFactory.mocks.createInitialState).toHaveBeenCalledWith(
                 space,
                 expect.any(Map),
-                expect.any(Map)
+                expect.any(Map),
             );
         });
     });
@@ -531,7 +531,7 @@ describe("CommunicationManager", () => {
                 expect.objectContaining({
                     space: space,
                     playUri: user.playUri,
-                })
+                }),
             );
         });
 
@@ -555,7 +555,7 @@ describe("CommunicationManager", () => {
                 CommunicationType.WEBRTC,
                 expect.any(Object),
                 expect.any(Function),
-                expect.any(Function)
+                expect.any(Function),
             );
         });
 
@@ -586,6 +586,60 @@ describe("CommunicationManager", () => {
             await manager.handleUserAdded(user);
 
             expect(lifecycleManager.mocks.transitionTo).toHaveBeenCalledWith(newState);
+        });
+
+        it("should make a concurrent watch wait for the in-flight transition instead of cancelling it", async () => {
+            const space = createSpace();
+            const oldState = createState(CommunicationType.WEBRTC);
+            const newState = createState(CommunicationType.LIVEKIT);
+
+            // Orchestrator mock with a real transition lock and a deferred state creation
+            const orchestrator = createOrchestrator();
+            orchestrator.mocks.setTransitionLock.mockImplementation((promise: Promise<void>) => {
+                orchestrator.mocks.waitForTransitionLock.mockReturnValue(promise);
+            });
+            orchestrator.mocks.clearTransitionLock.mockImplementation(() => {
+                orchestrator.mocks.waitForTransitionLock.mockResolvedValue(undefined);
+            });
+            let resolveCreation!: (state: ICommunicationState<ICommunicationStrategy>) => void;
+            orchestrator.mocks.executeImmediateTransition.mockReturnValue(
+                new Promise<ICommunicationState<ICommunicationStrategy>>((resolve) => {
+                    resolveCreation = resolve;
+                }),
+            );
+
+            const policy = createPolicy(true, CommunicationType.LIVEKIT);
+            policy.mocks.shouldTransition.mockImplementation(
+                (currentType: CommunicationType) => currentType === CommunicationType.WEBRTC,
+            );
+            const lifecycleManager = createLifecycleManager(oldState);
+            lifecycleManager.mocks.transitionTo.mockImplementation(
+                (state: ICommunicationState<ICommunicationStrategy>) => {
+                    lifecycleManager.mocks.getCurrentState.mockReturnValue(state);
+                },
+            );
+
+            const manager = new CommunicationManager(space, {
+                policy: policy,
+                orchestrator: orchestrator,
+                lifecycleManager: lifecycleManager,
+            });
+
+            const joiner = createSpaceUser("user_5");
+            const joinPromise = manager.handleUserAdded(joiner);
+            // The join and the watch are two distinct back messages: give the join one tick to take the lock
+            await Promise.resolve();
+            const watchPromise = manager.handleUserToNotifyAdded(joiner);
+            // Let the watch reach the lock before the LiveKit state is ready
+            await Promise.resolve();
+            resolveCreation(newState);
+            await Promise.all([joinPromise, watchPromise]);
+
+            expect(orchestrator.mocks.executeImmediateTransition).toHaveBeenCalledTimes(1);
+            expect(orchestrator.mocks.cancelPendingTransition).toHaveBeenCalledTimes(1);
+            expect(lifecycleManager.mocks.transitionTo).toHaveBeenCalledTimes(1);
+            expect(oldState.mocks.handleUserAdded).not.toHaveBeenCalled();
+            expect(oldState.mocks.handleUserToNotifyAdded).not.toHaveBeenCalled();
         });
 
         it("should not transition when immediate transition returns null", async () => {
@@ -761,13 +815,13 @@ describe("CommunicationManager", () => {
                     egressId: "egress-1",
                     roomName: "test-space",
                     phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_ENDED,
-                })
+                }),
             );
 
             expect(recordingManager.mocks.finishRecordingByWebhook).toHaveBeenCalledWith(
                 "session-1",
                 "egress-1",
-                "test-space"
+                "test-space",
             );
             expect(orchestrator.mocks.scheduleDelayedTransition).toHaveBeenCalledWith(
                 CommunicationType.WEBRTC,
@@ -776,7 +830,7 @@ describe("CommunicationManager", () => {
                     space,
                 }),
                 expect.any(Function),
-                expect.any(Function)
+                expect.any(Function),
             );
         });
 
@@ -815,19 +869,19 @@ describe("CommunicationManager", () => {
                     recordingSessionId: "session-1",
                     rawBody: Buffer.from("{}"),
                     authorizationHeader: "jwt-token",
-                })
+                }),
             );
 
             expect(state.handleLivekitWebhook).toHaveBeenCalledWith(
                 expect.any(Uint8Array),
                 "jwt-token",
                 "test-space",
-                "session-1"
+                "session-1",
             );
             expect(recordingManager.mocks.finishRecordingByWebhook).toHaveBeenCalledWith(
                 "session-1",
                 "egress-1",
-                "test-space"
+                "test-space",
             );
         });
 
@@ -860,7 +914,7 @@ describe("CommunicationManager", () => {
                     egressId: "egress-1",
                     roomName: "test-space",
                     phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_ENDED,
-                })
+                }),
             );
 
             expect(space.dispatchPrivateEvent).toHaveBeenCalledWith({
@@ -905,7 +959,7 @@ describe("CommunicationManager", () => {
                     egressId: "egress-1",
                     roomName: "test-space",
                     phase: RecordingWebhookPhase.RECORDING_WEBHOOK_PHASE_ENDED,
-                })
+                }),
             );
 
             expect(orchestrator.mocks.scheduleDelayedTransition).not.toHaveBeenCalled();
@@ -920,7 +974,7 @@ describe("CommunicationManager", () => {
                 (_type: CommunicationType, _context: unknown, onComplete: TransitionCompleteCallback) => {
                     capturedCallback = onComplete;
                     return { abortController: new AbortController() };
-                }
+                },
             );
 
             const policy = createPolicy(true, CommunicationType.WEBRTC);
@@ -952,7 +1006,7 @@ describe("CommunicationManager", () => {
                 (_type: CommunicationType, _context: unknown, onComplete: TransitionCompleteCallback) => {
                     capturedCallback = onComplete;
                     return { abortController: new AbortController() };
-                }
+                },
             );
 
             // Start with transition allowed

--- a/back/tests/CommunicationManager.test.ts
+++ b/back/tests/CommunicationManager.test.ts
@@ -1,5 +1,5 @@
 // Disabled because test mocks use vi.fn() which are passed as object properties
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 import {
     HandleLivekitWebhookRequest,
     HandleRecordingWebhookRequest,
@@ -588,6 +588,16 @@ describe("CommunicationManager", () => {
             expect(lifecycleManager.mocks.transitionTo).toHaveBeenCalledWith(newState);
         });
 
+        // Gives the orchestrator mock a real transition lock (waiters block until it is cleared)
+        const withRealTransitionLock = (orchestrator: ReturnType<typeof createOrchestrator>) => {
+            orchestrator.mocks.setTransitionLock.mockImplementation((promise: Promise<void>) => {
+                orchestrator.mocks.waitForTransitionLock.mockReturnValue(promise);
+            });
+            orchestrator.mocks.clearTransitionLock.mockImplementation(() => {
+                orchestrator.mocks.waitForTransitionLock.mockResolvedValue(undefined);
+            });
+        };
+
         it("should make a concurrent watch wait for the in-flight transition instead of cancelling it", async () => {
             const space = createSpace();
             const oldState = createState(CommunicationType.WEBRTC);
@@ -595,12 +605,7 @@ describe("CommunicationManager", () => {
 
             // Orchestrator mock with a real transition lock and a deferred state creation
             const orchestrator = createOrchestrator();
-            orchestrator.mocks.setTransitionLock.mockImplementation((promise: Promise<void>) => {
-                orchestrator.mocks.waitForTransitionLock.mockReturnValue(promise);
-            });
-            orchestrator.mocks.clearTransitionLock.mockImplementation(() => {
-                orchestrator.mocks.waitForTransitionLock.mockResolvedValue(undefined);
-            });
+            withRealTransitionLock(orchestrator);
             let resolveCreation!: (state: ICommunicationState<ICommunicationStrategy>) => void;
             orchestrator.mocks.executeImmediateTransition.mockReturnValue(
                 new Promise<ICommunicationState<ICommunicationStrategy>>((resolve) => {
@@ -640,6 +645,59 @@ describe("CommunicationManager", () => {
             expect(lifecycleManager.mocks.transitionTo).toHaveBeenCalledTimes(1);
             expect(oldState.mocks.handleUserAdded).not.toHaveBeenCalled();
             expect(oldState.mocks.handleUserToNotifyAdded).not.toHaveBeenCalled();
+        });
+
+        it("should delegate a user joining while the new state initializes without waiting for init()", async () => {
+            const space = createSpace();
+            const oldState = createState(CommunicationType.WEBRTC);
+            const newState = createState(CommunicationType.LIVEKIT);
+
+            const orchestrator = createOrchestrator();
+            withRealTransitionLock(orchestrator);
+            orchestrator.mocks.executeImmediateTransition.mockResolvedValue(newState);
+
+            const policy = createPolicy(true, CommunicationType.LIVEKIT);
+            policy.mocks.shouldTransition.mockImplementation(
+                (currentType: CommunicationType) => currentType === CommunicationType.WEBRTC,
+            );
+            // transitionTo() makes the new state current right away, then init() takes a while
+            let finishInit!: () => void;
+            const lifecycleManager = createLifecycleManager(oldState);
+            (
+                lifecycleManager.mocks.transitionTo as Mock<
+                    (state: ICommunicationState<ICommunicationStrategy>) => Promise<void>
+                >
+            ).mockImplementation((state) => {
+                lifecycleManager.mocks.getCurrentState.mockReturnValue(state);
+                return new Promise<void>((resolve) => {
+                    finishInit = resolve;
+                });
+            });
+
+            const manager = new CommunicationManager(space, {
+                policy: policy,
+                orchestrator: orchestrator,
+                lifecycleManager: lifecycleManager,
+            });
+
+            const flipper = createSpaceUser("user_4");
+            const flipperJoin = manager.handleUserAdded(flipper);
+            // Let the transition reach transitionTo() (init pending)
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+            expect(lifecycleManager.mocks.transitionTo).toHaveBeenCalledTimes(1);
+
+            // A user joining now must be told the new strategy before init() sends their invitation:
+            // the join must complete through the new state without waiting for init() to finish.
+            const lateJoiner = createSpaceUser("user_5");
+            await manager.handleUserAdded(lateJoiner);
+            expect(newState.mocks.handleUserAdded).toHaveBeenCalledWith(lateJoiner);
+            expect(oldState.mocks.handleUserAdded).not.toHaveBeenCalled();
+
+            finishInit();
+            await flipperJoin;
+            expect(newState.mocks.handleUserAdded).toHaveBeenCalledTimes(1);
         });
 
         it("should not transition when immediate transition returns null", async () => {


### PR DESCRIPTION
## Problem

When a bubble is at `MAX_USERS_FOR_WEBRTC` (4) and a 5th user joins, the joiner receives `switchMessage(WEBRTC)` and, ~100 ms later, `switchMessage(LIVEKIT)`. Only the joiner sees the flip; the four others go straight to LiveKit. The joiner opens four peer-to-peer connections and tears them down a tenth of a second later.

Seen in production breadcrumbs: the joiner got `WEBRTC` at `09:45:48.045` and `LIVEKIT` at `09:45:48.150`, while the user already in the bubble received a single `LIVEKIT` in the same second.

## Cause

`CommunicationManager.handleUserAdded` delegated to the current (WebRTC) state first, which sends the joiner the current strategy, and only then evaluated the transition policy and created the LiveKit state. The 100 ms gap is the admin API credentials call in `StateFactory.createLivekitState`.

A second issue sat right next to it: the pusher sends the joiner's `addSpaceUserToNotifyMessage` right after the join, i.e. typically during that credentials call. `handleUserToNotifyAdded` → `executeTransition` → `cancelPendingTransition()` aborted the join's in-flight LiveKit creation and started a second one. The orchestrator already has a transition lock that `evaluateAndHandleTransition` awaits, but nothing ever set it.

## Fix (`back/src/Model/CommunicationManager.ts`)

- `handleUserAdded` / `handleUserToNotifyAdded` evaluate the transition **before** delegating to the current state, and only delegate if the state did not change. When the state changed, the old state's `switchState()` already sent the joiner the new strategy and the new state's `init()` already added them (the registry maps are shared with the states).
- Immediate transitions now hold the orchestrator's transition lock while the next state is **created**, so a concurrent handler waits for the in-flight LiveKit creation instead of cancelling it. The lock is released as soon as `transitionTo()` has made the new state current and dispatched the switch, not after `init()`: a user joining during `init()` must be notified through the new state right away, before `init()` sends them their LiveKit invitation (the front drops an invitation received before the switch). The first version of this PR held the lock through `init()` and broke exactly that case in the helm e2e run (`livekit.spec.ts` "Should display 5 cameras", second commit fixes it).

Deletes are untouched (delayed transition, and the departing user must be removed from the current state regardless). The front already handles any switch order.

## Tests

Two tests added in `back/tests/CommunicationManager.test.ts`:
- a join followed by its watch during the in-flight LiveKit creation yields one `executeImmediateTransition`, one `transitionTo`, and no call to the old WebRTC state for the joiner (so no `WEBRTC` switch message and no second credentials call);
- a user joining while the new state's `init()` is still running is delegated to the new state immediately, without waiting for `init()`.

`npm test`, `npm run typecheck`, `npm run lint`, `npm run pretty-check` in `back/` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
