### PR TITLE
Stop P2P video encoding for viewers that do not display it; keep FPS variability free of deliberate changes

### DIFF
--- a/play/src/front/Components/Video/VideoTags/InnerWebRtcVideo.svelte
+++ b/play/src/front/Components/Video/VideoTags/InnerWebRtcVideo.svelte
@@ -84,6 +84,13 @@
         resizeObserver.observe(videoElement);
     }
 
+    // Tells the sender we do not display the video: it stops encoding for us until we send a size again.
+    function reportHidden() {
+        lastWidth = undefined;
+        lastHeight = undefined;
+        setDimensions(0, 0);
+    }
+
     onMount(() => {
         videoElement.srcObject = stream;
 
@@ -117,6 +124,9 @@
     });
 
     onDestroy(() => {
+        // The tile is gone: scrolled out of view (VideoBoxOptimizer), tab hidden without Picture-in-Picture
+        // (CenteredVideo), layout change... No need to receive video for it anymore.
+        reportHidden();
         if (noVideoOutputDetector) {
             noVideoOutputDetector.destroy();
             noVideoOutputDetector = undefined;

--- a/play/src/front/Components/Video/VideoTags/InnerWebRtcVideo.svelte
+++ b/play/src/front/Components/Video/VideoTags/InnerWebRtcVideo.svelte
@@ -84,13 +84,6 @@
         resizeObserver.observe(videoElement);
     }
 
-    // Tells the sender we do not display the video: it stops encoding for us until we send a size again.
-    function reportHidden() {
-        lastWidth = undefined;
-        lastHeight = undefined;
-        setDimensions(0, 0);
-    }
-
     onMount(() => {
         videoElement.srcObject = stream;
 
@@ -125,8 +118,8 @@
 
     onDestroy(() => {
         // The tile is gone: scrolled out of view (VideoBoxOptimizer), tab hidden without Picture-in-Picture
-        // (CenteredVideo), layout change... No need to receive video for it anymore.
-        reportHidden();
+        // (CenteredVideo), layout change... Tell the sender to stop encoding for us.
+        setDimensions(0, 0);
         if (noVideoOutputDetector) {
             noVideoOutputDetector.destroy();
             noVideoOutputDetector = undefined;

--- a/play/src/front/Components/Video/WebRtcStats.ts
+++ b/play/src/front/Components/Video/WebRtcStats.ts
@@ -7,7 +7,8 @@ export interface WebRtcStats {
     // Bandwidth in bytes/seconds
     bandwidth: number;
     fps: number;
-    // Variability of the received frame rate, deliberate changes excluded (see FpsVariabilityTracker)
+    // Variability of the received frame rate, deliberate changes excluded (see FpsVariabilityTracker).
+    // Never measured for screen shares, whose frame rate follows the content.
     fpsStdDev?: number;
     // Frame rate the sender targets for us, when it told us (0: it paused the video because we do not display it)
     expectedFps?: number;

--- a/play/src/front/Components/Video/WebRtcStats.ts
+++ b/play/src/front/Components/Video/WebRtcStats.ts
@@ -7,7 +7,12 @@ export interface WebRtcStats {
     // Bandwidth in bytes/seconds
     bandwidth: number;
     fps: number;
+    // Variability of the received frame rate, deliberate changes excluded (see FpsVariabilityTracker)
     fpsStdDev?: number;
+    // Frame rate the sender targets for us, when it told us (0: it paused the video because we do not display it)
+    expectedFps?: number;
+    // The sender intentionally sends no video right now
+    paused?: boolean;
     // Whether the selected ICE route is TURN relayed
     relay?: boolean;
     // Protocol used with TURN when relayed (browser-dependent)

--- a/play/src/front/Components/Video/WebRtcStats.ts
+++ b/play/src/front/Components/Video/WebRtcStats.ts
@@ -12,8 +12,6 @@ export interface WebRtcStats {
     fpsStdDev?: number;
     // Frame rate the sender targets for us, when it told us (0: it paused the video because we do not display it)
     expectedFps?: number;
-    // The sender intentionally sends no video right now
-    paused?: boolean;
     // Whether the selected ICE route is TURN relayed
     relay?: boolean;
     // Protocol used with TURN when relayed (browser-dependent)

--- a/play/src/front/Components/Video/WebRtcStatsBox.svelte
+++ b/play/src/front/Components/Video/WebRtcStatsBox.svelte
@@ -32,8 +32,13 @@
                     <td>Bandwidth:</td><td>{Math.round((webRtcStats.bandwidth / 1000) * 8)} kbps</td>
                 </tr>
                 <tr>
-                    <td>FPS:</td><td>{Math.round(webRtcStats.fps)}</td>
+                    <td>FPS:</td><td>{webRtcStats.paused ? "paused by sender" : Math.round(webRtcStats.fps)}</td>
                 </tr>
+                {#if webRtcStats.expectedFps}
+                    <tr>
+                        <td>Expected FPS:</td><td>{Math.round(webRtcStats.expectedFps)}</td>
+                    </tr>
+                {/if}
                 <tr>
                     <td>FPS Variability:</td>
                     <td>{fpsStdDevDisplay}</td>

--- a/play/src/front/Components/Video/WebRtcStatsBox.svelte
+++ b/play/src/front/Components/Video/WebRtcStatsBox.svelte
@@ -32,7 +32,9 @@
                     <td>Bandwidth:</td><td>{Math.round((webRtcStats.bandwidth / 1000) * 8)} kbps</td>
                 </tr>
                 <tr>
-                    <td>FPS:</td><td>{webRtcStats.paused ? "paused by sender" : Math.round(webRtcStats.fps)}</td>
+                    <td>FPS:</td><td
+                        >{webRtcStats.expectedFps === 0 ? "paused by sender" : Math.round(webRtcStats.fps)}</td
+                    >
                 </tr>
                 {#if webRtcStats.expectedFps}
                     <tr>

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -586,7 +586,7 @@ export class LiveKitParticipant {
         const trackStore = type === "video" ? this._videoRemoteTrack : this._screenShareRemoteTrack;
         return derived([trackStore], ([$track], set) => {
             if ($track) {
-                const statsStore = createLivekitWebRtcStats($track);
+                const statsStore = createLivekitWebRtcStats($track, type === "video" ? "video" : "screenSharing");
                 const statsUnsubscribe = statsStore.subscribe(set);
                 return () => {
                     statsUnsubscribe();

--- a/play/src/front/WebRtc/AdaptiveVideoEncoding.ts
+++ b/play/src/front/WebRtc/AdaptiveVideoEncoding.ts
@@ -1,0 +1,64 @@
+/**
+ * Decides how a P2P video sender encodes for one viewer, from what that viewer displays.
+ * Pure logic, kept out of RemotePeer so it can be unit tested.
+ */
+
+export type ViewerDisplay = {
+    // Size of the tile the viewer renders us in. 0x0 means the tile is not displayed (hidden tab, scrolled out...).
+    width: number;
+    height: number;
+    // Bandwidth the viewer is willing to receive, 0 for no limit.
+    maxBitrate: number;
+};
+
+export type CaptureSize = { width: number; height: number };
+
+export type VideoPreset = { bitrate: number; fps: number };
+
+export type VideoEncodingUpdate = {
+    active: boolean;
+    maxBitrate?: number;
+    maxFramerate?: number;
+    scaleResolutionDownBy?: number;
+};
+
+/**
+ * What we assume until the viewer tells us the size of its tile: a small stream, so the first frames show up
+ * right away at a negligible cost. A viewer that displays the video reports its real size within a second; one
+ * that never reports (hidden tab, offscreen tile) gets cut after VIEWER_REPORT_TIMEOUT_MS.
+ */
+export const DEFAULT_VIEWER_DISPLAY: ViewerDisplay = { width: 320, height: 180, maxBitrate: 0 };
+export const HIDDEN_VIEWER_DISPLAY: ViewerDisplay = { width: 0, height: 0, maxBitrate: 0 };
+export const VIEWER_REPORT_TIMEOUT_MS = 5000;
+
+export function isViewerDisplayHidden(viewer: ViewerDisplay): boolean {
+    return viewer.width <= 0 || viewer.height <= 0;
+}
+
+export function computeVideoEncoding(
+    viewer: ViewerDisplay,
+    capture: CaptureSize,
+    selectPreset: (width: number, height: number) => VideoPreset,
+): VideoEncodingUpdate {
+    if (isViewerDisplayHidden(viewer)) {
+        // Nobody looks at it: stop the encoder for this connection (audio is not affected).
+        return { active: false };
+    }
+
+    // Never encode more than what is displayed or what the camera captures.
+    let { width, height } = viewer;
+    if (capture.width * capture.height < width * height) {
+        width = capture.width;
+        height = capture.height;
+    }
+
+    const preset = selectPreset(width, height);
+    const scaleFactor = Math.max(1, Math.min(capture.width / width, capture.height / height));
+
+    return {
+        active: true,
+        maxBitrate: viewer.maxBitrate > 0 ? Math.min(preset.bitrate, viewer.maxBitrate) : preset.bitrate,
+        maxFramerate: preset.fps,
+        scaleResolutionDownBy: scaleFactor > 1 ? scaleFactor : undefined,
+    };
+}

--- a/play/src/front/WebRtc/AdaptiveVideoEncoding.ts
+++ b/play/src/front/WebRtc/AdaptiveVideoEncoding.ts
@@ -11,10 +11,6 @@ export type ViewerDisplay = {
     maxBitrate: number;
 };
 
-export type CaptureSize = { width: number; height: number };
-
-export type VideoPreset = { bitrate: number; fps: number };
-
 export type VideoEncodingUpdate = {
     active: boolean;
     maxBitrate?: number;
@@ -28,7 +24,6 @@ export type VideoEncodingUpdate = {
  * that never reports (hidden tab, offscreen tile) gets cut after VIEWER_REPORT_TIMEOUT_MS.
  */
 export const DEFAULT_VIEWER_DISPLAY: ViewerDisplay = { width: 320, height: 180, maxBitrate: 0 };
-export const HIDDEN_VIEWER_DISPLAY: ViewerDisplay = { width: 0, height: 0, maxBitrate: 0 };
 export const VIEWER_REPORT_TIMEOUT_MS = 5000;
 
 export function isViewerDisplayHidden(viewer: ViewerDisplay): boolean {
@@ -37,8 +32,8 @@ export function isViewerDisplayHidden(viewer: ViewerDisplay): boolean {
 
 export function computeVideoEncoding(
     viewer: ViewerDisplay,
-    capture: CaptureSize,
-    selectPreset: (width: number, height: number) => VideoPreset,
+    capture: { width: number; height: number },
+    selectPreset: (width: number, height: number) => { bitrate: number; fps: number },
 ): VideoEncodingUpdate {
     if (isViewerDisplayHidden(viewer)) {
         // Nobody looks at it: stop the encoder for this connection (audio is not affected).

--- a/play/src/front/WebRtc/FpsVariabilityTracker.ts
+++ b/play/src/front/WebRtc/FpsVariabilityTracker.ts
@@ -1,0 +1,61 @@
+const WINDOW_SIZE = 8;
+// After the sender changes its target frame rate, the encoder needs a moment to settle: not instability.
+const TRANSITION_MS = 2000;
+
+/**
+ * Standard deviation of the received frame rate over the last WINDOW_SIZE one-second samples, used to tell an
+ * unstable connection from a stable one.
+ *
+ * Deliberate changes must not count as instability: when the sender tells us its target frame rate (expectedFps),
+ * the window restarts on every change and stays empty while the stream is intentionally paused (expectedFps 0)
+ * or still settling after a change. Without an expected frame rate, the raw frame rate is measured as before.
+ */
+export class FpsVariabilityTracker {
+    private samples: number[] = [];
+    private expectedFps: number | undefined;
+    private frameWidth: number | undefined;
+    private frameHeight: number | undefined;
+    private transitionUntil = 0;
+
+    /**
+     * @returns the variability, or undefined while there are not enough steady samples
+     */
+    public push(
+        fps: number,
+        expectedFps: number | undefined,
+        frameWidth: number,
+        frameHeight: number,
+        now: number,
+    ): number | undefined {
+        if (expectedFps !== this.expectedFps) {
+            this.expectedFps = expectedFps;
+            this.samples.length = 0;
+            this.transitionUntil = now + TRANSITION_MS;
+        }
+        if (
+            this.frameWidth !== undefined &&
+            this.frameHeight !== undefined &&
+            (frameWidth !== this.frameWidth || frameHeight !== this.frameHeight)
+        ) {
+            this.samples.length = 0;
+        }
+        this.frameWidth = frameWidth;
+        this.frameHeight = frameHeight;
+
+        if (expectedFps === 0 || now < this.transitionUntil || !Number.isFinite(fps)) {
+            return undefined;
+        }
+
+        this.samples.push(fps);
+        if (this.samples.length > WINDOW_SIZE) {
+            this.samples.shift();
+        }
+        if (this.samples.length < WINDOW_SIZE) {
+            return undefined;
+        }
+        const mean = this.samples.reduce((sum, value) => sum + value, 0) / this.samples.length;
+        const variance =
+            this.samples.reduce((sum, value) => sum + Math.pow(value - mean, 2), 0) / (this.samples.length - 1);
+        return Math.sqrt(variance);
+    }
+}

--- a/play/src/front/WebRtc/P2PMessages/EncodingMessage.ts
+++ b/play/src/front/WebRtc/P2PMessages/EncodingMessage.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+/**
+ * Sent by the video sender to the viewer each time it changes how it encodes for that viewer: the frame rate the
+ * viewer should expect (0 while the sender pauses the video because the viewer does not display it). Lets the viewer
+ * tell deliberate frame rate changes from an unstable connection.
+ */
+export const EncodingMessage = z.object({
+    type: z.literal("encoding"),
+    expectedFps: z.number().nonnegative(),
+});
+
+export type EncodingMessage = z.infer<typeof EncodingMessage>;

--- a/play/src/front/WebRtc/P2PMessages/P2PMessage.ts
+++ b/play/src/front/WebRtc/P2PMessages/P2PMessage.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { BlockMessage } from "./BlockMessage";
 import { UnblockMessage } from "./UnblockMessage";
 import { ResolutionMessage } from "./ResolutionMessage";
+import { EncodingMessage } from "./EncodingMessage";
 
 export const STREAM_STOPPED_MESSAGE_TYPE = "stream_stopped";
 
@@ -22,6 +23,7 @@ export const P2PMessage = z.union([
     KickOffMessage,
     StreamStoppedMessage,
     ResolutionMessage,
+    EncodingMessage,
 ]);
 
 /**

--- a/play/src/front/WebRtc/P2PMessages/ResolutionMessage.ts
+++ b/play/src/front/WebRtc/P2PMessages/ResolutionMessage.ts
@@ -1,10 +1,14 @@
 import { z } from "zod";
 
+/**
+ * Size of the tile the viewer displays our video in. A 0x0 size means the viewer does not display it at all
+ * (hidden tab, tile scrolled out of view): the sender stops encoding for that viewer until a size comes back.
+ */
 export const ResolutionMessage = z.object({
     type: z.literal("resolution"),
-    width: z.number().int().positive(),
-    height: z.number().int().positive(),
-    maxBitrate: z.number().int().positive(),
+    width: z.number().int().nonnegative(),
+    height: z.number().int().nonnegative(),
+    maxBitrate: z.number().int().nonnegative(),
 });
 
 export type ResolutionMessage = z.infer<typeof ResolutionMessage>;

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -25,6 +25,14 @@ import { isFirefox } from "./DeviceUtils";
 import { P2PMessage, STREAM_STOPPED_MESSAGE_TYPE } from "./P2PMessages/P2PMessage";
 import { subscribeToOutboundVideoQualityAnalytics, subscribeToVideoQualityAnalytics } from "./VideoQualityAnalytics";
 import { createPeerWebRtcStats } from "./WebRtcStatsFactory";
+import {
+    computeVideoEncoding,
+    DEFAULT_VIEWER_DISPLAY,
+    HIDDEN_VIEWER_DISPLAY,
+    isViewerDisplayHidden,
+    VIEWER_REPORT_TIMEOUT_MS,
+    type ViewerDisplay,
+} from "./AdaptiveVideoEncoding";
 import { registerLocalEncoderStats } from "./LocalEncoderStats";
 import { selectVideoPreset, type VideoQualitySetting } from "./VideoPresets";
 
@@ -75,6 +83,12 @@ export class RemotePeer extends Peer implements Streamable {
     private analyticsStatsUnsubscribe: Unsubscriber | undefined;
     private analyticsRemoteStreamUnsubscribe: (() => void) | undefined;
     private receiverMaxBitrateBps: number | undefined;
+    // What the remote viewer displays of our video, as last reported (see ResolutionMessage)
+    private viewerDisplay: ViewerDisplay = DEFAULT_VIEWER_DISPLAY;
+    private viewerReportedDisplay = false;
+    // Cuts the video if the viewer never tells us how it displays it (see VIEWER_REPORT_TIMEOUT_MS)
+    private viewerReportTimeout: ReturnType<typeof setTimeout> | undefined;
+    private videoEncodingRetryTimeout: ReturnType<typeof setTimeout> | undefined;
     /**
      * Set to true when closeStreamable() is called.
      * When preparingClose is true, we don't stop immediately sending our stream. Instead, we wait for the remote peer to
@@ -152,6 +166,7 @@ export class RemotePeer extends Peer implements Streamable {
         this._statusStore.set("connected");
 
         this._connected = true;
+        this.applyVideoEncoding();
 
         /*const proximityRoomChat = gameManager.getCurrentGameScene().proximityChatRoom;
 
@@ -440,10 +455,12 @@ export class RemotePeer extends Peer implements Streamable {
                         } finally {
                             this.localStream.removeTrack(oldVideoTrack);
                         }
+                        this.applyVideoEncoding();
                     } else if (newVideoTrack && !oldVideoTrack) {
                         debug("Adding video track in P2P connection");
                         this.localStream.addTrack(newVideoTrack);
                         this.addTrack(newVideoTrack, this.localStream);
+                        this.applyVideoEncoding();
                     } else if (oldVideoTrack && !newVideoTrack) {
                         debug("Removing video track in P2P connection");
                         try {
@@ -678,6 +695,12 @@ export class RemotePeer extends Peer implements Streamable {
             if (this.closeStreamableTimeout) {
                 clearTimeout(this.closeStreamableTimeout);
             }
+            if (this.videoEncodingRetryTimeout) {
+                clearTimeout(this.videoEncodingRetryTimeout);
+            }
+            if (this.viewerReportTimeout) {
+                clearTimeout(this.viewerReportTimeout);
+            }
 
             this._connected = false;
             this.senderAnalyticsUnsubscribe?.();
@@ -894,15 +917,23 @@ export class RemotePeer extends Peer implements Streamable {
      * The logic is throttled to max one call every 250ms.
      */
     private _setDimensions = throttle(250, (width: number, height: number): void => {
+        if (this.destroyed || this.closing) {
+            // The tile of a closing peer unmounts and reports itself hidden: nothing to tell anymore.
+            return;
+        }
         try {
-            const preset = this.getPresetForDimensions(width, height);
+            // 0x0: we do not display the video, the sender stops encoding for us
+            const hidden = width <= 0 || height <= 0;
+            debug(
+                `Adaptive video: reporting our display of ${this._spaceUserId} as ${hidden ? "hidden" : `${width}x${height}`}`,
+            );
             this.write(
                 new Buffer(
                     JSON.stringify({
                         type: "resolution",
-                        width: width,
-                        height: height,
-                        maxBitrate: preset.bitrate,
+                        width: hidden ? 0 : width,
+                        height: hidden ? 0 : height,
+                        maxBitrate: hidden ? 0 : this.getPresetForDimensions(width, height).bitrate,
                     } satisfies P2PMessage),
                 ),
             );
@@ -912,74 +943,109 @@ export class RemotePeer extends Peer implements Streamable {
     });
 
     /**
-     * Updates video constraints based on the preset information from the remote peer.
-     * This adjusts bitrate and resolution to match what's actually displayed.
+     * Called when the remote viewer reports the size it displays our video in (0x0: not displayed).
      */
     private updateVideoConstraintsForDisplayDimensions(width: number, height: number, bandwidthLimit: number): void {
+        this.viewerDisplay = { width, height, maxBitrate: bandwidthLimit };
+        this.viewerReportedDisplay = true;
+        if (this.viewerReportTimeout) {
+            clearTimeout(this.viewerReportTimeout);
+            this.viewerReportTimeout = undefined;
+        }
+        this.applyVideoEncoding();
+    }
+
+    /**
+     * A viewer that displays our video reports its tile size within a second of receiving the stream. Without any
+     * report (hidden tab, offscreen tile, unknown client), stop sending video rather than keep the default stream.
+     */
+    private cutVideoUnlessViewerReports(): void {
+        if (this.viewerReportedDisplay || this.viewerReportTimeout) {
+            return;
+        }
+        this.viewerReportTimeout = setTimeout(() => {
+            this.viewerReportTimeout = undefined;
+            if (this.viewerReportedDisplay) {
+                return;
+            }
+            debug(`Adaptive video: no display report from ${this._spaceUserId} after ${VIEWER_REPORT_TIMEOUT_MS}ms`);
+            this.viewerDisplay = HIDDEN_VIEWER_DISPLAY;
+            this.applyVideoEncoding();
+        }, VIEWER_REPORT_TIMEOUT_MS);
+    }
+
+    /**
+     * Encodes for what the viewer displays: scaled down to its tile, and not at all while the tile is hidden.
+     * Called when the connection opens, when our video track changes and when the viewer reports its tile.
+     */
+    private applyVideoEncoding(): void {
         const pc = this._pc as RTCPeerConnection | undefined;
-        if (!pc) {
-            console.warn("Adaptive video: no RTCPeerConnection available");
+        const videoSender = pc?.getSenders().find((s) => s.track?.kind === "video");
+        if (!videoSender?.track) {
             return;
         }
 
-        const videoSender = pc.getSenders().find((s) => s.track?.kind === "video");
-        if (!videoSender || !videoSender.track) {
-            console.warn("Adaptive video: no video sender found");
-            return;
-        }
-        const settings = videoSender.track.getSettings();
-        const currentWidth = settings.width || 1280;
-        const currentHeight = settings.height || 720;
-
-        // Compute bandwidth and framerate based on the smallest of the displayed resolution and the capture resolution.
-        if (currentWidth * currentHeight < width * height) {
-            width = currentWidth;
-            height = currentHeight;
-        }
-
-        // Let's find the best presets
-        const preset = this.getPresetForDimensions(width, height);
-
-        // Calculate scale factor based on current capture resolution vs target preset
-        const scaleFactor = Math.max(1, Math.min(currentWidth / width, currentHeight / height));
-
-        // Get current parameters and modify encoding settings
         const parameters = videoSender.getParameters();
         if (!parameters.encodings || parameters.encodings.length === 0) {
-            console.warn("Adaptive video: no encodings found in parameters");
+            this.retryVideoEncodingLater();
             return;
         }
 
-        // Apply new constraints
+        this.cutVideoUnlessViewerReports();
+
+        const settings = videoSender.track.getSettings();
+        const encoding = computeVideoEncoding(
+            this.viewerDisplay,
+            { width: settings.width || 1280, height: settings.height || 720 },
+            (width, height) => this.getPresetForDimensions(width, height),
+        );
+
         if (this.type === "screenSharing") {
             parameters.degradationPreference = get(bandwidthConstrainedPreferenceStore);
         }
-        parameters.encodings[0].maxBitrate = Math.min(preset.bitrate, bandwidthLimit);
-        parameters.encodings[0].maxFramerate = preset.fps;
-
-        if (scaleFactor > 1) {
-            parameters.encodings[0].scaleResolutionDownBy = scaleFactor;
-            debug(
-                `Adaptive video: scaling down ${currentWidth}x${currentHeight} by ${scaleFactor.toFixed(
-                    2,
-                )}x to ~${Math.round(currentWidth / scaleFactor)}x${Math.round(currentHeight / scaleFactor)}`,
-            );
-        } else {
-            delete parameters.encodings[0].scaleResolutionDownBy;
-            debug("Adaptive video: no scaling needed, using full resolution");
+        parameters.encodings[0].active = encoding.active;
+        if (encoding.active) {
+            parameters.encodings[0].maxBitrate = encoding.maxBitrate;
+            parameters.encodings[0].maxFramerate = encoding.maxFramerate;
+            if (encoding.scaleResolutionDownBy !== undefined) {
+                parameters.encodings[0].scaleResolutionDownBy = encoding.scaleResolutionDownBy;
+            } else {
+                delete parameters.encodings[0].scaleResolutionDownBy;
+            }
         }
 
         // Apply parameters transactionally
         videoSender
             .setParameters(parameters)
             .then(() => {
+                this.videoEncodingRetries = 0;
                 debug(
-                    `Adaptive video: successfully applied resolution ${width}x${height} @ ${preset.bitrate}bps, ${preset.fps}fps`,
+                    isViewerDisplayHidden(this.viewerDisplay)
+                        ? "Adaptive video: viewer does not display our video, encoder paused"
+                        : `Adaptive video: applied ${this.viewerDisplay.width}x${this.viewerDisplay.height} @ ${encoding.maxBitrate}bps, ${encoding.maxFramerate}fps, scale ${encoding.scaleResolutionDownBy ?? 1}`,
                 );
             })
-            .catch((err) => {
+            .catch((err: unknown) => {
+                if (err instanceof DOMException && err.name === "InvalidStateError") {
+                    // Chrome rejects setParameters() until the first negotiation of the sender is done.
+                    this.retryVideoEncodingLater();
+                    return;
+                }
                 console.error("Adaptive video: failed to set parameters", err);
             });
+    }
+
+    private videoEncodingRetries = 0;
+
+    private retryVideoEncodingLater(): void {
+        if (this.videoEncodingRetryTimeout || this.videoEncodingRetries >= 5) {
+            return;
+        }
+        this.videoEncodingRetries++;
+        this.videoEncodingRetryTimeout = setTimeout(() => {
+            this.videoEncodingRetryTimeout = undefined;
+            this.applyVideoEncoding();
+        }, 1000);
     }
 
     private getLocalQualitySetting(): VideoQualitySetting {

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -83,6 +83,8 @@ export class RemotePeer extends Peer implements Streamable {
     private analyticsStatsUnsubscribe: Unsubscriber | undefined;
     private analyticsRemoteStreamUnsubscribe: (() => void) | undefined;
     private receiverMaxBitrateBps: number | undefined;
+    // Frame rate the remote sender targets for us, as last announced (see EncodingMessage); 0 while it pauses
+    public expectedFps: number | undefined;
     // What the remote viewer displays of our video, as last reported (see ResolutionMessage)
     private viewerDisplay: ViewerDisplay = DEFAULT_VIEWER_DISPLAY;
     private viewerReportedDisplay = false;
@@ -223,6 +225,10 @@ export class RemotePeer extends Peer implements Streamable {
                 }
                 case "resolution": {
                     this.updateVideoConstraintsForDisplayDimensions(message.width, message.height, message.maxBitrate);
+                    break;
+                }
+                case "encoding": {
+                    this.expectedFps = message.expectedFps;
                     break;
                 }
                 default: {
@@ -1019,6 +1025,7 @@ export class RemotePeer extends Peer implements Streamable {
             .setParameters(parameters)
             .then(() => {
                 this.videoEncodingRetries = 0;
+                this.announceExpectedFps(encoding.active ? encoding.maxFramerate : 0, settings.frameRate);
                 debug(
                     isViewerDisplayHidden(this.viewerDisplay)
                         ? "Adaptive video: viewer does not display our video, encoder paused"
@@ -1033,6 +1040,29 @@ export class RemotePeer extends Peer implements Streamable {
                 }
                 console.error("Adaptive video: failed to set parameters", err);
             });
+    }
+
+    /**
+     * Tells the viewer the frame rate to expect from us, so that it does not count our deliberate changes
+     * (pause, tile resized) as an unstable connection.
+     */
+    private announceExpectedFps(maxFramerate: number | undefined, captureFrameRate: number | undefined): void {
+        if (this.destroyed || this.closing) {
+            return;
+        }
+        const expectedFps = Math.min(maxFramerate ?? captureFrameRate ?? 0, captureFrameRate ?? Infinity);
+        try {
+            this.write(
+                new Buffer(
+                    JSON.stringify({
+                        type: "encoding",
+                        expectedFps: Number.isFinite(expectedFps) ? expectedFps : 0,
+                    } satisfies P2PMessage),
+                ),
+            );
+        } catch (e) {
+            console.error("Failed to send encoding message to peer", e);
+        }
     }
 
     private videoEncodingRetries = 0;

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -28,7 +28,6 @@ import { createPeerWebRtcStats } from "./WebRtcStatsFactory";
 import {
     computeVideoEncoding,
     DEFAULT_VIEWER_DISPLAY,
-    HIDDEN_VIEWER_DISPLAY,
     isViewerDisplayHidden,
     VIEWER_REPORT_TIMEOUT_MS,
     type ViewerDisplay,
@@ -975,7 +974,7 @@ export class RemotePeer extends Peer implements Streamable {
                 return;
             }
             debug(`Adaptive video: no display report from ${this._spaceUserId} after ${VIEWER_REPORT_TIMEOUT_MS}ms`);
-            this.viewerDisplay = HIDDEN_VIEWER_DISPLAY;
+            this.viewerDisplay = { width: 0, height: 0, maxBitrate: 0 };
             this.applyVideoEncoding();
         }, VIEWER_REPORT_TIMEOUT_MS);
     }

--- a/play/src/front/WebRtc/VideoQualityAnalytics.ts
+++ b/play/src/front/WebRtc/VideoQualityAnalytics.ts
@@ -36,7 +36,8 @@ export function subscribeToVideoQualityAnalytics(
     sendReport: (message: VideoQualityReportMessage) => void,
 ): Unsubscriber {
     return subscribeToSamples(statsStore, context, sendReport, (stats, base) => {
-        if (!isValidStats(stats)) {
+        // A stream the sender paused on purpose (we do not display it) says nothing about the connection
+        if (stats.paused || !isValidStats(stats)) {
             return undefined;
         }
         return {

--- a/play/src/front/WebRtc/VideoQualityAnalytics.ts
+++ b/play/src/front/WebRtc/VideoQualityAnalytics.ts
@@ -37,7 +37,7 @@ export function subscribeToVideoQualityAnalytics(
 ): Unsubscriber {
     return subscribeToSamples(statsStore, context, sendReport, (stats, base) => {
         // A stream the sender paused on purpose (we do not display it) says nothing about the connection
-        if (stats.paused || !isValidStats(stats)) {
+        if (stats.expectedFps === 0 || !isValidStats(stats)) {
             return undefined;
         }
         return {

--- a/play/src/front/WebRtc/WebRtcStatsFactory.ts
+++ b/play/src/front/WebRtc/WebRtcStatsFactory.ts
@@ -1,7 +1,8 @@
-import type { LocalVideoTrack, RemoteTrack } from "livekit-client";
+import { Track, type LocalVideoTrack, type RemoteTrack } from "livekit-client";
 import { derived, readable, type Readable } from "svelte/store";
 import type { WebRtcQualityLimitationReason, WebRtcSenderStats, WebRtcStats } from "../Components/Video/WebRtcStats";
 import type { RemotePeer } from "./RemotePeer";
+import { FpsVariabilityTracker } from "./FpsVariabilityTracker";
 
 const WEBRTC_STATS_DISPLAY_INTERVAL_MS = 1_000;
 
@@ -35,6 +36,7 @@ export function createPeerWebRtcStats(remotePeer: RemotePeer): PeerWebRtcStats {
             source: "P2P",
             getTrackId: () => remotePeer.remoteStream?.getVideoTracks()[0]?.id,
             includeRelayDetails: true,
+            getExpectedFps: () => remotePeer.expectedFps,
         }),
         sender: createSenderStatsStore(reportStore, "P2P"),
     };
@@ -62,6 +64,8 @@ export function createLivekitWebRtcStats(track: RemoteTrack | undefined): Readab
             return trackWithMedia.mediaStreamTrack?.id;
         },
         includeRelayDetails: false,
+        // The SFU pauses the track when we do not display it (adaptiveStream); the target frame rate is unknown
+        getExpectedFps: () => (track?.streamState === Track.StreamState.Paused ? 0 : undefined),
     });
 }
 
@@ -112,6 +116,8 @@ type ReceiverStatsOptions = {
     source: string;
     getTrackId?: () => string | undefined;
     includeRelayDetails?: boolean;
+    // Frame rate the sender targets for us right now, 0 when it intentionally sends nothing, undefined if unknown
+    getExpectedFps?: () => number | undefined;
 };
 
 function createReceiverStatsStore(
@@ -121,10 +127,7 @@ function createReceiverStatsStore(
     let bytesReceivedPrev = 0;
     let framesDecodedPrev = 0;
     let timestampPrev = 0;
-    let lastFrameWidth: number | undefined;
-    let lastFrameHeight: number | undefined;
-    const fpsSamples: number[] = [];
-    let fpsStdDev: number | undefined;
+    const fpsVariability = new FpsVariabilityTracker();
 
     return derived<Readable<RTCStatsReport | undefined>, WebRtcStats | undefined>(
         reportStore,
@@ -152,33 +155,16 @@ function createReceiverStatsStore(
             if (!receiverStats) {
                 return;
             }
-            if (
-                lastFrameWidth !== undefined &&
-                lastFrameHeight !== undefined &&
-                (receiverStats.frameWidth !== lastFrameWidth || receiverStats.frameHeight !== lastFrameHeight)
-            ) {
-                fpsSamples.length = 0;
-                fpsStdDev = undefined;
-            }
-            if (Number.isFinite(receiverStats.fps)) {
-                fpsSamples.push(receiverStats.fps);
-                if (fpsSamples.length > 8) {
-                    fpsSamples.shift();
-                }
-                if (fpsSamples.length === 8) {
-                    const mean = fpsSamples.reduce((sum, value) => sum + value, 0) / fpsSamples.length;
-                    const variance =
-                        fpsSamples.reduce((sum, value) => sum + Math.pow(value - mean, 2), 0) / (fpsSamples.length - 1);
-                    fpsStdDev = Math.sqrt(variance);
-                } else {
-                    fpsStdDev = undefined;
-                }
-            } else {
-                fpsStdDev = undefined;
-            }
-            receiverStats.fpsStdDev = fpsStdDev;
-            lastFrameWidth = receiverStats.frameWidth;
-            lastFrameHeight = receiverStats.frameHeight;
+            const expectedFps = options.getExpectedFps?.();
+            receiverStats.expectedFps = expectedFps;
+            receiverStats.paused = expectedFps === 0;
+            receiverStats.fpsStdDev = fpsVariability.push(
+                receiverStats.fps,
+                expectedFps,
+                receiverStats.frameWidth,
+                receiverStats.frameHeight,
+                Date.now(),
+            );
             set(receiverStats);
         },
         undefined,

--- a/play/src/front/WebRtc/WebRtcStatsFactory.ts
+++ b/play/src/front/WebRtc/WebRtcStatsFactory.ts
@@ -37,12 +37,16 @@ export function createPeerWebRtcStats(remotePeer: RemotePeer): PeerWebRtcStats {
             getTrackId: () => remotePeer.remoteStream?.getVideoTracks()[0]?.id,
             includeRelayDetails: true,
             getExpectedFps: () => remotePeer.expectedFps,
+            measureFpsVariability: remotePeer.videoType === "video",
         }),
         sender: createSenderStatsStore(reportStore, "P2P"),
     };
 }
 
-export function createLivekitWebRtcStats(track: RemoteTrack | undefined): Readable<WebRtcStats | undefined> {
+export function createLivekitWebRtcStats(
+    track: RemoteTrack | undefined,
+    videoType: "video" | "screenSharing",
+): Readable<WebRtcStats | undefined> {
     const reportStore = createStatsReportStore(
         () => {
             if (!track) {
@@ -66,6 +70,7 @@ export function createLivekitWebRtcStats(track: RemoteTrack | undefined): Readab
         includeRelayDetails: false,
         // The SFU pauses the track when we do not display it (adaptiveStream); the target frame rate is unknown
         getExpectedFps: () => (track?.streamState === Track.StreamState.Paused ? 0 : undefined),
+        measureFpsVariability: videoType === "video",
     });
 }
 
@@ -118,6 +123,9 @@ type ReceiverStatsOptions = {
     includeRelayDetails?: boolean;
     // Frame rate the sender targets for us right now, 0 when it intentionally sends nothing, undefined if unknown
     getExpectedFps?: () => number | undefined;
+    // False for screen shares: their frame rate follows the content (a still screen sends about one frame per
+    // second, whatever the codec), so its variability says nothing about the connection.
+    measureFpsVariability: boolean;
 };
 
 function createReceiverStatsStore(
@@ -158,13 +166,15 @@ function createReceiverStatsStore(
             const expectedFps = options.getExpectedFps?.();
             receiverStats.expectedFps = expectedFps;
             receiverStats.paused = expectedFps === 0;
-            receiverStats.fpsStdDev = fpsVariability.push(
-                receiverStats.fps,
-                expectedFps,
-                receiverStats.frameWidth,
-                receiverStats.frameHeight,
-                Date.now(),
-            );
+            receiverStats.fpsStdDev = options.measureFpsVariability
+                ? fpsVariability.push(
+                      receiverStats.fps,
+                      expectedFps,
+                      receiverStats.frameWidth,
+                      receiverStats.frameHeight,
+                      Date.now(),
+                  )
+                : undefined;
             set(receiverStats);
         },
         undefined,

--- a/play/src/front/WebRtc/WebRtcStatsFactory.ts
+++ b/play/src/front/WebRtc/WebRtcStatsFactory.ts
@@ -165,7 +165,6 @@ function createReceiverStatsStore(
             }
             const expectedFps = options.getExpectedFps?.();
             receiverStats.expectedFps = expectedFps;
-            receiverStats.paused = expectedFps === 0;
             receiverStats.fpsStdDev = options.measureFpsVariability
                 ? fpsVariability.push(
                       receiverStats.fps,

--- a/play/tests/front/WebRtc/AdaptiveVideoEncoding.test.ts
+++ b/play/tests/front/WebRtc/AdaptiveVideoEncoding.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+    computeVideoEncoding,
+    DEFAULT_VIEWER_DISPLAY,
+    isViewerDisplayHidden,
+} from "../../../src/front/WebRtc/AdaptiveVideoEncoding";
+
+const capture = { width: 1280, height: 720 };
+const selectPreset = (width: number, height: number) => ({ bitrate: width * height, fps: height >= 720 ? 30 : 15 });
+
+describe("computeVideoEncoding", () => {
+    it("stops the encoder when the viewer does not display the video", () => {
+        expect(computeVideoEncoding({ width: 0, height: 0, maxBitrate: 0 }, capture, selectPreset)).toEqual({
+            active: false,
+        });
+        expect(isViewerDisplayHidden({ width: 0, height: 0, maxBitrate: 0 })).toBe(true);
+    });
+
+    it("scales down to the displayed size", () => {
+        expect(computeVideoEncoding({ width: 320, height: 180, maxBitrate: 0 }, capture, selectPreset)).toEqual({
+            active: true,
+            maxBitrate: 320 * 180,
+            maxFramerate: 15,
+            scaleResolutionDownBy: 4,
+        });
+    });
+
+    it("never encodes more than the capture, and honours the viewer bandwidth limit", () => {
+        expect(computeVideoEncoding({ width: 1920, height: 1080, maxBitrate: 100 }, capture, selectPreset)).toEqual({
+            active: true,
+            maxBitrate: 100,
+            maxFramerate: 30,
+            scaleResolutionDownBy: undefined,
+        });
+    });
+
+    it("assumes a small tile until the viewer reports its size", () => {
+        expect(isViewerDisplayHidden(DEFAULT_VIEWER_DISPLAY)).toBe(false);
+        expect(computeVideoEncoding(DEFAULT_VIEWER_DISPLAY, capture, selectPreset)).toMatchObject({
+            active: true,
+            scaleResolutionDownBy: 4,
+        });
+    });
+});

--- a/play/tests/front/WebRtc/FpsVariabilityTracker.test.ts
+++ b/play/tests/front/WebRtc/FpsVariabilityTracker.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { FpsVariabilityTracker } from "../../../src/front/WebRtc/FpsVariabilityTracker";
+
+function feed(tracker: FpsVariabilityTracker, fpsValues: number[], expectedFps: number | undefined, startAt = 0) {
+    let result: number | undefined;
+    fpsValues.forEach((fps, index) => {
+        result = tracker.push(fps, expectedFps, 640, 360, startAt + index * 1000);
+    });
+    return result;
+}
+
+describe("FpsVariabilityTracker", () => {
+    it("measures the raw frame rate when the sender never told us its target", () => {
+        const tracker = new FpsVariabilityTracker();
+        expect(feed(tracker, [20, 20, 20, 20, 20, 20, 20], undefined)).toBeUndefined();
+        expect(feed(tracker, [20], undefined, 7000)).toBe(0);
+        expect(feed(tracker, [10], undefined, 8000)).toBeGreaterThan(3);
+    });
+
+    it("does not count an intentional pause and resume as instability", () => {
+        const tracker = new FpsVariabilityTracker();
+        // Settle after the transition that follows the first announced target (2 s), then 8 steady samples
+        feed(tracker, [20, 20], 20, 0);
+        expect(feed(tracker, [20, 20, 20, 20, 20, 20, 20, 20], 20, 2000)).toBe(0);
+
+        // Paused by the sender because we do not display it: nothing measured
+        expect(feed(tracker, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 0, 10_000)).toBeUndefined();
+
+        // Resumed: the encoder ramps up during the transition, then the window restarts from scratch
+        expect(feed(tracker, [5, 15], 20, 20_000)).toBeUndefined();
+        expect(feed(tracker, [20, 20, 20, 20, 20, 20, 20], 20, 22_000)).toBeUndefined();
+        expect(feed(tracker, [20], 20, 29_000)).toBe(0);
+    });
+
+    it("restarts the window when the target frame rate changes", () => {
+        const tracker = new FpsVariabilityTracker();
+        feed(tracker, [20, 20], 20, 0);
+        expect(feed(tracker, [20, 20, 20, 20, 20, 20, 20, 20], 20, 2000)).toBe(0);
+        // The viewer enlarged its tile: the sender now targets 30 fps
+        expect(feed(tracker, [30, 30, 30, 30, 30, 30, 30, 30, 30, 30], 30, 10_000)).toBe(0);
+    });
+
+    it("restarts the window when the frame size changes", () => {
+        const tracker = new FpsVariabilityTracker();
+        feed(tracker, [20, 20, 20, 20, 20, 20, 20, 20], undefined);
+        expect(tracker.push(20, undefined, 1280, 720, 8000)).toBeUndefined();
+    });
+});

--- a/tests/tests/adaptive_streaming.spec.ts
+++ b/tests/tests/adaptive_streaming.spec.ts
@@ -35,6 +35,14 @@ test.describe("Adaptive streaming test @nomobile @nowebkit @nofirefox", () => {
             browser,
             "Bob",
             publicTestMapUrl("tests/E2E/empty.json", "adaptive_streaming"),
+            {
+                // Without Picture-in-Picture, a hidden tab displays no video at all (see the end of the test)
+                pageCreatedHook: async (page) => {
+                    await page.addInitScript(() => {
+                        localStorage.setItem("allowPictureInPicture", "false");
+                    });
+                },
+            },
         );
         await userBob.evaluate(() => localStorage.setItem("debug", "*"));
         await Map.teleportToPosition(userBob, 160, 160);
@@ -88,5 +96,27 @@ test.describe("Adaptive streaming test @nomobile @nowebkit @nofirefox", () => {
                 },
             )
             .toBeTruthy();
+
+        ////////////////////////// Bob hides his tab: Alice stops encoding for him /////////////////////////
+        // The encoder box of Alice's own tile aggregates what she sends (here, to Bob only).
+        const aliceEncoderBox = page.locator("#cameras-container").getByTestId("encoder-stats");
+        const aliceEncodedFps = async () => Number(/FPS:\s*(\d+)/.exec(await aliceEncoderBox.innerText())?.[1] ?? -1);
+        await expect.poll(aliceEncodedFps, { timeout: 30_000 }).toBeGreaterThan(5);
+
+        // Headless Chromium never hides a page: emulate what the browser does when the tab goes to the background.
+        await userBob.evaluate(() => {
+            Object.defineProperty(document, "visibilityState", { configurable: true, get: () => "hidden" });
+            document.dispatchEvent(new Event("visibilitychange"));
+        });
+        await expect.poll(aliceEncodedFps, { timeout: 30_000 }).toBe(0);
+
+        // Bob comes back: Alice resumes, and Bob does not get a "No video stream received" warning
+        await userBob.evaluate(() => {
+            Object.defineProperty(document, "visibilityState", { configurable: true, get: () => "visible" });
+            document.dispatchEvent(new Event("visibilitychange"));
+        });
+        await expect.poll(aliceEncodedFps, { timeout: 30_000 }).toBeGreaterThan(5);
+        await expect(userBob.locator("#cameras-container").getByText("Alice")).toBeVisible();
+        await expect(userBob.getByText("No video stream received")).toBeHidden();
     });
 });


### PR DESCRIPTION
Stacked on #6505 (the encoder stats box is used by the new E2E assertions). Merge that one first.

## Why

A P2P sender adapted its encoding only once the viewer reported the size of its tile. Two situations never produce that report: a hidden tab (the video element is unmounted unless Picture-in-Picture is open) and a tile scrolled out of view (`VideoBoxOptimizer` unmounts it). The sender then kept its initial state, full capture resolution, for viewers who saw nothing. Found while looking at encoder stats: an idle viewer in a hidden tab was receiving 720p.

## What

Three per-connection changes (the camera track is shared by all peers, so nothing touches the track itself):

1. **Small default stream.** Until a viewer reports a size, send 320x180 so the first frames show up right away at a negligible cost. Chrome rejects `setParameters()` until the sender is negotiated, so the call is retried.
2. **Cut after 5 s without any report.** A viewer that displays the video reports its tile within a second. Without a report (hidden tab from the start, offscreen tile, unknown client), the encoding is deactivated (`encodings[0].active = false`): the encoder stops for that peer, audio is unaffected, no renegotiation.
3. **Pause on unmount.** A viewer whose video element unmounts reports a 0x0 size, the sender deactivates the encoding, the next size report reactivates it. This is what LiveKit already does with `adaptiveStream.pauseVideoInBackground`.

Two follow-ups so that these deliberate changes are not read as instability:

- **Expected frame rate.** The sender announces the frame rate it targets for the viewer (0 while paused) in a new `encoding` P2P message. The FPS variability window restarts on every change, stays empty during the 2 s the encoder needs to settle and while the stream is paused. Paused streams produce no inbound analytics sample. The stats box shows "Expected FPS" and "paused by sender".
- **No FPS variability for screen shares.** Their frame rate follows the content (a still screen sends about one refresh frame per second, whatever the codec), so it says nothing about the connection. Jitter, fps and bandwidth are still measured; the admin's bad-quality rule already falls back to jitter alone when the variability is absent.

The decision logic is a pure function (`AdaptiveVideoEncoding.ts`) and the variability window a small class (`FpsVariabilityTracker.ts`), both unit tested.

## Test plan

- [x] `npm run typecheck`, `npm run svelte-check`, eslint, prettier
- [x] Unit tests for `computeVideoEncoding` and `FpsVariabilityTracker`
- [x] `adaptive_streaming.spec.ts` extended: Bob hides his tab, Alice's encoder stops (0 fps), Bob comes back, Alice resumes, no "No video stream received" on Bob's side (headless Chromium never hides a page, so the spec emulates `document.visibilityState` and disables Picture-in-Picture for Bob)
- [x] Dev stack: viewer hidden from the start gets the 320x180 default stream, then the cut after 5 s, then resumes at the tile size once shown; after a pause/resume the viewer's FPS variability stays at 0.35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
