### PR TITLE
fix(map-editor): stop the Jitsi advanced options from crashing on render

### DIFF
--- a/play/src/front/Components/Input/RangeSlider.svelte
+++ b/play/src/front/Components/Input/RangeSlider.svelte
@@ -25,7 +25,7 @@
         label = undefined,
         placeholder = "",
         min = 0,
-        value = $bindable<number>(),
+        value = $bindable(min),
         max = 100,
         step = 0,
         onchange = () => {},
@@ -37,20 +37,11 @@
         children,
     }: Props = $props();
 
-    // Unset bound property: render from `min`, the effect below runs too late for the first render.
-    let displayValue = $derived(value ?? min);
-
-    $effect(() => {
-        if (value === undefined) {
-            value = min;
-        }
-    });
-
     let uniqueId = (() => id || `input-${Math.random().toString(36).substring(2, 9)} `)();
 </script>
 
 {#if label}
-    <label for={uniqueId} class="px-3"> {label} {@render children?.()}: {valueFormatter(displayValue)} {unit}</label>
+    <label for={uniqueId} class="px-3"> {label} {@render children?.()}: {valueFormatter(value)} {unit}</label>
 {/if}
 
 <div class={wrapperMargins ? "mx-2.5" : "w-full"}>
@@ -61,7 +52,7 @@
         class:input-range-square={buttonShape === "square"}
     >
         <!-- remove the -10px so that the slider does not extend out of the bar -->
-        <div class="input-range-slider" style="width: calc({((displayValue - min) / (max - min)) * 100}% - 10px);">
+        <div class="input-range-slider" style="width: calc({((value - min) / (max - min)) * 100}% - 10px);">
             <div class="input-range-btn group/range -end-5">
                 {#if buttonShape === "square"}
                     <svg

--- a/play/src/front/Components/Input/RangeSlider.svelte
+++ b/play/src/front/Components/Input/RangeSlider.svelte
@@ -37,6 +37,9 @@
         children,
     }: Props = $props();
 
+    // Unset bound property: render from `min`, the effect below runs too late for the first render.
+    let displayValue = $derived(value ?? min);
+
     $effect(() => {
         if (value === undefined) {
             value = min;
@@ -47,7 +50,7 @@
 </script>
 
 {#if label}
-    <label for={uniqueId} class="px-3"> {label} {@render children?.()}: {valueFormatter(value)} {unit}</label>
+    <label for={uniqueId} class="px-3"> {label} {@render children?.()}: {valueFormatter(displayValue)} {unit}</label>
 {/if}
 
 <div class={wrapperMargins ? "mx-2.5" : "w-full"}>
@@ -58,7 +61,7 @@
         class:input-range-square={buttonShape === "square"}
     >
         <!-- remove the -10px so that the slider does not extend out of the bar -->
-        <div class="input-range-slider" style="width: calc({((value - min) / (max - min)) * 100}% - 10px);">
+        <div class="input-range-slider" style="width: calc({((displayValue - min) / (max - min)) * 100}% - 10px);">
             <div class="input-range-btn group/range -end-5">
                 {#if buttonShape === "square"}
                     <svg

--- a/play/src/front/Components/Input/RangeSlider.svelte
+++ b/play/src/front/Components/Input/RangeSlider.svelte
@@ -25,7 +25,7 @@
         label = undefined,
         placeholder = "",
         min = 0,
-        value = $bindable(min),
+        value = $bindable<number>(),
         max = 100,
         step = 0,
         onchange = () => {},
@@ -37,11 +37,21 @@
         children,
     }: Props = $props();
 
+    // A bound property can be unset (an area saved without a width): render from `min` instead of
+    // giving `value` a $props fallback, which makes Svelte reject `bind:value={undefined}`.
+    let displayValue = $derived(value ?? min);
+
+    $effect(() => {
+        if (value === undefined) {
+            value = min;
+        }
+    });
+
     let uniqueId = (() => id || `input-${Math.random().toString(36).substring(2, 9)} `)();
 </script>
 
 {#if label}
-    <label for={uniqueId} class="px-3"> {label} {@render children?.()}: {valueFormatter(value)} {unit}</label>
+    <label for={uniqueId} class="px-3"> {label} {@render children?.()}: {valueFormatter(displayValue)} {unit}</label>
 {/if}
 
 <div class={wrapperMargins ? "mx-2.5" : "w-full"}>
@@ -52,7 +62,7 @@
         class:input-range-square={buttonShape === "square"}
     >
         <!-- remove the -10px so that the slider does not extend out of the bar -->
-        <div class="input-range-slider" style="width: calc({((value - min) / (max - min)) * 100}% - 10px);">
+        <div class="input-range-slider" style="width: calc({((displayValue - min) / (max - min)) * 100}% - 10px);">
             <div class="input-range-btn group/range -end-5">
                 {#if buttonShape === "square"}
                     <svg

--- a/play/src/front/Components/MapEditor/AreaEditor/AreaPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/AreaEditor/AreaPropertiesEditor.svelte
@@ -182,6 +182,7 @@
                     jitsiRoomConfig: {},
                     hideButtonLabel: true,
                     roomName: $LL.mapEditor.properties.jitsiRoomProperty.label(),
+                    width: 50,
                     trigger: ON_ACTION_TRIGGER_ENTER,
                 };
             }

--- a/play/src/front/Components/MapEditor/PropertyEditor/JitsiRoomPropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/JitsiRoomPropertyEditor.svelte
@@ -36,6 +36,9 @@
     }: Props = $props();
     let optionAdvancedActivated = $state(false);
 
+    // Same default as the one applied when opening the Jitsi cowebsite (see GameMapPropertiesListener).
+    property.width ??= 50;
+
     function onTriggerValueChange() {
         triggerOnActionChoosen = property.trigger === ON_ACTION_TRIGGER_BUTTON;
         onchange?.();

--- a/play/tests/front/Components/BoundRangeSlider.svelte
+++ b/play/tests/front/Components/BoundRangeSlider.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+    import RangeSlider from "../../../src/front/Components/Input/RangeSlider.svelte";
+
+    // A parent binding a property that is not set yet, e.g. an area saved without a width.
+    let value: number | undefined = $state(undefined);
+</script>
+
+<RangeSlider label="Width" min={15} max={85} bind:value />

--- a/play/tests/front/Components/RangeSlider.test.ts
+++ b/play/tests/front/Components/RangeSlider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { mount, unmount } from "svelte";
 import RangeSlider from "../../../src/front/Components/Input/RangeSlider.svelte";
+import BoundRangeSlider from "./BoundRangeSlider.svelte";
 
 describe("RangeSlider", () => {
     // Regression: an unset optional property (e.g. the Jitsi area width) used to throw on the first
@@ -8,6 +9,15 @@ describe("RangeSlider", () => {
     it("renders with an undefined value", async () => {
         const target = document.createElement("div");
         const component = mount(RangeSlider, { target, props: { label: "Width", min: 15, max: 85 } });
+        expect(target.textContent).toContain("15");
+        await unmount(component);
+    });
+
+    // Regression: giving `value` a $props fallback makes Svelte reject `bind:value={undefined}`
+    // with props_invalid_value, which crashes the parent panel.
+    it("renders when a parent binds an unset value", async () => {
+        const target = document.createElement("div");
+        const component = mount(BoundRangeSlider, { target });
         expect(target.textContent).toContain("15");
         await unmount(component);
     });

--- a/play/tests/front/Components/RangeSlider.test.ts
+++ b/play/tests/front/Components/RangeSlider.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { mount, unmount } from "svelte";
+import RangeSlider from "../../../src/front/Components/Input/RangeSlider.svelte";
+
+describe("RangeSlider", () => {
+    // Regression: an unset optional property (e.g. the Jitsi area width) used to throw on the first
+    // render, which broke the whole panel embedding the slider.
+    it("renders with an undefined value", async () => {
+        const target = document.createElement("div");
+        const component = mount(RangeSlider, { target, props: { label: "Width", min: 15, max: 85 } });
+        expect(target.textContent).toContain("15");
+        await unmount(component);
+    });
+});


### PR DESCRIPTION
## Problem

In the map editor, toggling **Advanced options** on a Jitsi area property does nothing: the switch flips but the panel never appears.

It is not the switch — rendering the block throws:

```
TypeError: Cannot read properties of undefined (reading 'toString')
    at valueFormatter (RangeSlider.svelte:35)
```

The Jitsi area property is the only one created without a `width` (`openWebsite` and `openFile` both set `width: 50`), and `RangeSlider` formats its bound value in the label during the **first** render, before the `$effect` that falls back to `min` has run.

## Regression window

Introduced by the Svelte 5 migration (#6157, 2026-06-08, released in v1.32.0). Before it, `export let value = min` applied the default whenever the prop was `undefined`; `$bindable<number>()` plus an `$effect` fallback does not.

## Fix

- `RangeSlider`: render from `value ?? min`, so an unset bound property no longer breaks the panel embedding the slider — this covers every caller, not just Jitsi.
- `JitsiRoomPropertyEditor`: default `width` to `50`, the value already applied when the Jitsi cowebsite is opened (`GameMapPropertiesListener`), instead of showing the slider minimum (15%).

## Test

`play/tests/front/Components/RangeSlider.test.ts` mounts the slider with an undefined value. It fails with the exact `TypeError` on the previous code and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)