### PR TITLE
fix(screenshare): stop erroring on our own outgoing screen-share peers

### DIFF
--- a/play/src/front/Space/Space.ts
+++ b/play/src/front/Space/Space.ts
@@ -48,6 +48,7 @@ import { SpacePeerManager } from "./SpacePeerManager/SpacePeerManager";
 import { lookupUserById } from "./Utils/UserLookup";
 import { recordingSchema, spaceMetadataValidator } from "./SpaceMetadataValidator";
 import { VideoBox } from "./VideoBox";
+import { LOCAL_SCREEN_SHARING_STREAM_ID } from "./Streamable";
 import type { Streamable } from "./Streamable";
 
 export class Space implements SpaceInterface {
@@ -1327,6 +1328,12 @@ export class Space implements SpaceInterface {
         this.observeScreenSharingPeerAdded?.unsubscribe();
         this.observeScreenSharingPeerRemoved?.unsubscribe();
         this.observeScreenSharingPeerAdded = this._peerManager.screenSharingPeerAdded.subscribe((peer) => {
+            // Peers sending our own screen carry the recipient's spaceUserId, not ours. Nothing to
+            // attach: they aren't sharing yet; updateUserData attaches this same peer when they do.
+            if (peer.uniqueId === LOCAL_SCREEN_SHARING_STREAM_ID) {
+                return;
+            }
+
             const spaceUserId = peer.spaceUserId;
 
             if (spaceUserId === this._mySpaceUserId) {
@@ -1334,7 +1341,7 @@ export class Space implements SpaceInterface {
             }
 
             if (!spaceUserId) {
-                console.error("observeVideoPeerAdded : peer has no spaceUserId");
+                console.error("observeScreenSharingPeerAdded : peer has no spaceUserId");
                 return;
             }
 

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -41,6 +41,9 @@ export interface ComponentStreamable {
 
 export type StreamCategory = "video" | "screenSharing" | "scripting" | "component";
 
+// Our own screen capture: local preview + the outgoing peers that send it.
+export const LOCAL_SCREEN_SHARING_STREAM_ID = "localScreenSharingStream";
+
 export interface Streamable {
     readonly uniqueId: string;
     readonly media: LivekitStreamable | WebRtcStreamable | ScriptingVideoStreamable | ComponentStreamable;

--- a/play/src/front/Space/tests/Space.test.ts
+++ b/play/src/front/Space/tests/Space.test.ts
@@ -9,6 +9,7 @@ import { Space } from "../Space";
 import { SpaceNameIsEmptyError } from "../Errors/SpaceError";
 import type { RoomConnection } from "../../Connection/RoomConnection";
 import { recordingStore } from "../../Stores/RecordingStore";
+import { LOCAL_SCREEN_SHARING_STREAM_ID } from "../Streamable";
 import type { StreamCategory, Streamable } from "../Streamable";
 import type { StreamableSubjects } from "../SpacePeerManager/SpacePeerManager";
 import type { PeerStatus } from "../../WebRtc/RemotePeer";
@@ -460,6 +461,37 @@ describe("Space test", () => {
         ]);
         expect(activeStreamable.closeStreamable).toHaveBeenCalledOnce();
         expect(pendingStreamable.closeStreamable).not.toHaveBeenCalled();
+    });
+
+    it("should ignore the outgoing peers created to send our own screen share", async () => {
+        const space = await Space.create(
+            "space-name",
+            FilterType.ALL_USERS,
+            defaultRoomConnectionMock,
+            videoPropertiesToSync,
+            signal,
+            {
+                metadata: new Map<string, unknown>(),
+            },
+        );
+        const subjects = getStreamableSubjects(space);
+        // Peers sending our screen carry the *recipient's* spaceUserId, and the recipient is not sharing.
+        const localScreenShare = createStreamable(LOCAL_SCREEN_SHARING_STREAM_ID, "alice-id", "screenSharing");
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        space.initUsers([
+            createSpaceUser({
+                spaceUserId: "alice-id",
+                name: "Alice",
+                screenSharingState: false,
+            }),
+        ]);
+
+        subjects.screenSharingPeerAdded.next(localScreenShare);
+
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+        expect(space.getScreenSharingPeerVideoBox("alice-id")).toBeUndefined();
+        consoleErrorSpy.mockRestore();
     });
 
     it("should show a named recording toast immediately when the recorder is already known", async () => {

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -6,6 +6,7 @@ import { localUserStore } from "../Connection/LocalUserStore";
 import type { VideoQualitySetting } from "../Connection/LocalUserStore";
 import { screenShareMaxResolution } from "../WebRtc/VideoPresets";
 import LL from "../../i18n/i18n-svelte";
+import { LOCAL_SCREEN_SHARING_STREAM_ID } from "../Space/Streamable";
 import type { Streamable, WebRtcStreamable } from "../Space/Streamable";
 import { VideoBox } from "../Space/VideoBox";
 import { localEncoderStatsStore } from "../WebRtc/LocalEncoderStats";
@@ -316,7 +317,7 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
     );
 
     const localMedia = {
-        uniqueId: "localScreenSharingStream",
+        uniqueId: LOCAL_SCREEN_SHARING_STREAM_ID,
         media: {
             type: "webrtc" as const,
             streamStore: mutedLocalMediaStreamStore,

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -18,6 +18,7 @@ import { volumeProximityDiscussionStore } from "../Stores/PeerStore";
 import { screenShareQualityStore } from "../Stores/ScreenSharingStore";
 import { bandwidthConstrainedPreferenceStore } from "../Stores/BandwidthConstrainedPreferenceStore";
 import type { WebRtcSenderStats, WebRtcStats } from "../Components/Video/WebRtcStats";
+import { LOCAL_SCREEN_SHARING_STREAM_ID } from "../Space/Streamable";
 import type { Streamable, StreamCategory, WebRtcStreamable } from "../Space/Streamable";
 import { createMediaStreamTrackPresenceStore } from "../Space/MediaStreamTrackPresenceStore";
 import type { UserSimplePeerInterface } from "./SimplePeer";
@@ -298,7 +299,7 @@ export class RemotePeer extends Peer implements Streamable {
         this.usePresentationMode = !(type === "video");
         //this.userUuid = spaceUser.uuid;
         this.uniqueId = isLocalPeer
-            ? "localScreenSharingStream"
+            ? LOCAL_SCREEN_SHARING_STREAM_ID
             : type === "video"
               ? "video_" + _spaceUserId
               : "screensharing_" + _spaceUserId;


### PR DESCRIPTION
## Problem

Every time you start sharing your screen, the console fills with one `console.error` per person in the bubble:

```
observeScreenSharingPeerAdded : videoBox not found for user https://play…/wa-village_811
observeScreenSharingPeerAdded : videoBox not found for user https://play…/wa-village_845
```

Confusing at first glance, because they name *other* people while it is your own screen being shared.

## Cause

`sendLocalScreenSharingStream()` creates one outgoing peer per remote user, and each one is built with the **recipient's** `spaceUserId`, not ours (`SimplePeer.ts`). The guard at the top of `observeScreenSharingPeerAdded` compares that id to `mySpaceUserId`, so it never matches. We then look up a screen-sharing video box for someone who is not sharing — a box only created when *that* user announces `screenSharingState: true` — and log the error.

Display is unaffected: our own screen comes from the local streamable in `ScreenSharingStore`. But it is noise at `error` level, and it hides the genuine "should not happen" case the message was written for.

## Fix

Guard on the streamable actually being our own screen capture. The uniqueId `"localScreenSharingStream"` already marked it in two places, so it is extracted as `LOCAL_SCREEN_SHARING_STREAM_ID` and used in all three. Also fixes a copy-pasted message that said `observeVideoPeerAdded` inside the screen-sharing subscriber.

Skipping is always correct here: the outgoing peer is only created when no screen-sharing peer exists yet with that user (`if (this.screenSharePeers.has(userId)) return;`), so the recipient is never already sharing at that point and there is no box to attach to. When they later start sharing, `updateUserData` creates the box and attaches this same — bidirectional — peer.

`screenSharingPeerRemoved` is deliberately left untouched: there the peer may legitimately be carrying their screen by the time it closes, and skipping would break `promotePendingStreamable()`.

## Test

One test in `Space.test.ts` covering an outgoing local screen-share peer for a non-sharing user. Verified it fails when the guard is neutralised. `tsc`, ESLint and Prettier clean on the touched files.

## Known follow-up, not addressed here

The screen-sharing connection is shared in both directions. If you share first, the peer is labelled `localScreenSharingStream`, and the other person's screen later arrives on that same mislabelled peer. Harmless today, but this fix leans on that label, so the naming deserves a proper pass at some point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)