### PR TITLE
fix(menu): stop the open submenu from closing itself

### DIFF
--- a/play/src/front/Components/Menu/Menu.svelte
+++ b/play/src/front/Components/Menu/Menu.svelte
@@ -28,7 +28,13 @@
     import ShortcutSubMenu from "./ShortcutSubMenu.svelte";
     import HelpSubMenu from "./HelpSubMenu.svelte";
 
-    let activeSubMenu: MenuItem = $state($subMenusStore[$activeSubMenuStore]);
+    // raw, not $state: this holds one of the objects in subMenusStore and is compared back against
+    // them with ===, both here and in the markup. A deep-reactive $state would proxy it, and a proxy
+    // never matches the object it wraps - so the active item would stop matching itself: no
+    // highlight in the list, and includes() below would decide the open menu had been removed from
+    // the store and switch away from it, tearing down whatever it was showing. It is only ever
+    // reassigned, never mutated, so there is nothing for the proxy to do anyway.
+    let activeSubMenu: MenuItem = $state.raw($subMenusStore[$activeSubMenuStore]);
     let activeComponent: WorkAdventureComponent = $state(ProfileSubMenu);
     let props: { url: string; allowApi: boolean; allow?: string } = $state({
         url: "",


### PR DESCRIPTION
## The symptom

Open a custom submenu (`WA.ui.registerMenuCommand` with an iframe) and it can vanish on its own a second later: the page it points at is fetched, then the iframe is torn down. The active item in the menu list is also never highlighted.

The console says why:

```
[svelte] state_proxy_equality_mismatch
Reactive `$state(...)` proxies and the values they proxy have different identities.
```

## The cause

`activeSubMenu` holds one of the objects in `subMenusStore` and is compared back against them with `===` — in the markup to mark the active item, and in the `subMenusStore` subscriber to check the open menu still exists:

```js
let activeSubMenu: MenuItem = $state($subMenusStore[$activeSubMenuStore]);
…
if (!$subMenusStore.includes(activeSubMenu)) {
    switchMenu($subMenusStore[$activeSubMenuStore]);   // switches away
}
```

`$state` proxies the object it is given, and a proxy is never `===` the object it wraps, so every one of those comparisons has been false since the Svelte 5 migration. `includes()` therefore reports that the open menu has been removed from the store on **every** store emission — a script registering a menu, the chat entry appearing once Matrix connects — and the component switches away from whatever the user just opened.

## The fix

`$state.raw`, which keeps the reference the store handed us. The variable is only ever reassigned, never mutated, so deep reactivity had nothing to offer it — and this restores the pre-Svelte-5 semantics the surrounding code was written against.

`svelte-check` is clean. Verified against a custom submenu that was reliably losing its iframe: it now stays open, and the active item highlights again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)