### PR TITLE
fix(calendar): format dates with the browser locale

### DIFF
--- a/play/src/front/Components/Calendar/Calendar.svelte
+++ b/play/src/front/Components/Calendar/Calendar.svelte
@@ -21,7 +21,8 @@
     }
 
     function formatHour(date: Date) {
-        return date.toLocaleString("en-GB", {
+        // undefined locale: follow the browser's own date/time settings
+        return date.toLocaleString(undefined, {
             hour: "2-digit",
             minute: "2-digit",
         });
@@ -73,7 +74,7 @@
                             <img draggable="false" src={calendarPng} class="w-8" alt={$LL.menu.icon.open.calendar()} />
                         {/if}
                         <h3 class="text-xl text-left leading-none">
-                            {new Date().toLocaleString("en-EN", {
+                            {new Date().toLocaleString(undefined, {
                                 month: "long",
                                 day: "2-digit",
                                 year: "numeric",


### PR DESCRIPTION
The calendar panel hardcoded its locales: event hours were formatted with `en-GB` (24h forced for everyone) and the header date with `en-EN` — not a valid tag, since there is no `EN` region, so `Intl` silently fell back to English.

Passing `undefined` as the locale lets `Intl` use the browser's own date and time settings.

## Notes

- Alternative considered: formatting with the locale selected in WorkAdventure (`$locale` from `i18n-svelte`). Kept the browser setting as asked; WA initialises its own locale from `navigator.language` anyway, so the two only differ when the user overrides the language in the app.
- `formatHour()` is not reactive to a locale change mid-session — Svelte does not track `$locale` as a dependency of `{formatHour(event.start)}`. Not an issue with `undefined`, worth knowing if we later switch to `$locale`.

## Test

Set the browser to a `fr-FR` (or `en-US`) locale and open the calendar panel: hours follow the local convention (24h vs AM/PM) and the header date is localised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)