### PR TITLE
Backport Report encoder health

### DIFF
--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -141,22 +141,33 @@ message WebRtcSignal {
 }
 
 enum VideoQualityStreamCategory {
-  VIDEO_QUALITY_STREAM_CATEGORY_UNSPECIFIED = 0;
-  VIDEO_QUALITY_STREAM_CATEGORY_VIDEO = 1;
-  VIDEO_QUALITY_STREAM_CATEGORY_SCREEN_SHARING = 2;
+  VIDEO_QUALITY_STREAM_CATEGORY_VIDEO = 0;
+  VIDEO_QUALITY_STREAM_CATEGORY_SCREEN_SHARING = 1;
 }
 
 enum VideoQualityTransportType {
-  VIDEO_QUALITY_TRANSPORT_TYPE_UNSPECIFIED = 0;
-  VIDEO_QUALITY_TRANSPORT_TYPE_P2P = 1;
-  VIDEO_QUALITY_TRANSPORT_TYPE_LIVEKIT = 2;
+  VIDEO_QUALITY_TRANSPORT_TYPE_P2P = 0;
+  VIDEO_QUALITY_TRANSPORT_TYPE_LIVEKIT = 1;
 }
 
 enum VideoQualityRelayProtocol {
-  VIDEO_QUALITY_RELAY_PROTOCOL_UNSPECIFIED = 0;
-  VIDEO_QUALITY_RELAY_PROTOCOL_UDP = 1;
-  VIDEO_QUALITY_RELAY_PROTOCOL_TCP = 2;
-  VIDEO_QUALITY_RELAY_PROTOCOL_TLS = 3;
+  VIDEO_QUALITY_RELAY_PROTOCOL_UDP = 0;
+  VIDEO_QUALITY_RELAY_PROTOCOL_TCP = 1;
+  VIDEO_QUALITY_RELAY_PROTOCOL_TLS = 2;
+}
+
+// Direction of a video stream from the reporter's point of view.
+enum VideoQualityStreamDirection {
+  VIDEO_QUALITY_STREAM_DIRECTION_INBOUND = 0;
+  VIDEO_QUALITY_STREAM_DIRECTION_OUTBOUND = 1;
+}
+
+// Why the browser's encoder is not sending at full quality (RTCOutboundRtpStreamStats.qualityLimitationReason).
+enum VideoQualityLimitationReason {
+  VIDEO_QUALITY_LIMITATION_REASON_NONE = 0;
+  VIDEO_QUALITY_LIMITATION_REASON_CPU = 1;
+  VIDEO_QUALITY_LIMITATION_REASON_BANDWIDTH = 2;
+  VIDEO_QUALITY_LIMITATION_REASON_OTHER = 3;
 }
 
 message VideoQualitySampleMessage {
@@ -180,6 +191,11 @@ message VideoQualitySampleMessage {
   uint32 frameWidth = 18;
   uint32 frameHeight = 19;
   optional string mimeType = 20;
+  VideoQualityStreamDirection direction = 21;
+  // Outbound streams only.
+  optional VideoQualityLimitationReason qualityLimitationReason = 22;
+  // Outbound streams only: encoder implementation reported by the browser (e.g. "libaom", "libvpx", "ExternalEncoder").
+  optional string encoderImplementation = 23;
 }
 
 message VideoQualityReportMessage {

--- a/play/src/front/Components/Video/EncoderStatsBox.svelte
+++ b/play/src/front/Components/Video/EncoderStatsBox.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+    import type { LocalEncoderStats } from "../../WebRtc/LocalEncoderStats";
+    import { describeEncoder } from "../../WebRtc/LocalEncoderStats";
+
+    interface Props {
+        encoderStats: LocalEncoderStats | undefined;
+    }
+
+    let { encoderStats }: Props = $props();
+
+    let encoder = $derived(describeEncoder(encoderStats?.encoderImplementation));
+    // Red when the machine cannot keep up, yellow when something else holds the encoder back
+    let statsColorClass = $derived(
+        encoderStats?.qualityLimitationReason === "cpu"
+            ? "text-red-300 bg-red-950/50"
+            : encoderStats?.qualityLimitationReason === "bandwidth" || encoderStats?.qualityLimitationReason === "other"
+              ? "text-yellow-300 bg-yellow-950/50"
+              : "text-green-300 bg-green-950/50",
+    );
+</script>
+
+{#if encoderStats}
+    <div
+        class={`absolute bottom-0 right-0 p-2 text-[0.6rem] @[20rem]/videomediabox:text-[0.75rem] rounded-br-md rounded-tl-md select-text ${statsColorClass}`}
+        data-testid="encoder-stats"
+    >
+        <table class="m-0 p-0 border-hidden">
+            <tbody class="m-0 p-0 border-hidden">
+                <tr>
+                    <td>Encoder:</td><td data-testid="encoder-name">{encoder.name} ({encoder.type})</td>
+                </tr>
+                <tr>
+                    <td>Limited by:</td><td data-testid="encoder-limitation">{encoderStats.qualityLimitationReason}</td>
+                </tr>
+                <tr>
+                    <td>FPS:</td><td>{Math.round(encoderStats.fps)}</td>
+                </tr>
+                <tr>
+                    <td>Bandwidth:</td><td>{Math.round((encoderStats.bandwidth / 1000) * 8)} kbps</td>
+                </tr>
+                <tr>
+                    <td>Resolution:</td><td>{encoderStats.frameWidth}x{encoderStats.frameHeight}</td>
+                </tr>
+                <tr>
+                    <td>Codec:</td><td>{encoderStats.mimeType ?? "-"}</td>
+                </tr>
+                <tr>
+                    <td>Source:</td><td>{encoderStats.source}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+{/if}
+
+<style>
+    td {
+        padding: 0;
+    }
+</style>

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -23,6 +23,7 @@
     import UpDownChevron from "./UpDownChevron.svelte";
     import CenteredVideo from "./CenteredVideo.svelte";
     import WebRtcStats from "./WebRtcStatsBox.svelte";
+    import EncoderStatsBox from "./EncoderStatsBox.svelte";
     import { IconArrowsMinimize, IconArrowsMaximize, IconMicrophoneOff } from "@wa-icons";
 
     interface Props {
@@ -70,6 +71,8 @@
     let volumeMeter = $derived($volumeMeterStore);
     let webRtcStatsStore = $derived($displayVideoQualityStore ? streamable?.webrtcStats : undefined);
     let webRtcStats = $derived($webRtcStatsStore);
+    let encoderStatsStore = $derived($displayVideoQualityStore ? streamable?.senderStats : undefined);
+    let encoderStats = $derived($encoderStatsStore);
 
     // Check if user is currently reconnecting (WebRTC retry in progress)
     let isReconnecting = $derived(effectiveStatus === "reconnecting");
@@ -433,6 +436,9 @@
                             {/if}
                             {#if webRtcStats}
                                 <WebRtcStats {webRtcStats} />
+                            {/if}
+                            {#if encoderStats}
+                                <EncoderStatsBox {encoderStats} />
                             {/if}
 
                             <!-- The menu to go fullscreen -->

--- a/play/src/front/Components/Video/WebRtcStats.ts
+++ b/play/src/front/Components/Video/WebRtcStats.ts
@@ -13,3 +13,24 @@ export interface WebRtcStats {
     // Protocol used with TURN when relayed (browser-dependent)
     relayProtocol?: "udp" | "tcp" | "tls";
 }
+
+// RTCOutboundRtpStreamStats.qualityLimitationReason
+export type WebRtcQualityLimitationReason = "none" | "cpu" | "bandwidth" | "other";
+
+/**
+ * Statistics of a video track we are sending (camera or screen share), read from the encoder side of the connection.
+ */
+export interface WebRtcSenderStats {
+    source: string;
+    frameWidth: number;
+    frameHeight: number;
+    mimeType?: string;
+    // Bytes sent per second, all simulcast/SVC layers included
+    bandwidth: number;
+    // Frames encoded per second on the largest layer
+    fps: number;
+    // Why the browser is not encoding at the requested quality ("cpu" = the machine cannot keep up)
+    qualityLimitationReason: WebRtcQualityLimitationReason;
+    // Encoder reported by the browser, e.g. "libaom" / "libvpx" (software) or "ExternalEncoder" (hardware)
+    encoderImplementation?: string;
+}

--- a/play/src/front/Livekit/LiveKitRoom.test.ts
+++ b/play/src/front/Livekit/LiveKitRoom.test.ts
@@ -91,6 +91,11 @@ vi.mock("livekit-client", async (importOriginal) => {
 
 describe("LiveKitRoom", () => {
     beforeEach(() => {
+        // The encoder analytics hook checks the admin capabilities after a publication
+        window.capabilities = {};
+    });
+
+    beforeEach(() => {
         vi.clearAllMocks();
     });
 
@@ -344,6 +349,8 @@ function createSpace(
         isStreamingAudioStore: writable(false),
         shouldPublishScreenShareStore,
         emitBackEvent,
+        getName: () => "world.space",
+        emitVideoQualityReport: vi.fn(),
     } as unknown as SpaceInterface;
 }
 

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -28,6 +28,9 @@ import { triggerReorderStore } from "../Stores/OrderedStreamableCollectionStore"
 import { deriveSwitchStore } from "../Stores/InterruptorStore";
 import { selectVideoPreset, type VideoQualitySetting } from "../WebRtc/VideoPresets";
 import { analyticsClient } from "../Administration/AnalyticsClient";
+import { createLivekitSenderStats } from "../WebRtc/WebRtcStatsFactory";
+import { registerLocalEncoderStats } from "../WebRtc/LocalEncoderStats";
+import { subscribeToOutboundVideoQualityAnalytics } from "../WebRtc/VideoQualityAnalytics";
 import { LIVEKIT_PIXEL_DENSITY } from "../Enum/EnvironmentVariable";
 import { SCREEN_SHARE_STARTING_PRIORITY, VIDEO_STARTING_PRIORITY } from "../Space/VideoBoxPriorities";
 import { audioPlaybackStore } from "../Stores/AudioPlaybackStore";
@@ -64,6 +67,9 @@ export class LiveKitRoom implements LiveKitRoomInterface {
     private localScreenSharingAudioTrack: LocalAudioTrack | undefined;
     private localCameraTrack: LocalVideoTrack | undefined;
     private localMicrophoneTrack: LocalAudioTrack | undefined;
+    // Encoder health reports of the video tracks we publish (see subscribeToOutboundVideoQualityAnalytics)
+    private cameraAnalyticsUnsubscribe: Unsubscriber | undefined;
+    private screenShareAnalyticsUnsubscribe: Unsubscriber | undefined;
     private screenShareUpdateQueue: Promise<void> = Promise.resolve();
     private mediaTrackUpdateQueue: Promise<void> = Promise.resolve();
     private unsubscribers: Unsubscriber[] = [];
@@ -271,6 +277,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             // Only keep the reference once published: after a failed publish, later updates must publish again
             // instead of calling replaceTrack() on an unpublished track.
             this.localCameraTrack = cameraTrack;
+            this.cameraAnalyticsUnsubscribe = this.subscribeToEncoderAnalytics(cameraTrack, "video");
         } else {
             await this.localCameraTrack.replaceTrack(videoTrack, {
                 userProvidedTrack: true,
@@ -486,6 +493,10 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             await this.localParticipant.publishTrack(screenShareVideoLocalTrack, screenSharePublishOptions);
             // Only keep the reference once published (see handleCameraTrack)
             this.localScreenSharingVideoTrack = screenShareVideoLocalTrack;
+            this.screenShareAnalyticsUnsubscribe = this.subscribeToEncoderAnalytics(
+                screenShareVideoLocalTrack,
+                "screenSharing",
+            );
         } else if (this.localScreenSharingVideoTrack.mediaStreamTrack.id === screenShareVideoTrack.id) {
             // Note: this cannot really happen as we never pause the upstream. We unpublish the track instead.
             if (this.localScreenSharingVideoTrack.isUpstreamPaused) {
@@ -565,6 +576,8 @@ export class LiveKitRoom implements LiveKitRoomInterface {
 
         // Note: if we ever use "pauseUpstream" again instead of unpublishTrack, we should comment the clear of local track references
         // because of the memory leak issue mentioned above. We need to keep them to be able to replace the tracks when publishing a new screen share.
+        this.screenShareAnalyticsUnsubscribe?.();
+        this.screenShareAnalyticsUnsubscribe = undefined;
         this.localScreenSharingVideoTrack = undefined;
         this.localScreenSharingAudioTrack = undefined;
     }
@@ -922,6 +935,37 @@ export class LiveKitRoom implements LiveKitRoomInterface {
         this.previousSpeakers = speakersSet;
     }
 
+    /**
+     * Reports the health of the encoder of a published track (CPU / bandwidth limitation, encoder implementation)
+     * to the video quality analytics. The camera track is only paused when the camera is turned off, so its
+     * subscription lives as long as the room: paused tracks encode nothing and produce no sample.
+     */
+    private subscribeToEncoderAnalytics(
+        track: LocalVideoTrack,
+        streamCategory: "video" | "screenSharing",
+    ): Unsubscriber {
+        const senderStats = createLivekitSenderStats(track);
+        // Shown in the local camera / screen share feedback tile
+        const unregisterLocalEncoderStats = registerLocalEncoderStats(streamCategory, senderStats);
+        const unsubscribeAnalytics = subscribeToOutboundVideoQualityAnalytics(
+            senderStats,
+            {
+                streamId: `${this.localParticipant?.sid ?? "local"}:${streamCategory}:outbound`,
+                streamCategory,
+                transportType: "Livekit",
+                // The stream goes to the LiveKit server, not to a single remote user
+                remoteSpaceUserId: "",
+                spaceName: this.space.getName(),
+                livekitServerUrl: this.serverUrl,
+            },
+            (message) => this.space.emitVideoQualityReport(message),
+        );
+        return () => {
+            unsubscribeAnalytics();
+            unregisterLocalEncoderStats();
+        };
+    }
+
     public destroy(): void {
         if (this.destroyed) {
             // Called both from handleDisconnected() and from LivekitConnection
@@ -941,6 +985,10 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             this.room?.off(RoomEvent.AudioPlaybackStatusChanged, this.boundHandleAudioPlaybackStatusChanged);
             this.unregisterAudioPlaybackRetry?.();
             this.unregisterAudioPlaybackRetry = undefined;
+            this.cameraAnalyticsUnsubscribe?.();
+            this.cameraAnalyticsUnsubscribe = undefined;
+            this.screenShareAnalyticsUnsubscribe?.();
+            this.screenShareAnalyticsUnsubscribe = undefined;
             this.leaveRoom();
         } finally {
             this._livekitRoomCounter.decrement();

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -3,6 +3,7 @@ import type { RemoteVideoTrack } from "livekit-client";
 import type { WorkAdventureComponent } from "../../types/component";
 import type { PeerStatus } from "../WebRtc/RemotePeer";
 import type { WebRtcStats } from "../Components/Video/WebRtcStats";
+import type { LocalEncoderStats } from "../WebRtc/LocalEncoderStats";
 import type { VideoConfig } from "../Api/Events/Ui/PlayVideoEvent";
 
 export interface LivekitStreamable {
@@ -77,4 +78,8 @@ export interface Streamable {
     readonly volume: Writable<number>;
     readonly videoType: StreamCategory;
     readonly webrtcStats: Readable<WebRtcStats | undefined> | undefined;
+    /**
+     * Health of our own encoder(s), set on the local camera / screen share feedback tiles only.
+     */
+    readonly senderStats?: Readable<LocalEncoderStats | undefined>;
 }

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -8,6 +8,7 @@ import { screenShareMaxResolution } from "../WebRtc/VideoPresets";
 import LL from "../../i18n/i18n-svelte";
 import type { Streamable, WebRtcStreamable } from "../Space/Streamable";
 import { VideoBox } from "../Space/VideoBox";
+import { localEncoderStatsStore } from "../WebRtc/LocalEncoderStats";
 import { isSpeakerStore, type LocalStreamStoreValue } from "./MediaStore";
 import { inExternalServiceStore, myCameraStore, myMicrophoneStore } from "./MyMediaStore";
 import type {} from "../Api/Desktop";
@@ -341,6 +342,7 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
         volume: writable(1),
         videoType: "screenSharing",
         webrtcStats: undefined,
+        senderStats: localEncoderStatsStore.screenSharing,
     } satisfies Streamable;
 
     const unsubscribe = screenSharingLocalStreamStore.subscribe((screenSharingLocalStream) => {

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -6,6 +6,7 @@ import LL from "../../i18n/i18n-svelte";
 import { VideoBox } from "../Space/VideoBox";
 import type { Streamable } from "../Space/Streamable";
 import { touchScreenManager } from "../Touch/TouchScreenManager";
+import { localEncoderStatsStore } from "../WebRtc/LocalEncoderStats";
 import { screenSharingLocalVideoBox } from "./ScreenSharingStore";
 
 import { highlightedEmbedScreen } from "./HighlightedEmbedScreenStore";
@@ -85,6 +86,7 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) 
         volume: writable(1),
         videoType: "video",
         webrtcStats: undefined,
+        senderStats: localEncoderStatsStore.video,
     };
     const videoBox = VideoBox.fromLocalStreamable(streamable, -2);
     set(videoBox);

--- a/play/src/front/WebRtc/LocalEncoderStats.ts
+++ b/play/src/front/WebRtc/LocalEncoderStats.ts
@@ -1,0 +1,125 @@
+import { derived, writable, type Readable, type Unsubscriber } from "svelte/store";
+import type { WebRtcQualityLimitationReason, WebRtcSenderStats } from "../Components/Video/WebRtcStats";
+
+/**
+ * Health of the encoders of what we send, as displayed in the local camera / screen share feedback tiles.
+ *
+ * Every active sender registers its stats store here: one per LiveKit published track, one per P2P connection
+ * (Chrome runs one encoder per RTCPeerConnection). The tiles display one aggregate per category, the worst case.
+ */
+
+export type EncoderCategory = "video" | "screenSharing";
+
+export interface LocalEncoderStats extends WebRtcSenderStats {
+    // Number of encoders aggregated (P2P: one per peer)
+    encoderCount: number;
+}
+
+export type EncoderType = "software" | "hardware" | "unknown";
+
+const SOFTWARE_ENCODERS = /libaom|libvpx|openh264|libx264|svt/i;
+const HARDWARE_ENCODERS = /external|hardware|videotoolbox|mediafoundation|vaapi|nvenc|qsv|v4l2|mediacodec/i;
+
+/**
+ * Chrome names software encoders after their library ("libaom", "libvpx", "OpenH264", possibly wrapped in
+ * "SimulcastEncoderAdapter (libvpx, libvpx)") and hardware ones "ExternalEncoder". Firefox reports nothing.
+ */
+export function describeEncoder(encoderImplementation: string | undefined): { name: string; type: EncoderType } {
+    if (!encoderImplementation) {
+        return { name: "-", type: "unknown" };
+    }
+    if (SOFTWARE_ENCODERS.test(encoderImplementation)) {
+        return { name: encoderImplementation, type: "software" };
+    }
+    if (HARDWARE_ENCODERS.test(encoderImplementation)) {
+        return { name: encoderImplementation, type: "hardware" };
+    }
+    return { name: encoderImplementation, type: "unknown" };
+}
+
+const REASON_SEVERITY: Record<WebRtcQualityLimitationReason, number> = {
+    none: 0,
+    other: 1,
+    bandwidth: 2,
+    cpu: 3,
+};
+
+/**
+ * Worst case over several encoders: the most severe limitation reason wins, bandwidth is summed (that is what
+ * leaves the machine), fps is the lowest, the resolution the largest.
+ */
+export function aggregateSenderStats(values: (WebRtcSenderStats | undefined)[]): LocalEncoderStats | undefined {
+    const stats = values.filter((value): value is WebRtcSenderStats => value !== undefined);
+    if (stats.length === 0) {
+        return undefined;
+    }
+    const worst = stats.reduce((a, b) =>
+        REASON_SEVERITY[b.qualityLimitationReason] > REASON_SEVERITY[a.qualityLimitationReason] ? b : a,
+    );
+    const largest = stats.reduce((a, b) => (b.frameWidth * b.frameHeight > a.frameWidth * a.frameHeight ? b : a));
+    return {
+        source: stats.length > 1 ? `${stats[0].source} (${stats.length} encoders)` : stats[0].source,
+        frameWidth: largest.frameWidth,
+        frameHeight: largest.frameHeight,
+        mimeType: worst.mimeType ?? stats.find((s) => s.mimeType !== undefined)?.mimeType,
+        bandwidth: stats.reduce((sum, s) => sum + s.bandwidth, 0),
+        fps: Math.min(...stats.map((s) => s.fps)),
+        qualityLimitationReason: worst.qualityLimitationReason,
+        encoderImplementation:
+            worst.encoderImplementation ??
+            stats.find((s) => s.encoderImplementation !== undefined)?.encoderImplementation,
+        encoderCount: stats.length,
+    };
+}
+
+class LocalEncoderStatsRegistry {
+    private readonly stores = writable(new Map<symbol, Readable<WebRtcSenderStats | undefined>>());
+
+    public readonly stats: Readable<LocalEncoderStats | undefined> = derived<
+        Readable<Map<symbol, Readable<WebRtcSenderStats | undefined>>>,
+        LocalEncoderStats | undefined
+    >(
+        this.stores,
+        ($stores, set) => {
+            const list = Array.from($stores.values());
+            if (list.length === 0) {
+                set(undefined);
+                return;
+            }
+            return derived(list, ($values) => aggregateSenderStats($values)).subscribe(set);
+        },
+        undefined,
+    );
+
+    public register(store: Readable<WebRtcSenderStats | undefined>): Unsubscriber {
+        const key = Symbol();
+        this.stores.update((stores) => new Map(stores).set(key, store));
+        return () => {
+            this.stores.update((stores) => {
+                const next = new Map(stores);
+                next.delete(key);
+                return next;
+            });
+        };
+    }
+}
+
+const registries: Record<EncoderCategory, LocalEncoderStatsRegistry> = {
+    video: new LocalEncoderStatsRegistry(),
+    screenSharing: new LocalEncoderStatsRegistry(),
+};
+
+/**
+ * Registers the stats store of an encoder we run. Returns the function removing it.
+ */
+export function registerLocalEncoderStats(
+    category: EncoderCategory,
+    store: Readable<WebRtcSenderStats | undefined>,
+): Unsubscriber {
+    return registries[category].register(store);
+}
+
+export const localEncoderStatsStore: Record<EncoderCategory, Readable<LocalEncoderStats | undefined>> = {
+    video: registries.video.stats,
+    screenSharing: registries.screenSharing.stats,
+};

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -17,14 +17,15 @@ import { deriveSwitchStore } from "../Stores/InterruptorStore";
 import { volumeProximityDiscussionStore } from "../Stores/PeerStore";
 import { screenShareQualityStore } from "../Stores/ScreenSharingStore";
 import { bandwidthConstrainedPreferenceStore } from "../Stores/BandwidthConstrainedPreferenceStore";
-import type { WebRtcStats } from "../Components/Video/WebRtcStats";
+import type { WebRtcSenderStats, WebRtcStats } from "../Components/Video/WebRtcStats";
 import type { Streamable, StreamCategory, WebRtcStreamable } from "../Space/Streamable";
 import { createMediaStreamTrackPresenceStore } from "../Space/MediaStreamTrackPresenceStore";
 import type { UserSimplePeerInterface } from "./SimplePeer";
 import { isFirefox } from "./DeviceUtils";
 import { P2PMessage, STREAM_STOPPED_MESSAGE_TYPE } from "./P2PMessages/P2PMessage";
-import { subscribeToVideoQualityAnalytics } from "./VideoQualityAnalytics";
-import { createWebRtcStats } from "./WebRtcStatsFactory";
+import { subscribeToOutboundVideoQualityAnalytics, subscribeToVideoQualityAnalytics } from "./VideoQualityAnalytics";
+import { createPeerWebRtcStats } from "./WebRtcStatsFactory";
+import { registerLocalEncoderStats } from "./LocalEncoderStats";
 import { selectVideoPreset, type VideoQualitySetting } from "./VideoPresets";
 
 export type PeerStatus = "connecting" | "connected" | "error" | "closed";
@@ -67,6 +68,10 @@ export class RemotePeer extends Peer implements Streamable {
     public readonly volume: Writable<number>;
     public readonly videoType: StreamCategory;
     public readonly webrtcStats: Readable<WebRtcStats | undefined>;
+    // Health of our own encoder on this connection (what we send to the peer)
+    public readonly senderWebrtcStats: Readable<WebRtcSenderStats | undefined>;
+    private senderAnalyticsUnsubscribe: Unsubscriber | undefined;
+    private unregisterLocalEncoderStats: Unsubscriber | undefined;
     private analyticsStatsUnsubscribe: Unsubscriber | undefined;
     private analyticsRemoteStreamUnsubscribe: (() => void) | undefined;
     private receiverMaxBitrateBps: number | undefined;
@@ -491,7 +496,25 @@ export class RemotePeer extends Peer implements Streamable {
             this.showVoiceIndicatorStore.forward(showVoiceIndicator);
         }
 
-        this.webrtcStats = createWebRtcStats(this);
+        const stats = createPeerWebRtcStats(this);
+        this.webrtcStats = stats.receiver;
+        this.senderWebrtcStats = stats.sender;
+        // Shown in the local camera / screen share feedback tile
+        this.unregisterLocalEncoderStats = registerLocalEncoderStats(this.type, this.senderWebrtcStats);
+        // Each P2P connection has its own encoder: report it per peer.
+        this.senderAnalyticsUnsubscribe = subscribeToOutboundVideoQualityAnalytics(
+            this.senderWebrtcStats,
+            {
+                streamId: `${this._connectionId}:${this._spaceUserId}:${this.type}:outbound`,
+                streamCategory: this.type,
+                transportType: "P2P",
+                remoteSpaceUserId: this._spaceUserId,
+                remoteUserUuid: this.space.getSpaceUserBySpaceUserId(this._spaceUserId)?.uuid,
+                spaceName: this.space.getName(),
+                connectionId: this._connectionId,
+            },
+            (message) => this.space.emitVideoQualityReport(message),
+        );
     }
 
     private sendBlockMessage(blocking: boolean) {
@@ -657,6 +680,10 @@ export class RemotePeer extends Peer implements Streamable {
             }
 
             this._connected = false;
+            this.senderAnalyticsUnsubscribe?.();
+            this.senderAnalyticsUnsubscribe = undefined;
+            this.unregisterLocalEncoderStats?.();
+            this.unregisterLocalEncoderStats = undefined;
             if (this.closing) {
                 return;
             }

--- a/play/src/front/WebRtc/VideoQualityAnalytics.ts
+++ b/play/src/front/WebRtc/VideoQualityAnalytics.ts
@@ -1,11 +1,13 @@
 import type { Readable, Unsubscriber } from "svelte/store";
 import type { VideoQualityReportMessage, VideoQualitySampleMessage } from "@workadventure/messages";
 import {
+    VideoQualityLimitationReason,
     VideoQualityRelayProtocol,
     VideoQualityStreamCategory,
+    VideoQualityStreamDirection,
     VideoQualityTransportType,
 } from "@workadventure/messages";
-import type { WebRtcStats } from "../Components/Video/WebRtcStats";
+import type { WebRtcSenderStats, WebRtcStats } from "../Components/Video/WebRtcStats";
 import { hasCapability } from "../Connection/Capabilities";
 
 const VIDEO_ANALYTICS_SEND_INTERVAL_MS = 5_000;
@@ -15,6 +17,7 @@ export type VideoQualityAnalyticsContext = {
     streamId: string;
     streamCategory: "video" | "screenSharing";
     transportType: "P2P" | "Livekit";
+    // Empty for streams sent to a LiveKit server (no single remote user)
     remoteSpaceUserId: string;
     remoteUserUuid?: string;
     spaceName: string;
@@ -24,10 +27,83 @@ export type VideoQualityAnalyticsContext = {
 
 const sessionId = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
+/**
+ * Reports the quality of a video stream we receive.
+ */
 export function subscribeToVideoQualityAnalytics(
     statsStore: Readable<WebRtcStats | undefined>,
     context: VideoQualityAnalyticsContext,
     sendReport: (message: VideoQualityReportMessage) => void,
+): Unsubscriber {
+    return subscribeToSamples(statsStore, context, sendReport, (stats, base) => {
+        if (!isValidStats(stats)) {
+            return undefined;
+        }
+        return {
+            ...base,
+            direction: VideoQualityStreamDirection.VIDEO_QUALITY_STREAM_DIRECTION_INBOUND,
+            relay: stats.relay,
+            relayProtocol: toRelayProtocol(stats.relayProtocol),
+            fps: stats.fps,
+            fpsStdDev: stats.fpsStdDev,
+            jitter: stats.jitter,
+            bandwidthBytesPerSecond: stats.bandwidth,
+            frameWidth: toUInt32(stats.frameWidth),
+            frameHeight: toUInt32(stats.frameHeight),
+            mimeType: stats.mimeType,
+        };
+    });
+}
+
+/**
+ * Reports the health of the encoder of a video stream we send (camera or screen share): whether the browser is
+ * CPU or bandwidth limited, and which encoder it uses.
+ */
+export function subscribeToOutboundVideoQualityAnalytics(
+    statsStore: Readable<WebRtcSenderStats | undefined>,
+    context: VideoQualityAnalyticsContext,
+    sendReport: (message: VideoQualityReportMessage) => void,
+): Unsubscriber {
+    return subscribeToSamples(statsStore, context, sendReport, (stats, base) => {
+        if (!isValidSenderStats(stats)) {
+            return undefined;
+        }
+        return {
+            ...base,
+            direction: VideoQualityStreamDirection.VIDEO_QUALITY_STREAM_DIRECTION_OUTBOUND,
+            fps: stats.fps,
+            // The sender has no receive jitter
+            jitter: 0,
+            bandwidthBytesPerSecond: stats.bandwidth,
+            frameWidth: toUInt32(stats.frameWidth),
+            frameHeight: toUInt32(stats.frameHeight),
+            mimeType: stats.mimeType,
+            qualityLimitationReason: toLimitationReason(stats.qualityLimitationReason),
+            encoderImplementation: stats.encoderImplementation,
+        };
+    });
+}
+
+type BaseSample = Pick<
+    VideoQualitySampleMessage,
+    | "clientEventTimeMs"
+    | "sampleSeq"
+    | "streamId"
+    | "connectionId"
+    | "sessionId"
+    | "remoteUserUuid"
+    | "remoteSpaceUserId"
+    | "spaceName"
+    | "streamCategory"
+    | "transportType"
+    | "livekitServerUrl"
+>;
+
+function subscribeToSamples<T>(
+    statsStore: Readable<T | undefined>,
+    context: VideoQualityAnalyticsContext,
+    sendReport: (message: VideoQualityReportMessage) => void,
+    buildSample: (stats: T, base: BaseSample) => VideoQualitySampleMessage | undefined,
 ): Unsubscriber {
     if (hasCapability(VIDEO_QUALITY_ANALYTICS_CAPABILITY) !== "v1") {
         return () => {};
@@ -37,7 +113,7 @@ export function subscribeToVideoQualityAnalytics(
     let lastSentAt = 0;
 
     return statsStore.subscribe((stats) => {
-        if (!stats || !isValidStats(stats)) {
+        if (!stats) {
             return;
         }
 
@@ -45,9 +121,8 @@ export function subscribeToVideoQualityAnalytics(
         if (now - lastSentAt < VIDEO_ANALYTICS_SEND_INTERVAL_MS) {
             return;
         }
-        lastSentAt = now;
 
-        const sample: VideoQualitySampleMessage = {
+        const sample = buildSample(stats, {
             clientEventTimeMs: now,
             sampleSeq,
             streamId: context.streamId,
@@ -58,18 +133,13 @@ export function subscribeToVideoQualityAnalytics(
             spaceName: context.spaceName,
             streamCategory: toStreamCategory(context.streamCategory),
             transportType: toTransportType(context.transportType),
-            relay: stats.relay,
-            relayProtocol: toRelayProtocol(stats.relayProtocol),
             livekitServerUrl: context.livekitServerUrl,
-            fps: stats.fps,
-            fpsStdDev: stats.fpsStdDev,
-            jitter: stats.jitter,
-            bandwidthBytesPerSecond: stats.bandwidth,
-            frameWidth: toUInt32(stats.frameWidth),
-            frameHeight: toUInt32(stats.frameHeight),
-            mimeType: stats.mimeType,
-        };
+        });
+        if (!sample) {
+            return;
+        }
 
+        lastSentAt = now;
         sampleSeq += 1;
 
         try {
@@ -88,6 +158,17 @@ function isValidStats(stats: WebRtcStats): boolean {
         Number.isFinite(stats.frameWidth) &&
         Number.isFinite(stats.frameHeight) &&
         (stats.fpsStdDev === undefined || Number.isFinite(stats.fpsStdDev))
+    );
+}
+
+function isValidSenderStats(stats: WebRtcSenderStats): boolean {
+    return (
+        Number.isFinite(stats.fps) &&
+        Number.isFinite(stats.bandwidth) &&
+        Number.isFinite(stats.frameWidth) &&
+        Number.isFinite(stats.frameHeight) &&
+        // A paused track encodes nothing: not worth a sample, unless the encoder is stalled by a limitation
+        (stats.fps > 0 || stats.qualityLimitationReason !== "none")
     );
 }
 
@@ -114,6 +195,19 @@ function toRelayProtocol(relayProtocol: WebRtcStats["relayProtocol"]): VideoQual
         return VideoQualityRelayProtocol.VIDEO_QUALITY_RELAY_PROTOCOL_TLS;
     }
     return undefined;
+}
+
+function toLimitationReason(reason: WebRtcSenderStats["qualityLimitationReason"]): VideoQualityLimitationReason {
+    switch (reason) {
+        case "cpu":
+            return VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_CPU;
+        case "bandwidth":
+            return VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_BANDWIDTH;
+        case "other":
+            return VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_OTHER;
+        default:
+            return VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_NONE;
+    }
 }
 
 function toUInt32(value: number): number {

--- a/play/src/front/WebRtc/WebRtcStatsFactory.ts
+++ b/play/src/front/WebRtc/WebRtcStatsFactory.ts
@@ -1,19 +1,23 @@
-import type { RemoteTrack } from "livekit-client";
-import { readable, type Readable } from "svelte/store";
-import type { WebRtcStats } from "../Components/Video/WebRtcStats";
+import type { LocalVideoTrack, RemoteTrack } from "livekit-client";
+import { derived, readable, type Readable } from "svelte/store";
+import type { WebRtcQualityLimitationReason, WebRtcSenderStats, WebRtcStats } from "../Components/Video/WebRtcStats";
 import type { RemotePeer } from "./RemotePeer";
 
-/**
- * Creates a readable store that provides WebRTC statistics for a peer connection.
- * Updates every second with current bandwidth, FPS, frame dimensions, jitter, and TURN routing info.
- *
- * @param remotePeer The RemotePeer instance to collect statistics from
- * @returns A Svelte readable store with WebRtcStats or undefined
- */
 const WEBRTC_STATS_DISPLAY_INTERVAL_MS = 1_000;
 
-export function createWebRtcStats(remotePeer: RemotePeer): Readable<WebRtcStats | undefined> {
-    return createWebRtcStatsFromReport(
+export type PeerWebRtcStats = {
+    // What we receive from the peer
+    receiver: Readable<WebRtcStats | undefined>;
+    // What we send to the peer (our own encoder)
+    sender: Readable<WebRtcSenderStats | undefined>;
+};
+
+/**
+ * Creates the WebRTC statistics stores of a P2P connection. Both stores are derived from a single getStats()
+ * poll (one call per second while at least one of them is subscribed).
+ */
+export function createPeerWebRtcStats(remotePeer: RemotePeer): PeerWebRtcStats {
+    const reportStore = createStatsReportStore(
         () => {
             const pc = remotePeer._pc as RTCPeerConnection;
             if (!pc) {
@@ -22,18 +26,22 @@ export function createWebRtcStats(remotePeer: RemotePeer): Readable<WebRtcStats 
             return pc.getStats(null);
         },
         {
+            isStopped: () => remotePeer.destroyed,
+            onError: (e) => console.error("getStats error for peer ", remotePeer.spaceUserId, e),
+        },
+    );
+    return {
+        receiver: createReceiverStatsStore(reportStore, {
             source: "P2P",
             getTrackId: () => remotePeer.remoteStream?.getVideoTracks()[0]?.id,
             includeRelayDetails: true,
-            isStopped: () => remotePeer.destroyed,
-            onError: (e) => console.error("getStats error for peer ", remotePeer.spaceUserId, e),
-            intervalMs: WEBRTC_STATS_DISPLAY_INTERVAL_MS,
-        },
-    );
+        }),
+        sender: createSenderStatsStore(reportStore, "P2P"),
+    };
 }
 
 export function createLivekitWebRtcStats(track: RemoteTrack | undefined): Readable<WebRtcStats | undefined> {
-    return createWebRtcStatsFromReport(
+    const reportStore = createStatsReportStore(
         () => {
             if (!track) {
                 return Promise.resolve(undefined);
@@ -41,42 +49,43 @@ export function createLivekitWebRtcStats(track: RemoteTrack | undefined): Readab
             return track.getRTCStatsReport();
         },
         {
-            source: "Livekit",
-            getTrackId: () => {
-                if (!track) {
-                    return undefined;
-                }
-                const trackWithMedia = track as unknown as { mediaStreamTrack?: MediaStreamTrack };
-                return trackWithMedia.mediaStreamTrack?.id;
-            },
-            includeRelayDetails: false,
             onError: (e) => console.error("getRTCStatsReport error for livekit track", e),
-            intervalMs: WEBRTC_STATS_DISPLAY_INTERVAL_MS,
         },
     );
+    return createReceiverStatsStore(reportStore, {
+        source: "Livekit",
+        getTrackId: () => {
+            if (!track) {
+                return undefined;
+            }
+            const trackWithMedia = track as unknown as { mediaStreamTrack?: MediaStreamTrack };
+            return trackWithMedia.mediaStreamTrack?.id;
+        },
+        includeRelayDetails: false,
+    });
 }
 
-type StatsFactoryOptions = {
-    source: string;
-    getTrackId?: () => string | undefined;
-    includeRelayDetails?: boolean;
+/**
+ * Statistics of a track we publish to LiveKit (the report only contains this track's sender).
+ */
+export function createLivekitSenderStats(track: LocalVideoTrack): Readable<WebRtcSenderStats | undefined> {
+    const reportStore = createStatsReportStore(() => track.getRTCStatsReport(), {
+        onError: (e) => console.error("getRTCStatsReport error for local livekit track", e),
+    });
+    return createSenderStatsStore(reportStore, "Livekit");
+}
+
+type StatsReportStoreOptions = {
     isStopped?: () => boolean;
     onError?: (error: unknown) => void;
     intervalMs?: number;
 };
 
-function createWebRtcStatsFromReport(
+function createStatsReportStore(
     getReport: () => Promise<RTCStatsReport | undefined>,
-    options: StatsFactoryOptions,
-): Readable<WebRtcStats | undefined> {
-    return readable<WebRtcStats | undefined>(undefined, (set) => {
-        let bytesReceivedPrev = 0;
-        let framesDecodedPrev = 0;
-        let timestampPrev = 0;
-        let lastFrameWidth: number | undefined;
-        let lastFrameHeight: number | undefined;
-        const fpsSamples: number[] = [];
-        let fpsStdDev: number | undefined;
+    options: StatsReportStoreOptions,
+): Readable<RTCStatsReport | undefined> {
+    return readable<RTCStatsReport | undefined>(undefined, (set) => {
         const interval = setInterval(() => {
             if (options.isStopped?.()) {
                 set(undefined);
@@ -84,57 +93,9 @@ function createWebRtcStatsFromReport(
                 return;
             }
             getReport()
-                .then((stats) => {
-                    if (!stats) {
-                        return;
-                    }
-                    const videoTrackId = options.getTrackId?.();
-                    const { receiverStats, bytesReceived, framesDecoded, timestamp } = buildWebRtcStatsFromReport(
-                        stats,
-                        videoTrackId,
-                        {
-                            bytesReceivedPrev,
-                            framesDecodedPrev,
-                            timestampPrev,
-                        },
-                        options,
-                    );
-                    if (timestamp) {
-                        bytesReceivedPrev = bytesReceived;
-                        framesDecodedPrev = framesDecoded;
-                        timestampPrev = timestamp;
-                    }
-                    if (receiverStats) {
-                        if (
-                            lastFrameWidth !== undefined &&
-                            lastFrameHeight !== undefined &&
-                            (receiverStats.frameWidth !== lastFrameWidth ||
-                                receiverStats.frameHeight !== lastFrameHeight)
-                        ) {
-                            fpsSamples.length = 0;
-                            fpsStdDev = undefined;
-                        }
-                        if (Number.isFinite(receiverStats.fps)) {
-                            fpsSamples.push(receiverStats.fps);
-                            if (fpsSamples.length > 8) {
-                                fpsSamples.shift();
-                            }
-                            if (fpsSamples.length === 8) {
-                                const mean = fpsSamples.reduce((sum, value) => sum + value, 0) / fpsSamples.length;
-                                const variance =
-                                    fpsSamples.reduce((sum, value) => sum + Math.pow(value - mean, 2), 0) /
-                                    (fpsSamples.length - 1);
-                                fpsStdDev = Math.sqrt(variance);
-                            } else {
-                                fpsStdDev = undefined;
-                            }
-                        } else {
-                            fpsStdDev = undefined;
-                        }
-                        receiverStats.fpsStdDev = fpsStdDev;
-                        lastFrameWidth = receiverStats.frameWidth;
-                        lastFrameHeight = receiverStats.frameHeight;
-                        set(receiverStats);
+                .then((report) => {
+                    if (report) {
+                        set(report);
                     }
                 })
                 .catch((e) => {
@@ -147,6 +108,102 @@ function createWebRtcStatsFromReport(
     });
 }
 
+type ReceiverStatsOptions = {
+    source: string;
+    getTrackId?: () => string | undefined;
+    includeRelayDetails?: boolean;
+};
+
+function createReceiverStatsStore(
+    reportStore: Readable<RTCStatsReport | undefined>,
+    options: ReceiverStatsOptions,
+): Readable<WebRtcStats | undefined> {
+    let bytesReceivedPrev = 0;
+    let framesDecodedPrev = 0;
+    let timestampPrev = 0;
+    let lastFrameWidth: number | undefined;
+    let lastFrameHeight: number | undefined;
+    const fpsSamples: number[] = [];
+    let fpsStdDev: number | undefined;
+
+    return derived<Readable<RTCStatsReport | undefined>, WebRtcStats | undefined>(
+        reportStore,
+        ($report, set) => {
+            if (!$report) {
+                set(undefined);
+                return;
+            }
+            const videoTrackId = options.getTrackId?.();
+            const { receiverStats, bytesReceived, framesDecoded, timestamp } = buildWebRtcStatsFromReport(
+                $report,
+                videoTrackId,
+                {
+                    bytesReceivedPrev,
+                    framesDecodedPrev,
+                    timestampPrev,
+                },
+                options,
+            );
+            if (timestamp) {
+                bytesReceivedPrev = bytesReceived;
+                framesDecodedPrev = framesDecoded;
+                timestampPrev = timestamp;
+            }
+            if (!receiverStats) {
+                return;
+            }
+            if (
+                lastFrameWidth !== undefined &&
+                lastFrameHeight !== undefined &&
+                (receiverStats.frameWidth !== lastFrameWidth || receiverStats.frameHeight !== lastFrameHeight)
+            ) {
+                fpsSamples.length = 0;
+                fpsStdDev = undefined;
+            }
+            if (Number.isFinite(receiverStats.fps)) {
+                fpsSamples.push(receiverStats.fps);
+                if (fpsSamples.length > 8) {
+                    fpsSamples.shift();
+                }
+                if (fpsSamples.length === 8) {
+                    const mean = fpsSamples.reduce((sum, value) => sum + value, 0) / fpsSamples.length;
+                    const variance =
+                        fpsSamples.reduce((sum, value) => sum + Math.pow(value - mean, 2), 0) / (fpsSamples.length - 1);
+                    fpsStdDev = Math.sqrt(variance);
+                } else {
+                    fpsStdDev = undefined;
+                }
+            } else {
+                fpsStdDev = undefined;
+            }
+            receiverStats.fpsStdDev = fpsStdDev;
+            lastFrameWidth = receiverStats.frameWidth;
+            lastFrameHeight = receiverStats.frameHeight;
+            set(receiverStats);
+        },
+        undefined,
+    );
+}
+
+function createSenderStatsStore(
+    reportStore: Readable<RTCStatsReport | undefined>,
+    source: string,
+): Readable<WebRtcSenderStats | undefined> {
+    const prev = new Map<string, SenderLayerPrev>();
+
+    return derived<Readable<RTCStatsReport | undefined>, WebRtcSenderStats | undefined>(
+        reportStore,
+        ($report, set) => {
+            if (!$report) {
+                set(undefined);
+                return;
+            }
+            set(buildWebRtcSenderStatsFromReport($report, prev, source));
+        },
+        undefined,
+    );
+}
+
 type StatsPrev = {
     bytesReceivedPrev: number;
     framesDecodedPrev: number;
@@ -157,7 +214,7 @@ function buildWebRtcStatsFromReport(
     stats: RTCStatsReport,
     videoTrackId: string | undefined,
     prev: StatsPrev,
-    options: StatsFactoryOptions,
+    options: ReceiverStatsOptions,
 ): {
     receiverStats: WebRtcStats | undefined;
     bytesReceived: number;
@@ -262,4 +319,92 @@ function buildWebRtcStatsFromReport(
         framesDecoded,
         timestamp,
     };
+}
+
+export type SenderLayerPrev = {
+    bytesSent: number;
+    framesEncoded: number;
+    timestamp: number;
+};
+
+/**
+ * Builds the sender-side statistics from a stats report containing our outbound video RTP stream(s).
+ * With simulcast or SVC there is one outbound-rtp entry per layer: the frame size, fps and limitation reason come
+ * from the largest layer, the bandwidth is the sum of all layers.
+ *
+ * Returns undefined when the report has no outbound video stream or when no previous sample allows computing rates.
+ * `prev` is updated in place with the counters of this report.
+ */
+export function buildWebRtcSenderStatsFromReport(
+    stats: RTCStatsReport,
+    prev: Map<string, SenderLayerPrev>,
+    source: string,
+): WebRtcSenderStats | undefined {
+    const layers: any[] = [];
+    const codecs = new Map<string, any>();
+    stats.forEach((v: any) => {
+        if (v.type === "outbound-rtp" && (v.kind === "video" || v.mediaType === "video")) {
+            layers.push(v);
+        } else if (v.type === "codec") {
+            codecs.set(v.id, v);
+        }
+    });
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    if (layers.length === 0) {
+        prev.clear();
+        return undefined;
+    }
+
+    const topLayer = layers.reduce((best, layer) =>
+        (layer.frameWidth ?? 0) * (layer.frameHeight ?? 0) > (best.frameWidth ?? 0) * (best.frameHeight ?? 0)
+            ? layer
+            : best,
+    );
+    const topPrev = prev.get(topLayer.id);
+    const timeDiffSeconds = topPrev ? (topLayer.timestamp - topPrev.timestamp) / 1000 : 0;
+
+    let bytesSentDelta = 0;
+    for (const layer of layers) {
+        const layerPrev = prev.get(layer.id);
+        if (layerPrev) {
+            bytesSentDelta += (layer.bytesSent ?? 0) - layerPrev.bytesSent;
+        }
+        prev.set(layer.id, {
+            bytesSent: layer.bytesSent ?? 0,
+            framesEncoded: layer.framesEncoded ?? 0,
+            timestamp: layer.timestamp ?? 0,
+        });
+    }
+    for (const id of Array.from(prev.keys())) {
+        if (!layers.some((layer) => layer.id === id)) {
+            prev.delete(id);
+        }
+    }
+
+    if (!topPrev || timeDiffSeconds <= 0) {
+        return undefined;
+    }
+
+    return {
+        source,
+        frameWidth: topLayer.frameWidth ?? 0,
+        frameHeight: topLayer.frameHeight ?? 0,
+        mimeType: codecs.get(topLayer.codecId)?.mimeType,
+        bandwidth: Math.max(0, bytesSentDelta) / timeDiffSeconds,
+        fps: Math.max(0, (topLayer.framesEncoded ?? 0) - topPrev.framesEncoded) / timeDiffSeconds,
+        qualityLimitationReason: toQualityLimitationReason(topLayer.qualityLimitationReason),
+        encoderImplementation:
+            typeof topLayer.encoderImplementation === "string" ? topLayer.encoderImplementation : undefined,
+    };
+}
+
+function toQualityLimitationReason(reason: unknown): WebRtcQualityLimitationReason {
+    switch (reason) {
+        case "cpu":
+        case "bandwidth":
+        case "other":
+            return reason;
+        default:
+            return "none";
+    }
 }

--- a/play/src/pusher/services/VideoQualityAnalyticsQueue.ts
+++ b/play/src/pusher/services/VideoQualityAnalyticsQueue.ts
@@ -1,7 +1,9 @@
 import axios, { isAxiosError } from "axios";
 import {
+    VideoQualityLimitationReason,
     VideoQualityRelayProtocol,
     VideoQualityStreamCategory,
+    VideoQualityStreamDirection,
     VideoQualityTransportType,
     type VideoQualityReportMessage,
     type VideoQualitySampleMessage,
@@ -23,6 +25,8 @@ const RETRY_JITTER_MAX_MS = 250;
 export type VideoQualityAnalyticsStreamCategory = "video" | "screenSharing";
 export type VideoQualityAnalyticsTransportType = "P2P" | "Livekit";
 export type VideoQualityAnalyticsRelayProtocol = "udp" | "tcp" | "tls";
+export type VideoQualityAnalyticsStreamDirection = "inbound" | "outbound";
+export type VideoQualityAnalyticsLimitationReason = "none" | "cpu" | "bandwidth" | "other";
 
 export type VideoQualityAnalyticsSample = {
     clientEventTime: string;
@@ -31,7 +35,8 @@ export type VideoQualityAnalyticsSample = {
     remoteUserUuid: string | null;
     reporterUserId: number | null;
     reporterSpaceUserId: string;
-    remoteSpaceUserId: string;
+    // Null for outbound streams sent to a LiveKit server (no single remote user)
+    remoteSpaceUserId: string | null;
     spaceName: string;
     world: string;
     roomId: string;
@@ -40,6 +45,7 @@ export type VideoQualityAnalyticsSample = {
     streamId: string;
     streamCategory: VideoQualityAnalyticsStreamCategory;
     transportType: VideoQualityAnalyticsTransportType;
+    direction: VideoQualityAnalyticsStreamDirection;
     relay: boolean | null;
     relayProtocol: VideoQualityAnalyticsRelayProtocol | null;
     livekitServerUrl: string | null;
@@ -50,6 +56,9 @@ export type VideoQualityAnalyticsSample = {
     frameWidth: number;
     frameHeight: number;
     mimeType: string | null;
+    // Outbound streams only
+    qualityLimitationReason: VideoQualityAnalyticsLimitationReason | null;
+    encoderImplementation: string | null;
     sampleSeq: number | null;
     connectionId: string | null;
     sessionId: string | null;
@@ -215,6 +224,7 @@ export class VideoQualityAnalyticsQueue {
         const streamCategory = toStreamCategory(sample.streamCategory);
         const transportType = toTransportType(sample.transportType);
         const relayProtocol = toRelayProtocol(sample.relayProtocol);
+        const direction = toDirection(sample.direction);
 
         if (streamCategory === undefined) {
             console.warn("Video quality analytics sample dropped", {
@@ -238,9 +248,12 @@ export class VideoQualityAnalyticsQueue {
             return undefined;
         }
 
+        // Outbound streams published to a LiveKit server have no single remote user.
+        const remoteSpaceUserId = isRequiredString(sample.remoteSpaceUserId) ? sample.remoteSpaceUserId : null;
+
         if (
             !isRequiredString(sample.streamId) ||
-            !isRequiredString(sample.remoteSpaceUserId) ||
+            (direction === "inbound" && remoteSpaceUserId === null) ||
             !isRequiredString(sample.spaceName)
         ) {
             console.warn("Video quality analytics sample dropped", {
@@ -326,7 +339,7 @@ export class VideoQualityAnalyticsQueue {
             remoteUserUuid: sample.remoteUserUuid ?? null,
             reporterUserId: socketData.userId ?? null,
             reporterSpaceUserId: socketData.spaceUserId,
-            remoteSpaceUserId: sample.remoteSpaceUserId,
+            remoteSpaceUserId,
             spaceName: fullSpaceName,
             world: socketData.world,
             roomId: socketData.roomId,
@@ -335,6 +348,7 @@ export class VideoQualityAnalyticsQueue {
             streamId: sample.streamId,
             streamCategory,
             transportType,
+            direction,
             relay: sample.relay ?? null,
             relayProtocol,
             livekitServerUrl: sample.livekitServerUrl ?? null,
@@ -345,6 +359,9 @@ export class VideoQualityAnalyticsQueue {
             frameWidth: Math.round(sample.frameWidth),
             frameHeight: Math.round(sample.frameHeight),
             mimeType: sample.mimeType ?? null,
+            qualityLimitationReason:
+                direction === "outbound" ? toLimitationReason(sample.qualityLimitationReason) : null,
+            encoderImplementation: direction === "outbound" ? (sample.encoderImplementation ?? null) : null,
             sampleSeq: sample.sampleSeq ?? null,
             connectionId: sample.connectionId ?? null,
             sessionId: sample.sessionId ?? null,
@@ -431,6 +448,27 @@ function toRelayProtocol(
         return "tls";
     }
     return null;
+}
+
+function toDirection(direction: VideoQualityStreamDirection | undefined): VideoQualityAnalyticsStreamDirection {
+    return direction === VideoQualityStreamDirection.VIDEO_QUALITY_STREAM_DIRECTION_OUTBOUND ? "outbound" : "inbound";
+}
+
+function toLimitationReason(
+    reason: VideoQualityLimitationReason | undefined,
+): VideoQualityAnalyticsLimitationReason | null {
+    switch (reason) {
+        case VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_NONE:
+            return "none";
+        case VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_CPU:
+            return "cpu";
+        case VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_BANDWIDTH:
+            return "bandwidth";
+        case VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_OTHER:
+            return "other";
+        default:
+            return null;
+    }
 }
 
 function isRequiredString(value: string | undefined): value is string {

--- a/play/tests/front/WebRtc/LocalEncoderStats.test.ts
+++ b/play/tests/front/WebRtc/LocalEncoderStats.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { get, writable } from "svelte/store";
+import type { WebRtcSenderStats } from "../../../src/front/Components/Video/WebRtcStats";
+import {
+    aggregateSenderStats,
+    describeEncoder,
+    localEncoderStatsStore,
+    registerLocalEncoderStats,
+} from "../../../src/front/WebRtc/LocalEncoderStats";
+
+function senderStats(overrides: Partial<WebRtcSenderStats> = {}): WebRtcSenderStats {
+    return {
+        source: "P2P",
+        frameWidth: 640,
+        frameHeight: 360,
+        mimeType: "video/VP9",
+        bandwidth: 100_000,
+        fps: 25,
+        qualityLimitationReason: "none",
+        encoderImplementation: "libvpx",
+        ...overrides,
+    };
+}
+
+describe("describeEncoder", () => {
+    it.each([
+        ["libaom", "software"],
+        ["SimulcastEncoderAdapter (libvpx, libvpx)", "software"],
+        ["OpenH264", "software"],
+        ["ExternalEncoder", "hardware"],
+        ["VideoToolbox", "hardware"],
+        ["SomethingNew", "unknown"],
+    ] as const)("classifies %s as %s", (implementation, type) => {
+        expect(describeEncoder(implementation)).toEqual({ name: implementation, type });
+    });
+
+    it("has no name without an implementation", () => {
+        expect(describeEncoder(undefined)).toEqual({ name: "-", type: "unknown" });
+    });
+});
+
+describe("aggregateSenderStats", () => {
+    it("is empty without any encoder", () => {
+        expect(aggregateSenderStats([])).toBeUndefined();
+        expect(aggregateSenderStats([undefined])).toBeUndefined();
+    });
+
+    it("keeps a single encoder as is", () => {
+        expect(aggregateSenderStats([senderStats()])).toEqual({ ...senderStats(), encoderCount: 1 });
+    });
+
+    it("reports the worst case over several encoders", () => {
+        const aggregate = aggregateSenderStats([
+            senderStats({ fps: 30, bandwidth: 100_000 }),
+            undefined,
+            senderStats({
+                fps: 12,
+                bandwidth: 50_000,
+                frameWidth: 1280,
+                frameHeight: 720,
+                qualityLimitationReason: "cpu",
+                mimeType: "video/AV1",
+                encoderImplementation: "libaom",
+            }),
+            senderStats({ fps: 20, bandwidth: 25_000, qualityLimitationReason: "bandwidth" }),
+        ]);
+        expect(aggregate).toEqual({
+            source: "P2P (3 encoders)",
+            frameWidth: 1280,
+            frameHeight: 720,
+            mimeType: "video/AV1",
+            bandwidth: 175_000,
+            fps: 12,
+            qualityLimitationReason: "cpu",
+            encoderImplementation: "libaom",
+            encoderCount: 3,
+        });
+    });
+});
+
+describe("localEncoderStatsStore", () => {
+    it("aggregates the registered encoders and forgets the removed ones", () => {
+        const first = writable<WebRtcSenderStats | undefined>(senderStats());
+        const second = writable<WebRtcSenderStats | undefined>(undefined);
+
+        expect(get(localEncoderStatsStore.video)).toBeUndefined();
+
+        const unregisterFirst = registerLocalEncoderStats("video", first);
+        const unregisterSecond = registerLocalEncoderStats("video", second);
+        expect(get(localEncoderStatsStore.video)?.encoderCount).toBe(1);
+        expect(get(localEncoderStatsStore.screenSharing)).toBeUndefined();
+
+        second.set(senderStats({ qualityLimitationReason: "cpu" }));
+        expect(get(localEncoderStatsStore.video)).toMatchObject({
+            encoderCount: 2,
+            qualityLimitationReason: "cpu",
+        });
+
+        unregisterSecond();
+        expect(get(localEncoderStatsStore.video)).toMatchObject({
+            encoderCount: 1,
+            qualityLimitationReason: "none",
+        });
+
+        unregisterFirst();
+        expect(get(localEncoderStatsStore.video)).toBeUndefined();
+    });
+});

--- a/play/tests/front/WebRtc/VideoQualityAnalytics.test.ts
+++ b/play/tests/front/WebRtc/VideoQualityAnalytics.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { writable } from "svelte/store";
-import { VideoQualityStreamCategory, VideoQualityTransportType } from "@workadventure/messages";
-import type { WebRtcStats } from "../../../src/front/Components/Video/WebRtcStats";
-import { subscribeToVideoQualityAnalytics } from "../../../src/front/WebRtc/VideoQualityAnalytics";
+import {
+    VideoQualityLimitationReason,
+    VideoQualityStreamCategory,
+    VideoQualityStreamDirection,
+    VideoQualityTransportType,
+} from "@workadventure/messages";
+import type { WebRtcSenderStats, WebRtcStats } from "../../../src/front/Components/Video/WebRtcStats";
+import {
+    subscribeToOutboundVideoQualityAnalytics,
+    subscribeToVideoQualityAnalytics,
+} from "../../../src/front/WebRtc/VideoQualityAnalytics";
 
 const stats: WebRtcStats = {
     source: "P2P",
@@ -47,8 +55,69 @@ describe("subscribeToVideoQualityAnalytics", () => {
                     transportType: VideoQualityTransportType.VIDEO_QUALITY_TRANSPORT_TYPE_P2P,
                     remoteSpaceUserId: "remote-space-user",
                     spaceName: "world.space",
+                    direction: VideoQualityStreamDirection.VIDEO_QUALITY_STREAM_DIRECTION_INBOUND,
                 }),
             ],
         });
+    });
+});
+
+describe("subscribeToOutboundVideoQualityAnalytics", () => {
+    const senderStats: WebRtcSenderStats = {
+        source: "Livekit",
+        frameWidth: 1920,
+        frameHeight: 1080,
+        bandwidth: 300000,
+        fps: 28,
+        mimeType: "video/AV1",
+        qualityLimitationReason: "cpu",
+        encoderImplementation: "libaom",
+    };
+
+    it("emits outbound samples carrying the encoder health", () => {
+        window.capabilities = {
+            "api/analytics/video-quality-batch": "v1",
+        };
+        const sendReport = vi.fn();
+
+        subscribeToOutboundVideoQualityAnalytics(
+            writable(senderStats),
+            { ...context, transportType: "Livekit", remoteSpaceUserId: "", livekitServerUrl: "wss://livekit.test" },
+            sendReport,
+        );
+
+        expect(sendReport).toHaveBeenCalledWith({
+            samples: [
+                expect.objectContaining({
+                    direction: VideoQualityStreamDirection.VIDEO_QUALITY_STREAM_DIRECTION_OUTBOUND,
+                    transportType: VideoQualityTransportType.VIDEO_QUALITY_TRANSPORT_TYPE_LIVEKIT,
+                    remoteSpaceUserId: "",
+                    livekitServerUrl: "wss://livekit.test",
+                    fps: 28,
+                    jitter: 0,
+                    bandwidthBytesPerSecond: 300000,
+                    frameWidth: 1920,
+                    frameHeight: 1080,
+                    mimeType: "video/AV1",
+                    qualityLimitationReason: VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_CPU,
+                    encoderImplementation: "libaom",
+                }),
+            ],
+        });
+    });
+
+    it("skips samples of a paused encoder", () => {
+        window.capabilities = {
+            "api/analytics/video-quality-batch": "v1",
+        };
+        const sendReport = vi.fn();
+
+        subscribeToOutboundVideoQualityAnalytics(
+            writable({ ...senderStats, fps: 0, bandwidth: 0, qualityLimitationReason: "none" }),
+            context,
+            sendReport,
+        );
+
+        expect(sendReport).not.toHaveBeenCalled();
     });
 });

--- a/play/tests/front/WebRtc/WebRtcStatsFactory.test.ts
+++ b/play/tests/front/WebRtc/WebRtcStatsFactory.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { buildWebRtcSenderStatsFromReport, type SenderLayerPrev } from "../../../src/front/WebRtc/WebRtcStatsFactory";
+
+function report(entries: Record<string, unknown>[]): RTCStatsReport {
+    // RTCStatsReport is a ReadonlyMap<string, any>: a plain Map is one.
+    return new Map(entries.map((entry) => [String(entry.id), entry]));
+}
+
+function layer(id: string, overrides: Record<string, unknown>): Record<string, unknown> {
+    return {
+        id,
+        type: "outbound-rtp",
+        kind: "video",
+        codecId: "codec-av1",
+        qualityLimitationReason: "none",
+        encoderImplementation: "libaom",
+        ...overrides,
+    };
+}
+
+const codec = { id: "codec-av1", type: "codec", mimeType: "video/AV1" };
+
+describe("buildWebRtcSenderStatsFromReport", () => {
+    it("returns nothing when the report has no outbound video stream", () => {
+        const prev = new Map<string, SenderLayerPrev>();
+        expect(buildWebRtcSenderStatsFromReport(report([codec]), prev, "P2P")).toBeUndefined();
+    });
+
+    it("needs two reports to compute rates, then sums the layers and reads the largest one", () => {
+        const prev = new Map<string, SenderLayerPrev>();
+
+        const first = buildWebRtcSenderStatsFromReport(
+            report([
+                codec,
+                layer("low", {
+                    timestamp: 1000,
+                    bytesSent: 1000,
+                    framesEncoded: 10,
+                    frameWidth: 640,
+                    frameHeight: 360,
+                }),
+                layer("high", {
+                    timestamp: 1000,
+                    bytesSent: 5000,
+                    framesEncoded: 20,
+                    frameWidth: 1920,
+                    frameHeight: 1080,
+                }),
+            ]),
+            prev,
+            "P2P",
+        );
+        expect(first).toBeUndefined();
+
+        const second = buildWebRtcSenderStatsFromReport(
+            report([
+                codec,
+                layer("low", {
+                    timestamp: 3000,
+                    bytesSent: 3000,
+                    framesEncoded: 40,
+                    frameWidth: 640,
+                    frameHeight: 360,
+                }),
+                layer("high", {
+                    timestamp: 3000,
+                    bytesSent: 25000,
+                    framesEncoded: 50,
+                    frameWidth: 1920,
+                    frameHeight: 1080,
+                    qualityLimitationReason: "cpu",
+                }),
+            ]),
+            prev,
+            "P2P",
+        );
+        expect(second).toEqual({
+            source: "P2P",
+            frameWidth: 1920,
+            frameHeight: 1080,
+            mimeType: "video/AV1",
+            // (2000 + 20000) bytes over 2 seconds
+            bandwidth: 11000,
+            // 30 frames of the largest layer over 2 seconds
+            fps: 15,
+            qualityLimitationReason: "cpu",
+            encoderImplementation: "libaom",
+        });
+    });
+
+    it("maps unknown limitation reasons to none and forgets removed layers", () => {
+        const prev = new Map<string, SenderLayerPrev>();
+        buildWebRtcSenderStatsFromReport(
+            report([layer("a", { timestamp: 1000, bytesSent: 0, framesEncoded: 0 })]),
+            prev,
+            "Livekit",
+        );
+        const stats = buildWebRtcSenderStatsFromReport(
+            report([layer("a", { timestamp: 2000, bytesSent: 500, framesEncoded: 5, qualityLimitationReason: "??" })]),
+            prev,
+            "Livekit",
+        );
+        expect(stats?.qualityLimitationReason).toBe("none");
+
+        expect(buildWebRtcSenderStatsFromReport(report([]), prev, "Livekit")).toBeUndefined();
+        expect(prev.size).toBe(0);
+    });
+});

--- a/play/tests/pusher/VideoQualityAnalyticsQueue.test.ts
+++ b/play/tests/pusher/VideoQualityAnalyticsQueue.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+    VideoQualityLimitationReason,
     VideoQualityRelayProtocol,
     VideoQualityStreamCategory,
+    VideoQualityStreamDirection,
     VideoQualityTransportType,
     type VideoQualitySampleMessage,
 } from "@workadventure/messages";
@@ -75,6 +77,7 @@ describe("VideoQualityAnalyticsQueue", () => {
                         streamId: "stream-id",
                         streamCategory: "video",
                         transportType: "P2P",
+                        direction: "inbound",
                         relay: true,
                         relayProtocol: "udp",
                         livekitServerUrl: null,
@@ -85,6 +88,8 @@ describe("VideoQualityAnalyticsQueue", () => {
                         frameWidth: 1280,
                         frameHeight: 720,
                         mimeType: "video/VP8",
+                        qualityLimitationReason: null,
+                        encoderImplementation: null,
                         sampleSeq: 1,
                         connectionId: "connection-id",
                         sessionId: "session-id",
@@ -97,13 +102,65 @@ describe("VideoQualityAnalyticsQueue", () => {
                     "Content-Type": "application/json",
                 },
                 timeout: 500,
-            }
+            },
         );
         expect(queue.getStats()).toMatchObject({
             queueSize: 0,
             batchesSent: 1,
             samplesSent: 1,
         });
+    });
+
+    it("relays outbound (encoder) samples, with or without a remote user", async () => {
+        const post = vi.fn().mockResolvedValue(undefined);
+        const queue = new VideoQualityAnalyticsQueue(baseConfig, post);
+        queue.setEnabled(true);
+
+        queue.enqueueReport(
+            {
+                samples: [
+                    sample({
+                        direction: VideoQualityStreamDirection.VIDEO_QUALITY_STREAM_DIRECTION_OUTBOUND,
+                        transportType: VideoQualityTransportType.VIDEO_QUALITY_TRANSPORT_TYPE_LIVEKIT,
+                        remoteSpaceUserId: "",
+                        remoteUserUuid: undefined,
+                        livekitServerUrl: "wss://livekit.test",
+                        jitter: 0,
+                        qualityLimitationReason: VideoQualityLimitationReason.VIDEO_QUALITY_LIMITATION_REASON_CPU,
+                        encoderImplementation: "libaom",
+                    }),
+                ],
+            },
+            socketData(),
+        );
+        await queue.flush();
+
+        const batch = post.mock.calls[0][1] as VideoQualityAnalyticsBatch;
+        expect(batch.samples).toHaveLength(1);
+        expect(batch.samples[0]).toMatchObject({
+            direction: "outbound",
+            transportType: "Livekit",
+            remoteSpaceUserId: null,
+            remoteUserUuid: null,
+            livekitServerUrl: "wss://livekit.test",
+            qualityLimitationReason: "cpu",
+            encoderImplementation: "libaom",
+        });
+    });
+
+    it("keeps requiring a remote user for inbound samples", async () => {
+        const post = vi.fn().mockResolvedValue(undefined);
+        const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const queue = new VideoQualityAnalyticsQueue(baseConfig, post);
+        queue.setEnabled(true);
+
+        queue.enqueueReport({ samples: [sample({ remoteSpaceUserId: "" })] }, socketData());
+        await queue.flush();
+
+        expect(post).not.toHaveBeenCalled();
+        expect(queue.getStats()).toMatchObject({ droppedInvalid: 1, queueSize: 0 });
+
+        consoleWarn.mockRestore();
     });
 
     it("drops the oldest samples when the queue is full", async () => {
@@ -137,11 +194,11 @@ describe("VideoQualityAnalyticsQueue", () => {
                         spaceName: "other",
                     }),
                     sample({
-                        streamCategory: VideoQualityStreamCategory.VIDEO_QUALITY_STREAM_CATEGORY_UNSPECIFIED,
+                        streamCategory: VideoQualityStreamCategory.UNRECOGNIZED,
                     }),
                 ],
             },
-            socketData()
+            socketData(),
         );
         await queue.flush();
 
@@ -240,6 +297,7 @@ function sample(overrides: Partial<VideoQualitySampleMessage> = {}): VideoQualit
         spaceName: "space",
         streamCategory: VideoQualityStreamCategory.VIDEO_QUALITY_STREAM_CATEGORY_VIDEO,
         transportType: VideoQualityTransportType.VIDEO_QUALITY_TRANSPORT_TYPE_P2P,
+        direction: VideoQualityStreamDirection.VIDEO_QUALITY_STREAM_DIRECTION_INBOUND,
         relay: true,
         relayProtocol: VideoQualityRelayProtocol.VIDEO_QUALITY_RELAY_PROTOCOL_UDP,
         livekitServerUrl: undefined,


### PR DESCRIPTION
This is a backport of #6505 

(qualityLimitationReason, encoderImplementation) in video quality analytics (#6505)

* feat(analytics): report encoder health of the video streams we send

Video quality samples only described what a user receives (fps, jitter, bandwidth per remote stream). When a user's own camera or screen share degrades because the machine cannot keep up, nothing was reported: the symptom shows up on the other participants as "No video stream received" with no way to tell a slow laptop from a bad network.

Browsers expose exactly this on the sender side:
RTCOutboundRtpStreamStats.qualityLimitationReason ("cpu", "bandwidth", "other", "none") and encoderImplementation ("libaom", "libvpx", "ExternalEncoder"...). This adds "outbound" samples carrying both, for:

- every P2P connection (each RTCPeerConnection has its own encoder), read from the same getStats() poll as the receiver stats so the call rate does not change;
- the camera and screen share tracks published to LiveKit, read from the local track's sender.

The sample message gets a direction (unspecified = inbound for older clients), the limitation reason and the encoder implementation. The pusher relays them as-is; a stream published to LiveKit has no single remote user, so remoteSpaceUserId is only required for inbound samples. Paused tracks (camera off) encode nothing and produce no sample.



* feat(video): show our own encoder health in the local feedback tiles

The "Display video quality statistics" setting showed a stats box on the streams we receive only. The camera and screen share feedback tiles now get the same box for what we send: encoder name with a software/hardware label, the browser's limitation reason (red when CPU limited, yellow when bandwidth limited), encoded fps, bitrate, resolution and codec.

Every active sender registers its stats store in LocalEncoderStats: one per LiveKit published track, one per P2P connection since Chrome runs one encoder per RTCPeerConnection. Each tile shows the worst case over its encoders (most severe reason, summed bandwidth, lowest fps, largest resolution) and how many encoders were aggregated.



* test(livekit): give the LiveKitRoom test the space methods the encoder analytics need

After a successful publication, LiveKitRoom now subscribes the encoder analytics, which read the space name and the admin capabilities. The space stub of the unit test had neither.



* refactor(analytics): drop the unspecified video quality stream direction

Clients that predate the outbound samples cannot talk to the new pusher: every client is disconnected when the protocol changes on upgrade. Inbound is simply the zero value of the enum.



* refactor(analytics): drop the unspecified video quality limitation reason

The field is optional: absence is expressed by leaving it unset, and "none" is a real value reported by the browser. The zero value is now NONE.



* refactor(analytics): drop the unspecified values of the video quality enums

Stream category, transport type and relay protocol carried an UNSPECIFIED zero value that nothing produced. Every client is disconnected when the protocol changes on upgrade, so there is no legacy sender to account for: the first real value is the zero value. The pusher test that checks invalid samples are dropped now uses the generated UNRECOGNIZED value.



---------