### PR TITLE
fix(chat): stop "send message" from opening a group room as a DM

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -485,6 +485,12 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.client.getVisibleRooms().forEach((room) => this.updateRawUnreadRoom(room));
     }
 
+    private getDirectRoomIdsFor(userID: string): Set<string> {
+        const directRoomsPerUsers = this.client?.getAccountData(EventType.Direct)?.getContent() ?? {};
+        const roomIds: unknown = directRoomsPerUsers[userID];
+        return new Set(Array.isArray(roomIds) ? (roomIds as string[]) : []);
+    }
+
     private getDirectRoomIds(): Set<string> {
         const directRoomsPerUsers = this.client?.getAccountData(EventType.Direct)?.getContent() ?? {};
         return new Set(Object.values(directRoomsPerUsers).flat() as string[]);
@@ -1911,11 +1917,21 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         // reconciliation, so it can miss a DM the client already knows about — every miss here
         // forks a duplicate room. Same heuristic as Element's findDMForUser: a DM is a room of
         // exactly two active people containing those two people.
-        const suitableRooms = this.client.getRooms().filter((room) => {
+        const candidateRooms = this.client.getRooms().filter((room) => {
             if (room.isSpaceRoom() || !isActiveMembership(room.getMyMembership())) return false;
-            const activeMembers = room.getMembers().filter((member) => isActiveMembership(member.membership));
-            return activeMembers.length === 2 && activeMembers.some((member) => member.userId === userID);
+            // Counts come from the room summary, not from `getMembers().length`: under lazy loading the
+            // latter only holds the member events that happen to be loaded (the heroes and the recent
+            // senders), so a crowded room whose two loaded members are the two of us would be picked as
+            // our DM. Same reasoning as MatrixChatRoom.getMatrixRoomType.
+            if (room.getJoinedMemberCount() + room.getInvitedMemberCount() !== 2) return false;
+            return isActiveMembership(room.getMember(userID)?.membership);
         });
+
+        // A room flagged as a DM with that user wins over a room that merely ended up with two people:
+        // a group chat everybody else left still counts two active members but is not our DM.
+        const directRoomIds = this.getDirectRoomIdsFor(userID);
+        const flaggedRooms = candidateRooms.filter((room) => directRoomIds.has(room.roomId));
+        const suitableRooms = flaggedRooms.length > 0 ? flaggedRooms : candidateRooms;
 
         // Duplicate DMs already exist for some users: pick the most recently active one
         // (the sidebar sort criterion) instead of an arbitrary insertion order.

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -666,21 +666,41 @@ describe("MatrixChatConnection", () => {
                 myMembership = KnownMembership.Join,
                 lastActiveTimestamp = 0,
                 isSpace = false,
-            }: { myMembership?: string; lastActiveTimestamp?: number; isSpace?: boolean } = {},
-        ) =>
-            ({
+                // Defaults to the loaded memberships; set it to mimic lazy loading, where the summary
+                // counts the whole room while only a couple of member events are loaded.
+                summaryMemberCount,
+            }: {
+                myMembership?: string;
+                lastActiveTimestamp?: number;
+                isSpace?: boolean;
+                summaryMemberCount?: number;
+            } = {},
+        ) => {
+            const members = memberships.map(([userId, membership]) => ({ userId, membership }));
+            const activeMembers = members.filter(
+                ({ membership }) => membership === KnownMembership.Join || membership === KnownMembership.Invite,
+            );
+            return {
                 roomId,
                 isSpaceRoom: () => isSpace,
                 getMyMembership: () => myMembership,
-                getMembers: () => memberships.map(([userId, membership]) => ({ userId, membership })),
+                getMembers: () => members,
+                getMember: (userId: string) => members.find((member) => member.userId === userId),
+                getJoinedMemberCount: () => summaryMemberCount ?? activeMembers.length,
+                getInvitedMemberCount: () => 0,
                 getLastActiveTimestamp: () => lastActiveTimestamp,
-            }) as unknown as Room;
+            } as unknown as Room;
+        };
 
         // The lookup must read the SDK client directly: roomList is filled asynchronously
         // and can miss a DM the client already knows about (cold start, reconciliation).
-        const getConnectionWithSdkRooms = async (sdkRooms: Room[]) => {
+        const getConnectionWithSdkRooms = async (
+            sdkRooms: Room[],
+            directRoomsPerUser: Record<string, string[]> = {},
+        ) => {
             const mockMatrixClient = {
                 getRooms: () => sdkRooms,
+                getAccountData: () => ({ getContent: () => directRoomsPerUser }),
             } as unknown as MatrixClient;
             const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
             const createAndAddNewRootRoom = vi.fn(
@@ -750,6 +770,24 @@ describe("MatrixChatConnection", () => {
             const { matrixChatConnection } = await getConnectionWithSdkRooms([crowdedRoom]);
 
             expect(await matrixChatConnection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+        });
+
+        it("should ignore a crowded room whose only loaded members are the two of us", async () => {
+            // Lazy loading: the summary says five people, but only the heroes are loaded.
+            const crowdedRoom = createSdkRoomStub("crowded", directMemberships, { summaryMemberCount: 5 });
+            const { matrixChatConnection } = await getConnectionWithSdkRooms([crowdedRoom]);
+
+            expect(await matrixChatConnection.getDirectRoomFor("@alice:matrix.org")).toBeUndefined();
+        });
+
+        it("should prefer the room flagged as a direct room in m.direct", async () => {
+            const leftoverGroup = createSdkRoomStub("leftoverGroup", directMemberships, { lastActiveTimestamp: 200 });
+            const flaggedDm = createSdkRoomStub("flaggedDm", directMemberships, { lastActiveTimestamp: 100 });
+            const { matrixChatConnection } = await getConnectionWithSdkRooms([leftoverGroup, flaggedDm], {
+                "@alice:matrix.org": ["flaggedDm"],
+            });
+
+            expect((await matrixChatConnection.getDirectRoomFor("@alice:matrix.org"))?.id).toBe("flaggedDm");
         });
 
         it("should ignore rooms the other user has left", async () => {


### PR DESCRIPTION
## Problem

Clicking **Send message** on a user opened, for some contacts, a room with several people in it instead of the one-to-one conversation.

`getDirectRoomFor()` picked a room as our DM with someone when `room.getMembers()` held exactly two active members. The Matrix client runs with `lazyLoadMembers: true`, so `getMembers()` only returns the member events that happen to be loaded (the room heroes and the recent senders) — not the people actually in the room. A crowded room whose two loaded members were the two of us therefore matched, and the button opened that group room.

This is the very pitfall `MatrixChatRoom.getMatrixRoomType()` already documents and guards against; the DM lookup reintroduced it.

## Fix

- Take the member counts from the room summary (`getJoinedMemberCount() + getInvitedMemberCount()`), which stays accurate under lazy loading, and check the target's membership with `getMember()`.
- Prefer the rooms flagged in `m.direct` for that user over rooms that merely ended up with two people — a group everybody else left also counts two active members but is not our DM. Same ordering as Element's `findDMForUser`.

## Tests

Two regression tests in `MatrixChatConnection.test.ts`:
- a crowded room whose only loaded members are the two of us is ignored;
- the room flagged in `m.direct` wins over another two-person candidate.

The room stub now derives the summary counts from the loaded memberships, with an override to mimic lazy loading. 61/61 tests in the file pass; `tsc` and `eslint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)