### PR TITLE
fix(chat): allowlist inline mime types for Matrix attachments

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
@@ -328,14 +328,12 @@ export class MatrixChatMessage implements ChatMessage {
         switch (content.msgtype) {
             case "m.text":
                 return "text";
+            // An attachment whose filename and mimetype disagree is shown as a plain file instead
+            // of being rendered, the way Element does it.
             case "m.image":
+                return canRenderImageOrVideoInline(content) ? "image" : "file";
             case "m.video":
-                // An attachment whose filename and mimetype disagree is shown as a plain file
-                // instead of being rendered, the way Element does it.
-                if (!canRenderImageOrVideoInline(content)) {
-                    return "file";
-                }
-                return content.msgtype === "m.image" ? "image" : "video";
+                return canRenderImageOrVideoInline(content) ? "video" : "file";
             case "m.file":
                 return "file";
             case "m.audio":

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
@@ -12,6 +12,7 @@ import type {
     ChatThreadSummary,
     ChatUser,
 } from "../ChatConnection";
+import { DOWNLOAD_MIME_TYPE, sanitizeInlineMimeType } from "../../../Utils/InlineMimeType";
 import { chatUserFactoryFromRoom } from "./MatrixChatUser";
 import { MatrixChatMessageReaction } from "./MatrixChatMessageReaction";
 import { MatrixChatRelation } from "./MatrixChatRelation";
@@ -323,18 +324,20 @@ export class MatrixChatMessage implements ChatMessage {
         return this.room.client.mxcUrlToHttp(url);
     }
     private mapMatrixMessageTypeToChatMessage() {
-        const matrixMessageType = this.event.getOriginalContent().msgtype;
-        switch (matrixMessageType) {
+        const content = this.event.getOriginalContent();
+        // An attachment the chat cannot render inline (e.g. an SVG) is offered as a download instead.
+        const inline = sanitizeInlineMimeType(content.info?.mimetype as string | undefined) !== DOWNLOAD_MIME_TYPE;
+        switch (content.msgtype) {
             case "m.text":
                 return "text";
             case "m.image":
-                return "image";
+                return inline ? "image" : "file";
             case "m.file":
                 return "file";
             case "m.audio":
-                return "audio";
+                return inline ? "audio" : "file";
             case "m.video":
-                return "video";
+                return inline ? "video" : "file";
         }
         return "text";
     }

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
@@ -12,7 +12,7 @@ import type {
     ChatThreadSummary,
     ChatUser,
 } from "../ChatConnection";
-import { DOWNLOAD_MIME_TYPE, sanitizeInlineMimeType } from "../../../Utils/InlineMimeType";
+import { canRenderImageOrVideoInline } from "../../../Utils/InlineMimeType";
 import { chatUserFactoryFromRoom } from "./MatrixChatUser";
 import { MatrixChatMessageReaction } from "./MatrixChatMessageReaction";
 import { MatrixChatRelation } from "./MatrixChatRelation";
@@ -325,19 +325,21 @@ export class MatrixChatMessage implements ChatMessage {
     }
     private mapMatrixMessageTypeToChatMessage() {
         const content = this.event.getOriginalContent();
-        // An attachment the chat cannot render inline (e.g. an SVG) is offered as a download instead.
-        const inline = sanitizeInlineMimeType(content.info?.mimetype as string | undefined) !== DOWNLOAD_MIME_TYPE;
         switch (content.msgtype) {
             case "m.text":
                 return "text";
             case "m.image":
-                return inline ? "image" : "file";
+            case "m.video":
+                // An attachment whose filename and mimetype disagree is shown as a plain file
+                // instead of being rendered, the way Element does it.
+                if (!canRenderImageOrVideoInline(content)) {
+                    return "file";
+                }
+                return content.msgtype === "m.image" ? "image" : "video";
             case "m.file":
                 return "file";
             case "m.audio":
-                return inline ? "audio" : "file";
-            case "m.video":
-                return inline ? "video" : "file";
+                return "audio";
         }
         return "text";
     }

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -2052,6 +2052,7 @@ export class MatrixChatRoom
                 formatted_body: file.name,
                 info: {
                     size: file.size,
+                    mimetype: file.type,
                 },
                 msgtype: this.getMessageTypeFromFile(file),
                 url: uploadResponse.content_uri,

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatThread.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatThread.ts
@@ -536,6 +536,7 @@ export class MatrixChatThread implements ChatThread {
                 formatted_body: file.name,
                 info: {
                     size: file.size,
+                    mimetype: file.type,
                 },
                 msgtype: this.getMessageTypeFromFile(file),
                 url: uploadResponse.content_uri,

--- a/play/src/front/Chat/Connection/Matrix/MatrixMediaResolver.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixMediaResolver.ts
@@ -117,7 +117,14 @@ function toAttachmentMediaEventContent(content: IContent): MediaEventContent | u
     if (typeof content.body !== "string") {
         return undefined;
     }
-    if (content.msgtype !== "m.file" && content.msgtype !== "m.audio" && content.msgtype !== "m.video") {
+    // m.image is in the list because an image whose filename and mimetype disagree is shown as a
+    // plain file, and its encrypted media still has to be decrypted through this path.
+    if (
+        content.msgtype !== "m.file" &&
+        content.msgtype !== "m.audio" &&
+        content.msgtype !== "m.video" &&
+        content.msgtype !== "m.image"
+    ) {
         return undefined;
     }
     return content as MediaEventContent;

--- a/play/src/front/Chat/Connection/Matrix/MatrixMediaResolver.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixMediaResolver.ts
@@ -119,12 +119,7 @@ function toAttachmentMediaEventContent(content: IContent): MediaEventContent | u
     }
     // m.image is in the list because an image whose filename and mimetype disagree is shown as a
     // plain file, and its encrypted media still has to be decrypted through this path.
-    if (
-        content.msgtype !== "m.file" &&
-        content.msgtype !== "m.audio" &&
-        content.msgtype !== "m.video" &&
-        content.msgtype !== "m.image"
-    ) {
+    if (!["m.file", "m.audio", "m.video", "m.image"].includes(content.msgtype ?? "")) {
         return undefined;
     }
     return content as MediaEventContent;

--- a/play/src/front/Chat/Connection/Matrix/MatrixMediaResolver.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixMediaResolver.ts
@@ -1,5 +1,6 @@
 import type { IContent, MatrixClient, MatrixEvent } from "matrix-js-sdk";
 import type { EncryptedFile, MediaEventContent } from "matrix-js-sdk/lib/@types/media";
+import { sanitizeInlineMimeType } from "../../../Utils/InlineMimeType";
 
 type MediaErrorKind = "download" | "decrypt";
 
@@ -72,7 +73,9 @@ function createBlobUrlRegistry(): BlobUrlRegistry {
     const blobUrls = new Set<string>();
 
     const createFromBuffer = (buffer: ArrayBuffer, mimeType: string | undefined): string => {
-        const blob = new Blob([buffer], { type: mimeType ?? "application/octet-stream" });
+        // The mime type comes from the event and is not trusted: a same-origin blob: URL typed
+        // image/svg+xml or text/html would run scripts at our origin when opened as a document.
+        const blob = new Blob([buffer], { type: sanitizeInlineMimeType(mimeType) });
         const blobUrl = URL.createObjectURL(blob);
         blobUrls.add(blobUrl);
         return blobUrl;

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixMediaResolver.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixMediaResolver.test.ts
@@ -125,6 +125,47 @@ describe("resolveAttachmentMediaFromEvent", () => {
         expect(revokeObjectUrlSpy).toHaveBeenCalledWith("blob:attachment");
     });
 
+    it("should not type an encrypted attachment blob with a mime type the chat cannot render inline", async () => {
+        const createObjectUrlSpy = vi.fn((blob: Blob) => `blob:${blob.type}`);
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3]).buffer),
+                }),
+            ),
+        );
+        vi.stubGlobal("URL", { createObjectURL: createObjectUrlSpy, revokeObjectURL: vi.fn() });
+        vi.stubGlobal("crypto", {
+            subtle: {
+                digest: vi.fn(() => Promise.resolve(new Uint8Array([9, 8, 7]).buffer)),
+                importKey: vi.fn(() => Promise.resolve("imported-key")),
+                decrypt: vi.fn(() => Promise.resolve(new Uint8Array([4, 5, 6]).buffer)),
+            },
+        });
+        const client = { mxcUrlToHttp: (mxc: string) => `https://example.com/${mxc}` } as unknown as MatrixClient;
+        const event = {
+            getOriginalContent: () => ({
+                msgtype: "m.file",
+                body: "logo.svg",
+                file: {
+                    url: "mxc://example.org/encrypted",
+                    iv: "AA",
+                    hashes: { sha256: "CQgH" },
+                    key: { k: "AQIDBA", alg: "A256CTR", ext: true, key_ops: ["encrypt", "decrypt"], kty: "oct" },
+                    v: "v2",
+                },
+                info: { mimetype: "image/svg+xml" },
+            }),
+        } as unknown as MatrixEvent;
+
+        const result = await resolveAttachmentMediaFromEvent(event, client, new AbortController().signal);
+
+        expect(result.sourceUrl).toBe("blob:application/octet-stream");
+        result.cleanup();
+    });
+
     it("should map encrypted attachment decrypt failures to decrypt errors", async () => {
         vi.stubGlobal(
             "fetch",

--- a/play/src/front/Utils/InlineMimeType.test.ts
+++ b/play/src/front/Utils/InlineMimeType.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { DOWNLOAD_MIME_TYPE, sanitizeInlineMimeType } from "./InlineMimeType";
+import { DOWNLOAD_MIME_TYPE, canRenderImageOrVideoInline, sanitizeInlineMimeType } from "./InlineMimeType";
 
 describe("sanitizeInlineMimeType", () => {
     it("should keep allowlisted inline types, normalised", () => {
         expect(sanitizeInlineMimeType("image/png")).toBe("image/png");
         expect(sanitizeInlineMimeType("Image/PNG; charset=binary")).toBe("image/png");
         expect(sanitizeInlineMimeType("video/mp4")).toBe("video/mp4");
+        expect(sanitizeInlineMimeType("audio/x-flac")).toBe("audio/x-flac");
     });
 
     it("should downgrade everything else to a plain download", () => {
@@ -13,5 +14,38 @@ describe("sanitizeInlineMimeType", () => {
         expect(sanitizeInlineMimeType("text/html")).toBe(DOWNLOAD_MIME_TYPE);
         expect(sanitizeInlineMimeType("application/pdf")).toBe(DOWNLOAD_MIME_TYPE);
         expect(sanitizeInlineMimeType(undefined)).toBe(DOWNLOAD_MIME_TYPE);
+    });
+});
+
+describe("canRenderImageOrVideoInline", () => {
+    it("should render an attachment whose extension and mimetype agree", () => {
+        expect(canRenderImageOrVideoInline({ body: "cat.png", info: { mimetype: "image/png" } })).toBe(true);
+        expect(canRenderImageOrVideoInline({ body: "clip.mp4", info: { mimetype: "video/mp4" } })).toBe(true);
+        expect(canRenderImageOrVideoInline({ filename: "cat.PNG", body: "a caption" })).toBe(true);
+    });
+
+    it("should still render when the sender omitted the mimetype", () => {
+        expect(canRenderImageOrVideoInline({ body: "cat.png" })).toBe(true);
+        expect(canRenderImageOrVideoInline({ body: "clip.webm", info: {} })).toBe(true);
+    });
+
+    it("should refuse an attachment whose mimetype contradicts its extension", () => {
+        expect(canRenderImageOrVideoInline({ body: "invoice.png", info: { mimetype: "application/pdf" } })).toBe(false);
+        expect(canRenderImageOrVideoInline({ body: "clip.mp4", info: { mimetype: "image/png" } })).toBe(false);
+    });
+
+    it("should refuse an attachment without a usable filename", () => {
+        expect(canRenderImageOrVideoInline({ body: "screenshot", info: { mimetype: "image/png" } })).toBe(false);
+        expect(canRenderImageOrVideoInline({ body: "notes.txt", info: { mimetype: "image/png" } })).toBe(false);
+        expect(canRenderImageOrVideoInline({})).toBe(false);
+    });
+
+    it("should refuse an attachment whose thumbnail is not an image", () => {
+        expect(
+            canRenderImageOrVideoInline({
+                body: "cat.png",
+                info: { mimetype: "image/png", thumbnail_info: { mimetype: "text/html" } },
+            }),
+        ).toBe(false);
     });
 });

--- a/play/src/front/Utils/InlineMimeType.test.ts
+++ b/play/src/front/Utils/InlineMimeType.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { DOWNLOAD_MIME_TYPE, sanitizeInlineMimeType } from "./InlineMimeType";
+
+describe("sanitizeInlineMimeType", () => {
+    it("should keep allowlisted inline types, normalised", () => {
+        expect(sanitizeInlineMimeType("image/png")).toBe("image/png");
+        expect(sanitizeInlineMimeType("Image/PNG; charset=binary")).toBe("image/png");
+        expect(sanitizeInlineMimeType("video/mp4")).toBe("video/mp4");
+    });
+
+    it("should downgrade everything else to a plain download", () => {
+        expect(sanitizeInlineMimeType("image/svg+xml")).toBe(DOWNLOAD_MIME_TYPE);
+        expect(sanitizeInlineMimeType("text/html")).toBe(DOWNLOAD_MIME_TYPE);
+        expect(sanitizeInlineMimeType("application/pdf")).toBe(DOWNLOAD_MIME_TYPE);
+        expect(sanitizeInlineMimeType(undefined)).toBe(DOWNLOAD_MIME_TYPE);
+    });
+});

--- a/play/src/front/Utils/InlineMimeType.ts
+++ b/play/src/front/Utils/InlineMimeType.ts
@@ -1,11 +1,4 @@
 // Mirrors Element's apps/web/src/utils/blobs.ts + MessageEvent.validateImageOrVideoMimetype.
-//
-// Two separate concerns, kept separate on purpose:
-//  - the mime type given to a blob: URL (security). A same-origin blob typed image/svg+xml or
-//    text/html runs scripts at our origin when the URL is opened as a document, so anything
-//    outside the allowlist is typed application/octet-stream, whatever the event claims.
-//  - the tile we render an attachment with (anti-spoofing). Driven by the filename extension,
-//    which info.mimetype must agree with. This one never looks at the blob allowlist.
 
 // Taken from Element's ALLOWED_BLOB_MIMETYPES. Never add text/html, image/svg+xml or friends here.
 const INLINE_MIME_TYPES = new Set([
@@ -42,8 +35,6 @@ export function sanitizeInlineMimeType(mimeType: string | undefined): string {
     return INLINE_MIME_TYPES.has(type) ? type : DOWNLOAD_MIME_TYPE;
 }
 
-// Element resolves the extension through the `mime` package; we only need to know whether it says
-// "image" or "video", so a table beats pulling a full mime database into the front bundle.
 const IMAGE_EXTENSIONS = new Set([
     "apng",
     "avif",
@@ -63,19 +54,14 @@ const IMAGE_EXTENSIONS = new Set([
 ]);
 const VIDEO_EXTENSIONS = new Set(["3gp", "avi", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ogv", "webm", "wmv"]);
 
+// Element resolves the extension through the `mime` package; we only need to know whether it says
+// "image" or "video", so a table beats pulling a full mime database into the front bundle.
 function majorTypeFromFilename(filename: string): "image" | "video" | undefined {
     const extension = filename.split(".").pop()?.toLowerCase() ?? "";
     if (IMAGE_EXTENSIONS.has(extension)) {
         return "image";
     }
-    if (VIDEO_EXTENSIONS.has(extension)) {
-        return "video";
-    }
-    return undefined;
-}
-
-function majorType(mimeType: string | undefined): string | undefined {
-    return mimeType?.split("/")[0].trim().toLowerCase();
+    return VIDEO_EXTENSIONS.has(extension) ? "video" : undefined;
 }
 
 interface MediaLikeContent {
@@ -98,19 +84,15 @@ interface MediaLikeContent {
  * m.audio is never validated (Element doesn't either).
  */
 export function canRenderImageOrVideoInline(content: MediaLikeContent): boolean {
-    // As per the spec, body is the filename when filename is absent.
-    const filename = content.filename ?? content.body;
-    if (filename === undefined || filename === "") {
-        return false;
-    }
     const thumbnailMimeType = content.info?.thumbnail_info?.mimetype;
-    if (thumbnailMimeType !== undefined && majorType(thumbnailMimeType) !== "image") {
+    if (thumbnailMimeType !== undefined && !thumbnailMimeType.toLowerCase().startsWith("image/")) {
         return false;
     }
-    const extensionMajorType = majorTypeFromFilename(filename);
+    // As per the spec, body is the filename when filename is absent.
+    const extensionMajorType = majorTypeFromFilename(content.filename ?? content.body ?? "");
     if (extensionMajorType === undefined) {
         return false;
     }
     const declaredMimeType = content.info?.mimetype;
-    return declaredMimeType === undefined || majorType(declaredMimeType) === extensionMajorType;
+    return declaredMimeType === undefined || declaredMimeType.toLowerCase().startsWith(`${extensionMajorType}/`);
 }

--- a/play/src/front/Utils/InlineMimeType.ts
+++ b/play/src/front/Utils/InlineMimeType.ts
@@ -79,6 +79,8 @@ function majorType(mimeType: string | undefined): string | undefined {
 }
 
 interface MediaLikeContent {
+    // Matrix event contents are open-ended maps; the index signature lets one be passed as is.
+    [key: string]: unknown;
     filename?: string;
     body?: string;
     info?: {

--- a/play/src/front/Utils/InlineMimeType.ts
+++ b/play/src/front/Utils/InlineMimeType.ts
@@ -1,0 +1,27 @@
+// Only types the chat renders inline. Anything else (notably image/svg+xml and text/html, which
+// would run scripts at our origin when a same-origin blob: URL is opened as a document) is
+// downgraded to a plain download.
+const INLINE_MIME_TYPES = new Set([
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/avif",
+    "audio/mpeg",
+    "audio/ogg",
+    "audio/wav",
+    "audio/webm",
+    "audio/mp4",
+    "audio/aac",
+    "video/mp4",
+    "video/webm",
+    "video/ogg",
+]);
+
+export const DOWNLOAD_MIME_TYPE = "application/octet-stream";
+
+/** The mime type to give a received attachment: an allowlisted inline type, or a plain download. */
+export function sanitizeInlineMimeType(mimeType: string | undefined): string {
+    const type = mimeType?.split(";")[0].trim().toLowerCase() ?? "";
+    return INLINE_MIME_TYPES.has(type) ? type : DOWNLOAD_MIME_TYPE;
+}

--- a/play/src/front/Utils/InlineMimeType.ts
+++ b/play/src/front/Utils/InlineMimeType.ts
@@ -1,27 +1,114 @@
-// Only types the chat renders inline. Anything else (notably image/svg+xml and text/html, which
-// would run scripts at our origin when a same-origin blob: URL is opened as a document) is
-// downgraded to a plain download.
+// Mirrors Element's apps/web/src/utils/blobs.ts + MessageEvent.validateImageOrVideoMimetype.
+//
+// Two separate concerns, kept separate on purpose:
+//  - the mime type given to a blob: URL (security). A same-origin blob typed image/svg+xml or
+//    text/html runs scripts at our origin when the URL is opened as a document, so anything
+//    outside the allowlist is typed application/octet-stream, whatever the event claims.
+//  - the tile we render an attachment with (anti-spoofing). Driven by the filename extension,
+//    which info.mimetype must agree with. This one never looks at the blob allowlist.
+
+// Taken from Element's ALLOWED_BLOB_MIMETYPES. Never add text/html, image/svg+xml or friends here.
 const INLINE_MIME_TYPES = new Set([
-    "image/png",
     "image/jpeg",
     "image/gif",
+    "image/png",
+    "image/apng",
     "image/webp",
     "image/avif",
-    "audio/mpeg",
-    "audio/ogg",
-    "audio/wav",
-    "audio/webm",
-    "audio/mp4",
-    "audio/aac",
+
     "video/mp4",
     "video/webm",
     "video/ogg",
+    "video/quicktime",
+
+    "audio/mp4",
+    "audio/webm",
+    "audio/aac",
+    "audio/mpeg",
+    "audio/ogg",
+    "audio/wave",
+    "audio/wav",
+    "audio/x-wav",
+    "audio/x-pn-wav",
+    "audio/flac",
+    "audio/x-flac",
 ]);
 
 export const DOWNLOAD_MIME_TYPE = "application/octet-stream";
 
-/** The mime type to give a received attachment: an allowlisted inline type, or a plain download. */
+/** The mime type to give a blob: URL built from a received attachment. */
 export function sanitizeInlineMimeType(mimeType: string | undefined): string {
     const type = mimeType?.split(";")[0].trim().toLowerCase() ?? "";
     return INLINE_MIME_TYPES.has(type) ? type : DOWNLOAD_MIME_TYPE;
+}
+
+// Element resolves the extension through the `mime` package; we only need to know whether it says
+// "image" or "video", so a table beats pulling a full mime database into the front bundle.
+const IMAGE_EXTENSIONS = new Set([
+    "apng",
+    "avif",
+    "bmp",
+    "gif",
+    "heic",
+    "heif",
+    "ico",
+    "jfif",
+    "jpeg",
+    "jpg",
+    "png",
+    "svg",
+    "tif",
+    "tiff",
+    "webp",
+]);
+const VIDEO_EXTENSIONS = new Set(["3gp", "avi", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ogv", "webm", "wmv"]);
+
+function majorTypeFromFilename(filename: string): "image" | "video" | undefined {
+    const extension = filename.split(".").pop()?.toLowerCase() ?? "";
+    if (IMAGE_EXTENSIONS.has(extension)) {
+        return "image";
+    }
+    if (VIDEO_EXTENSIONS.has(extension)) {
+        return "video";
+    }
+    return undefined;
+}
+
+function majorType(mimeType: string | undefined): string | undefined {
+    return mimeType?.split("/")[0].trim().toLowerCase();
+}
+
+interface MediaLikeContent {
+    filename?: string;
+    body?: string;
+    info?: {
+        mimetype?: string;
+        thumbnail_info?: {
+            mimetype?: string;
+        };
+    };
+}
+
+/**
+ * Whether an m.image / m.video event may be rendered as an image or a video, following Element's
+ * validateImageOrVideoMimetype: the filename extension has to say image/video, and info.mimetype,
+ * when the sender bothered to set it, has to agree with it. Anything else is shown as a file.
+ * m.audio is never validated (Element doesn't either).
+ */
+export function canRenderImageOrVideoInline(content: MediaLikeContent): boolean {
+    // As per the spec, body is the filename when filename is absent.
+    const filename = content.filename ?? content.body;
+    if (filename === undefined || filename === "") {
+        return false;
+    }
+    const thumbnailMimeType = content.info?.thumbnail_info?.mimetype;
+    if (thumbnailMimeType !== undefined && majorType(thumbnailMimeType) !== "image") {
+        return false;
+    }
+    const extensionMajorType = majorTypeFromFilename(filename);
+    if (extensionMajorType === undefined) {
+        return false;
+    }
+    const declaredMimeType = content.info?.mimetype;
+    return declaredMimeType === undefined || majorType(declaredMimeType) === extensionMajorType;
 }


### PR DESCRIPTION
## Problem

The mime type of an encrypted Matrix attachment comes from the event's `info.mimetype` and was passed verbatim to the `Blob` behind the same-origin `blob:` URL (`MatrixMediaResolver.createFromBuffer`). A message of type `m.image` carrying `image/svg+xml` (or `text/html`) renders as a normal picture in the card, but the "open in new tab" button navigates to the blob as a top-level document at the play origin, where the page CSP allows inline scripts. A script inside the SVG can then read `localStorage` and IndexedDB.

Requires a Matrix account in the room. The same sink was found and fixed for the proximity file transfer in #6166, which introduces the shared helper this PR adds.

## Fix

The implementation follows Element, which keeps **two separate mechanisms** — conflating them is what an earlier revision of this PR got wrong.

**1. The type given to a blob (this is the security fix)** — mirrors `getBlobSafeMimeType` in Element's `apps/web/src/utils/blobs.ts`.

- `play/src/front/Utils/InlineMimeType.ts`: `sanitizeInlineMimeType` keeps an allowlist of non-scriptable image, audio and video types and downgrades everything else to `application/octet-stream`. The list is Element's `ALLOWED_BLOB_MIMETYPES` verbatim. Normalisation (strip `;` parameters, trim, lowercase) happens inside the helper; Element does it at the call site in `DecryptFile.ts`.
- `MatrixMediaResolver.createFromBuffer` types blobs through it. This is the only consumer: blob URLs are built for encrypted media only, unencrypted attachments keep their homeserver URL, which was never same-origin.

**2. The tile an attachment is rendered with (anti-spoofing, not security)** — mirrors `validateImageOrVideoMimetype` in Element's `MessageEvent.tsx`.

- `canRenderImageOrVideoInline` validates the filename (`content.filename ?? content.body`): its extension has to denote an image or a video, and `info.mimetype`, *when the sender set it*, has to agree with the extension's major type. A thumbnail mimetype, when present, has to be an image.
- `MatrixChatMessage.mapMatrixMessageTypeToChatMessage` applies it to `m.image` and `m.video` only and falls back to a `file` card when it fails, exactly like Element. `m.audio` is never validated — Element doesn't either.

## Technical choices

- **The allowlist decides the blob type, never the tile.** An attachment with no `info.mimetype` at all is common (Matrix marks `info` optional, and our own sender did not set it — see below); driving the tile choice off the allowlist turned every such image, audio and video into a plain file card.
- **`MatrixChatRoom.sendFile` / `MatrixChatThread.sendFile` now set `info.mimetype: file.type`**, next to the `size` they already send. Element does the same in `ContentMessages.ts`. Without it our own attachments carry no mimetype at all, which no receiving client can validate.
- **`image/svg+xml` passes the tile validation and renders as a picture**, as it does in Element. The protection is the blob typing: the blob is `application/octet-stream`, so opening the URL as a document downloads the file instead of rendering it, and an SVG referenced by `<img src>` does not execute its scripts (see the comment at the top of Element's `blobs.ts`).
- **The extension is resolved through a small table rather than the `mime` package.** Element resolves it with a full mime database it already ships; the check only needs to know whether the extension means "image" or "video", which does not justify pulling a mime database into the front bundle. An unknown extension yields a file card, the same outcome as `mime.getType()` returning `null`.
- **`MatrixMediaResolver.toAttachmentMediaEventContent` now accepts `m.image`.** An `m.image` shown as a file card is loaded through the attachment path; while that path rejected `m.image`, an encrypted image that failed validation ended up as a file card stuck in a permanent download error.

## Tests

- `MatrixMediaResolver.test.ts`: an encrypted attachment with `image/svg+xml` produces an `application/octet-stream` blob.
- `InlineMimeType.test.ts`: the allowlist, normalisation of case and parameters, downgrade of SVG/HTML/PDF/undefined; and for the tile validation, agreeing filename/mimetype pairs, a missing mimetype, contradicting pairs, an unusable filename and a non-image thumbnail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
