### PR TITLE
docs: document WA.player.isLogged

### DIFF
--- a/docs/developer/map-scripting/references/api-player.md
+++ b/docs/developer/map-scripting/references/api-player.md
@@ -89,6 +89,29 @@ WA.onInit().then(() => {
 })
 ```
 
+### Know if the player is logged in
+
+```
+WA.player.isLogged: boolean;
+```
+
+Whether the current player is signed in, as opposed to playing anonymously, is available from the `WA.player.isLogged` property.
+
+:::caution
+Being logged in says nothing about what a player is allowed to do. Rights come from
+[the player's tags](#get-the-tags-of-the-player), and a logged-in player may have none at all.
+:::
+
+:::info
+You need to wait for the end of the initialization before accessing `WA.player.isLogged`
+:::
+
+```typescript
+WA.onInit().then(() => {
+    console.log('Logged in: ', WA.player.isLogged);
+})
+```
+
 ### Get the position of the player
 ```
 WA.player.getPosition(): Promise<Position>

--- a/play/src/front/Api/Iframe/player.ts
+++ b/play/src/front/Api/Iframe/player.ts
@@ -280,11 +280,17 @@ export class WorkadventurePlayerCommands extends IframeApiContribution<Workadven
     }
 
     /**
-     * Get a value to provide connected status for the current player.
-     * Important: You need to wait for the end of the initialization before accessing.
-     * {@link https://docs.workadventu.re/map-building/api-player.md#get-the-tags-of-the-player | Website documentation}
+     * Whether the current player is signed in, as opposed to playing anonymously.
      *
-     * @returns {boolean} Player tags
+     * Being signed in says nothing about what the player is allowed to do - that is what
+     * {@link tags} is for. It is the right check for anything belonging to a person rather than to
+     * a visit: their own settings, their own data, anything they can be asked about and later
+     * change their mind on.
+     *
+     * Important: You need to wait for the end of the scripting API initialization before accessing
+     * this property.
+     *
+     * @returns {boolean} True when the player is signed in, false when they are anonymous
      */
     get isLogged(): boolean {
         if (isLogged === undefined) {


### PR DESCRIPTION
`WA.player.isLogged` had a one-line comment saying it returns true when the player is logged in, an `@returns` describing player tags, and a docs link pointing at the tags section. The scripting API reference did not mention the property at all.

This says what it means, and what it does not:

- **Signed in, not anonymous.** Who counts is decided by the room's administration, not by the browser. With an admin API, it is what that API reports for the room; on the SaaS that is anyone holding a membership in the world, which covers both invited members and self-registered visitors. Without an admin API, it falls back to whether the browser holds an OpenID Connect session.
- **It grants nothing.** Rights come from `WA.player.tags`, and a signed-in player may have none — worth saying, because "logged in" reads like permission.

No behaviour change: JSDoc on the accessor, plus a new section in `docs/developer/map-scripting/references/api-player.md` next to the tags one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)