### PR TITLE
fix(chat): never announce a proximity bubble with an empty user list

### DIFF
--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -10,6 +10,7 @@ import { AvailabilityStatus, FilterType } from "@workadventure/messages";
 import { asError } from "catch-unknown";
 import { eventToAbortReason } from "@workadventure/shared-utils/src/Abort/raceAbort";
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
+import { Deferred } from "@workadventure/shared-utils";
 import { abortAny } from "@workadventure/shared-utils/src/Abort/AbortAny";
 import { type WAMSettings, WAMSettingsUtils } from "@workadventure/map-editor";
 import type {
@@ -1102,10 +1103,6 @@ export class ProximityChatRoom implements ChatRoom {
             }
             await this.throwIfAborted(joinSignal, spaceForThisJoin);
 
-            const playersInSpace = this.mapSpaceUsersToRemotePlayers(users);
-            if (this.isDefaultProximityRoom()) {
-                iframeListener.sendJoinProximityMeetingEvent(playersInSpace);
-            }
             faviconManager.pushNotificationFavicon();
 
             // Note: by design, if someone comes talk to us, there should be only one new user in the space.
@@ -1156,10 +1153,29 @@ export class ProximityChatRoom implements ChatRoom {
         });
         await this.throwIfAborted(joinSignal, spaceForThisJoin);
 
-        // Now that we have the complete user list we can listen to incoming and outgoing users
+        // Now that we have the complete user list we can listen to incoming and outgoing users.
+        // The initial join events (sent below) may still be waiting for the zone data of the users already in the
+        // space, so late joiners are held back until those events are out: a user is announced exactly once, either
+        // in the initial list or as a participant joining afterwards.
+        const initialJoinEvents = new Deferred<void>();
+        initialJoinEvents.promise.catch(() => {});
+        const announcedUserIds = new Set<number>();
+        let joinEventsSent = false;
         this.observeUserJoinedSubscription = this._space.observeUserJoined.subscribe((spaceUser) => {
-            const player = this.getRemotePlayerFromSpaceUserId(spaceUser.spaceUserId);
-            if (player) {
+            (async () => {
+                const player = await this.waitForRemotePlayer(spaceUser.spaceUserId);
+                await initialJoinEvents.promise;
+                if (!player || announcedUserIds.has(player.userId)) {
+                    return;
+                }
+                announcedUserIds.add(player.userId);
+                if (!joinEventsSent) {
+                    // Nobody was known when we joined (getFirstUsers backstop, or zone data that never came):
+                    // this first peer IS the meeting we joined, not a participant joining an existing one.
+                    joinEventsSent = true;
+                    this.sendJoinEvents(spaceName, [player]);
+                    return;
+                }
                 iframeListener.sendParticipantJoinMeetingEvent(spaceName, player);
                 if (this.isDefaultProximityRoom()) {
                     iframeListener.sendParticipantJoinProximityMeetingEvent(player);
@@ -1174,7 +1190,11 @@ export class ProximityChatRoom implements ChatRoom {
                 if (this.users && this.users.size <= MAX_PARTICIPANTS_FOR_SOUND_NOTIFICATIONS) {
                     this.soundManager.playMeetingInSound();
                 }
-            }
+            })().catch((e) => {
+                if (!(e instanceof AbortError)) {
+                    console.error("Error while announcing a user joining the proximity space", e);
+                }
+            });
         });
 
         this.observeUserLeftSubscription = this._space.observeUserLeft.subscribe((spaceUser) => {
@@ -1197,13 +1217,38 @@ export class ProximityChatRoom implements ChatRoom {
             }
             this.removeTypingUserbyID(spaceUser.spaceUserId);
         });
-        await this.throwIfAborted(joinSignal, spaceForThisJoin);
+        try {
+            await this.throwIfAborted(joinSignal, spaceForThisJoin);
 
-        const playersInMeeting = this.mapSpaceUsersToRemotePlayers(Array.from((this.users ?? new Map()).values()));
-        iframeListener.sendJoinMeetingEvent(spaceName, get(this.name), get(this.kind), playersInMeeting);
+            const playersInMeeting = await this.mapSpaceUsersToRemotePlayers(
+                Array.from((this.users ?? new Map()).values()),
+            );
+            await this.throwIfAborted(joinSignal, spaceForThisJoin);
+
+            // A bubble with nobody known yet is not announced: the first peer to show up will trigger the join
+            // events (see observeUserJoinedSubscription above). Being alone in a meeting room is legitimate though.
+            if (isMeetingRoomChat || playersInMeeting.length > 0) {
+                joinEventsSent = true;
+                for (const player of playersInMeeting) {
+                    announcedUserIds.add(player.userId);
+                }
+                this.sendJoinEvents(spaceName, playersInMeeting);
+            }
+            initialJoinEvents.resolve();
+        } catch (e) {
+            initialJoinEvents.reject(asError(e));
+            throw e;
+        }
 
         this.joinSpaceAbortController = undefined;
         return this._space;
+    }
+
+    private sendJoinEvents(spaceName: string, players: MessageUserJoined[]): void {
+        if (this.isDefaultProximityRoom()) {
+            iframeListener.sendJoinProximityMeetingEvent(players);
+        }
+        iframeListener.sendJoinMeetingEvent(spaceName, get(this.name), get(this.kind), players);
     }
 
     /**
@@ -1339,17 +1384,30 @@ export class ProximityChatRoom implements ChatRoom {
         return this.remotePlayersRepository.getPlayers().get(userId);
     }
 
-    private mapSpaceUsersToRemotePlayers(spaceUsers: SpaceUserExtended[]): MessageUserJoined[] {
-        const playersInSpace: MessageUserJoined[] = [];
-
-        for (const spaceUser of spaceUsers.values()) {
-            const player = this.getRemotePlayerFromSpaceUserId(spaceUser.spaceUserId);
-            if (player) {
-                playersInSpace.push(player);
-            }
+    /**
+     * Resolves the remote player data of a space user. A user can be registered in the space before their
+     * userJoinedMessage reaches us through the zone system (typically someone spawning right next to us), so we
+     * wait for it rather than dropping the user. Resolves to undefined for ourselves and for users whose data
+     * never arrives.
+     */
+    private async waitForRemotePlayer(spaceUserId: string): Promise<MessageUserJoined | undefined> {
+        if (spaceUserId === this._spaceUserId) {
+            return undefined;
         }
+        const { userId } = this.extractUserIdAndRoomUrlFromSpaceId(spaceUserId);
+        try {
+            return await this.remotePlayersRepository.getPlayer(userId);
+        } catch (e) {
+            console.warn(`User ${spaceUserId} is in the proximity space but never showed up in the players list`, e);
+            return undefined;
+        }
+    }
 
-        return playersInSpace;
+    private async mapSpaceUsersToRemotePlayers(spaceUsers: SpaceUserExtended[]): Promise<MessageUserJoined[]> {
+        const players = await Promise.all(
+            spaceUsers.map((spaceUser) => this.waitForRemotePlayer(spaceUser.spaceUserId)),
+        );
+        return players.filter((player): player is MessageUserJoined => player !== undefined);
     }
 
     private extractUserIdAndRoomUrlFromSpaceId(spaceId: string): { roomUrl: string; userId: number } {

--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -1165,6 +1165,10 @@ export class ProximityChatRoom implements ChatRoom {
             (async () => {
                 const player = await this.waitForRemotePlayer(spaceUser.spaceUserId);
                 await initialJoinEvents.promise;
+                // The wait may outlive the meeting (we left, or joined another space) or the user (already gone).
+                if (this._space !== spaceForThisJoin || !this.users?.has(spaceUser.spaceUserId)) {
+                    return;
+                }
                 if (!player || announcedUserIds.has(player.userId)) {
                     return;
                 }
@@ -1199,7 +1203,9 @@ export class ProximityChatRoom implements ChatRoom {
 
         this.observeUserLeftSubscription = this._space.observeUserLeft.subscribe((spaceUser) => {
             const player = this.getRemotePlayerFromSpaceUserId(spaceUser.spaceUserId);
-            if (player) {
+            // Only announce the departure of users we did announce (one still waiting for zone data is unknown to
+            // scripts), and forget them so they are announced again if they come back.
+            if (player && announcedUserIds.delete(player.userId)) {
                 iframeListener.sendParticipantLeaveMeetingEvent(spaceName, player);
                 if (this.isDefaultProximityRoom()) {
                     iframeListener.sendParticipantLeaveProximityMeetingEvent(player);
@@ -1405,7 +1411,11 @@ export class ProximityChatRoom implements ChatRoom {
 
     private async mapSpaceUsersToRemotePlayers(spaceUsers: SpaceUserExtended[]): Promise<MessageUserJoined[]> {
         const players = await Promise.all(
-            spaceUsers.map((spaceUser) => this.waitForRemotePlayer(spaceUser.spaceUserId)),
+            spaceUsers.map(async (spaceUser) => {
+                const player = await this.waitForRemotePlayer(spaceUser.spaceUserId);
+                // The user may have left the space while we were waiting for their zone data.
+                return this.users?.has(spaceUser.spaceUserId) ? player : undefined;
+            }),
         );
         return players.filter((player): player is MessageUserJoined => player !== undefined);
     }

--- a/play/src/front/Chat/Connection/Proximity/tests/ProximityChatRoomJoinEvents.test.ts
+++ b/play/src/front/Chat/Connection/Proximity/tests/ProximityChatRoomJoinEvents.test.ts
@@ -97,6 +97,7 @@ function player(userId: number): MessageUserJoined {
 
 function createFakeSpace(users: Map<string, SpaceUserExtended>) {
     const observeUserJoined = new Subject<SpaceUserExtended>();
+    const observeUserLeft = new Subject<SpaceUserExtended>();
     const space = {
         getName: () => "bubble",
         destroyed: false,
@@ -105,10 +106,10 @@ function createFakeSpace(users: Map<string, SpaceUserExtended>) {
         observeMetadata: new Subject(),
         observePublicEvent: () => new Subject(),
         observeUserJoined,
-        observeUserLeft: new Subject<SpaceUserExtended>(),
+        observeUserLeft,
         getUsers: () => Promise.resolve(users),
     } as unknown as SpaceInterface;
-    return { space, observeUserJoined, users };
+    return { space, observeUserJoined, observeUserLeft, users };
 }
 
 function createRoom(space: SpaceInterface, repository: RemotePlayersRepository): ProximityChatRoom {
@@ -155,7 +156,7 @@ describe("ProximityChatRoom join events", () => {
 
     it("waits for the zone data of users already in the space and announces them all in one go", async () => {
         const users = new Map([1, 2, 3].map((id) => [`room_${id}`, spaceUser(id)]));
-        const { space, observeUserJoined } = createFakeSpace(users);
+        const { space, observeUserJoined, observeUserLeft } = createFakeSpace(users);
         const repository = new RemotePlayersRepository();
         const room = createRoom(space, repository);
 
@@ -174,12 +175,24 @@ describe("ProximityChatRoom join events", () => {
 
         // A later peer is a participant joining, not a new meeting.
         repository.addPlayer(player(4));
+        users.set("room_4", spaceUser(4));
         observeUserJoined.next(spaceUser(4));
         await flush();
         expect(iframeListener.sendParticipantJoinProximityMeetingEvent).toHaveBeenCalledWith(
             expect.objectContaining({ userId: 4 }),
         );
         expect(iframeListener.sendJoinProximityMeetingEvent).toHaveBeenCalledTimes(1);
+
+        // A participant who leaves is announced leaving, and announced again when coming back.
+        users.delete("room_4");
+        observeUserLeft.next(spaceUser(4));
+        expect(iframeListener.sendParticipantLeaveProximityMeetingEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: 4 }),
+        );
+        users.set("room_4", spaceUser(4));
+        observeUserJoined.next(spaceUser(4));
+        await flush();
+        expect(iframeListener.sendParticipantJoinProximityMeetingEvent).toHaveBeenCalledTimes(2);
     });
 
     it("does not announce an empty bubble: the first peer to show up triggers the join event", async () => {
@@ -196,6 +209,7 @@ describe("ProximityChatRoom join events", () => {
         expect(iframeListener.sendJoinProximityMeetingEvent).not.toHaveBeenCalled();
         expect(iframeListener.sendJoinMeetingEvent).not.toHaveBeenCalled();
 
+        users.set("room_2", spaceUser(2));
         observeUserJoined.next(spaceUser(2));
         repository.addPlayer(player(2));
         await vi.advanceTimersByTimeAsync(0);
@@ -204,6 +218,7 @@ describe("ProximityChatRoom join events", () => {
         expect(iframeListener.sendParticipantJoinProximityMeetingEvent).not.toHaveBeenCalled();
 
         repository.addPlayer(player(3));
+        users.set("room_3", spaceUser(3));
         observeUserJoined.next(spaceUser(3));
         await vi.advanceTimersByTimeAsync(0);
         expect(iframeListener.sendParticipantJoinProximityMeetingEvent).toHaveBeenCalledWith(

--- a/play/src/front/Chat/Connection/Proximity/tests/ProximityChatRoomJoinEvents.test.ts
+++ b/play/src/front/Chat/Connection/Proximity/tests/ProximityChatRoomJoinEvents.test.ts
@@ -1,0 +1,214 @@
+/* eslint-disable @typescript-eslint/unbound-method -- expect() on vi.fn() members of module mocks */
+import * as Phaser from "phaser";
+globalThis.Phaser = Phaser;
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { Subject } from "rxjs";
+import { writable } from "svelte/store";
+import { AvailabilityStatus, FilterType } from "@workadventure/messages";
+import { loadLocaleAsync } from "../../../../../i18n/i18n-util.async";
+import { setLocale } from "../../../../../i18n/i18n-svelte";
+import type { SpaceInterface, SpaceUserExtended } from "../../../../Space/SpaceInterface";
+import type { SpaceRegistryInterface } from "../../../../Space/SpaceRegistry/SpaceRegistryInterface";
+import type { MessageUserJoined } from "../../../../Connection/ConnexionModels";
+import { RemotePlayersRepository } from "../../../../Phaser/Game/RemotePlayersRepository";
+import { iframeListener } from "../../../../Api/IframeListener";
+import { ProximityChatRoom } from "../ProximityChatRoom";
+import { DEFAULT_PROXIMITY_SPACE_NAME } from "../ProximityChatRoomManager";
+
+vi.mock("../../../../Api/IframeListener", () => {
+    // Anything the room (or a module it pulls in) calls is a spy; anything it subscribes to is a stream.
+    const members = new Map<string, unknown>();
+    const iframeListener = new Proxy(
+        {},
+        {
+            get(_target, name: string) {
+                if (!members.has(name)) {
+                    members.set(name, name.endsWith("Stream") ? new Subject() : vi.fn());
+                }
+                return members.get(name);
+            },
+        },
+    );
+    return { iframeListener };
+});
+vi.mock("../../../../Phaser/Game/GameScene", () => ({ GameScene: class {} }));
+vi.mock("../../../../Notification/NotificationManager", () => ({
+    notificationManager: { createNotification: vi.fn() },
+}));
+vi.mock("../../../../WebRtc/FaviconManager", () => ({ faviconManager: { pushNotificationFavicon: vi.fn() } }));
+vi.mock("../../../../Components/ActionBar/AvailabilityStatus/statusChanger", () => ({
+    statusChanger: { setUserNameInteraction: vi.fn(), applyInteractionRules: vi.fn(), changeStatusTo: vi.fn() },
+}));
+vi.mock("../../../../Utils/ScreenWakeLock", () => ({
+    screenWakeLock: { requestWakeLock: () => Promise.resolve(undefined) },
+}));
+vi.mock("../../../../Utils/BreakpointsUtils", () => ({ isMediaBreakpointUp: () => false }));
+vi.mock("../../../../Phaser/Entity/CharacterLayerManager", () => ({
+    CharacterLayerManager: { wokaBase64: () => Promise.resolve("") },
+    wokaBase64: () => Promise.resolve(""),
+}));
+vi.mock("../../../../Phaser/Game/GameManager", () => ({
+    gameManager: { getCurrentGameScene: () => ({ roomUrl: "room" }) },
+}));
+vi.mock("../../../../Connection/ConnectionManager", () => ({
+    connectionManager: { roomConnectionStream: new Subject() },
+}));
+vi.mock("../../../../WebRtc/SimplePeer", () => ({ SimplePeer: vi.fn() }));
+vi.mock("../../../../WebRtc/MediaManager", () => ({ MediaManager: vi.fn(), mediaManager: {} }));
+vi.mock(
+    "../../../../Enum/EnvironmentVariable.ts",
+    () => import("../../../../../../tests/front/mocks/frontEnvironmentVariableMock"),
+);
+
+const MY_SPACE_USER_ID = "room_1";
+
+function spaceUser(userId: number): SpaceUserExtended {
+    return {
+        spaceUserId: `room_${userId}`,
+        name: `User ${userId}`,
+        availabilityStatus: AvailabilityStatus.ONLINE,
+        characterTextures: [],
+        tags: [],
+        uuid: `uuid-${userId}`,
+        roomName: "room",
+        playUri: "room",
+        isLogged: false,
+        color: "#000000",
+        pictureStore: writable(undefined),
+        reactiveUser: { availabilityStatus: writable(AvailabilityStatus.ONLINE) },
+    } as unknown as SpaceUserExtended;
+}
+
+function player(userId: number): MessageUserJoined {
+    return {
+        userId,
+        name: `User ${userId}`,
+        characterTextures: [],
+        position: { x: 0, y: 0, direction: 0, moving: false },
+        availabilityStatus: AvailabilityStatus.ONLINE,
+        visitCardUrl: null,
+        companionTexture: undefined,
+        userUuid: `uuid-${userId}`,
+        outlineColor: undefined,
+        variables: new Map(),
+    };
+}
+
+function createFakeSpace(users: Map<string, SpaceUserExtended>) {
+    const observeUserJoined = new Subject<SpaceUserExtended>();
+    const space = {
+        getName: () => "bubble",
+        destroyed: false,
+        usersStore: writable(users),
+        getMetadata: () => new Map(),
+        observeMetadata: new Subject(),
+        observePublicEvent: () => new Subject(),
+        observeUserJoined,
+        observeUserLeft: new Subject<SpaceUserExtended>(),
+        getUsers: () => Promise.resolve(users),
+    } as unknown as SpaceInterface;
+    return { space, observeUserJoined, users };
+}
+
+function createRoom(space: SpaceInterface, repository: RemotePlayersRepository): ProximityChatRoom {
+    const spaceRegistry = { joinSpace: () => Promise.resolve(space) } as unknown as SpaceRegistryInterface;
+    const soundManager = {
+        playBubbleInSound: vi.fn(),
+        playBubbleOutSound: vi.fn(),
+        playMeetingInSound: vi.fn(),
+        playMeetingOutSound: vi.fn(),
+    } as unknown as ConstructorParameters<typeof ProximityChatRoom>[7];
+    return new ProximityChatRoom(
+        DEFAULT_PROXIMITY_SPACE_NAME,
+        "Proximity",
+        "default",
+        MY_SPACE_USER_ID,
+        spaceRegistry,
+        iframeListener,
+        repository,
+        soundManager,
+        undefined,
+        [],
+    );
+}
+
+const flush = () =>
+    new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+const joinedUserIds = () =>
+    vi
+        .mocked(iframeListener.sendJoinProximityMeetingEvent)
+        .mock.calls.map(([users]) => users.map((user) => user.userId));
+
+describe("ProximityChatRoom join events", () => {
+    beforeAll(async () => {
+        await loadLocaleAsync("en-US");
+        setLocale("en-US");
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.useRealTimers();
+    });
+
+    it("waits for the zone data of users already in the space and announces them all in one go", async () => {
+        const users = new Map([1, 2, 3].map((id) => [`room_${id}`, spaceUser(id)]));
+        const { space, observeUserJoined } = createFakeSpace(users);
+        const repository = new RemotePlayersRepository();
+        const room = createRoom(space, repository);
+
+        const joinPromise = room.joinSpace("bubble", [], false, FilterType.ALL_USERS, false);
+        await flush();
+        // The peers are in the space but their userJoinedMessage has not reached us yet: nothing announced.
+        expect(iframeListener.sendJoinProximityMeetingEvent).not.toHaveBeenCalled();
+
+        repository.addPlayer(player(2));
+        repository.addPlayer(player(3));
+        await joinPromise;
+
+        expect(joinedUserIds()).toEqual([[2, 3]]);
+        expect(iframeListener.sendJoinMeetingEvent).toHaveBeenCalledTimes(1);
+        expect(iframeListener.sendParticipantJoinProximityMeetingEvent).not.toHaveBeenCalled();
+
+        // A later peer is a participant joining, not a new meeting.
+        repository.addPlayer(player(4));
+        observeUserJoined.next(spaceUser(4));
+        await flush();
+        expect(iframeListener.sendParticipantJoinProximityMeetingEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: 4 }),
+        );
+        expect(iframeListener.sendJoinProximityMeetingEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not announce an empty bubble: the first peer to show up triggers the join event", async () => {
+        vi.useFakeTimers();
+        const users = new Map([["room_1", spaceUser(1)]]);
+        const { space, observeUserJoined } = createFakeSpace(users);
+        const repository = new RemotePlayersRepository();
+        const room = createRoom(space, repository);
+
+        const joinPromise = room.joinSpace("bubble", [], false, FilterType.ALL_USERS, false);
+        // getFirstUsers backstop: nobody registered in the space.
+        await vi.advanceTimersByTimeAsync(9_000);
+        await joinPromise;
+        expect(iframeListener.sendJoinProximityMeetingEvent).not.toHaveBeenCalled();
+        expect(iframeListener.sendJoinMeetingEvent).not.toHaveBeenCalled();
+
+        observeUserJoined.next(spaceUser(2));
+        repository.addPlayer(player(2));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(joinedUserIds()).toEqual([[2]]);
+        expect(iframeListener.sendJoinMeetingEvent).toHaveBeenCalledTimes(1);
+        expect(iframeListener.sendParticipantJoinProximityMeetingEvent).not.toHaveBeenCalled();
+
+        repository.addPlayer(player(3));
+        observeUserJoined.next(spaceUser(3));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(iframeListener.sendParticipantJoinProximityMeetingEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: 3 }),
+        );
+        expect(iframeListener.sendJoinProximityMeetingEvent).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## What

`WA.player.proximityMeeting.onJoin()` (and `WA.player.meetings.onJoin()`) could fire with an empty `users` array. Bots relying on the initial list never learned who they were talking to.

## Why it happened

Two paths in `ProximityChatRoom.joinSpace`:

1. **9s backstop.** When nobody registered in the space within 9 seconds, `getFirstUsers` resolved with `[]` and the join event was emitted with an empty list. The peer then only came through `onParticipantJoin`. Sentry shows the backstop firing ~4400 times / 1800 users over the last 30 days, so this is not an edge case.
2. **Zone data race.** A user already registered in the space whose `userJoinedMessage` had not reached the client yet (typically someone spawning right next to us) was silently dropped by the synchronous lookup in `RemotePlayersRepository`.

## Fix

- Join events are emitted once, at the end of `joinSpace`, from the complete list of space users, so the full list still comes in one go whenever it is available.
- Users are resolved through `RemotePlayersRepository.getPlayer()`, which waits for the zone data (up to 5s) instead of dropping the user.
- If nobody is known at that point, the bubble is not announced. The first peer to show up triggers the join event, later peers are announced as participants. Late joiners are held back until the initial events are out and a set of announced user ids guarantees each user is announced exactly once.
- Meeting rooms keep announcing an empty list: being alone in a meeting room is legitimate.

## Reviewer notes

- `ProximityChatRoomJoinEvents.test.ts` is the first test to load the real `ProximityChatRoom` module, hence the module mocks at the top (borrowed from the Space tests). It covers both scenarios, the backstop one with fake timers.
- `npm run typecheck`, eslint, prettier and the proximity test suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
