### PR TITLE
fix(chat): clear the user providers filter when closing the search bar

### DIFF
--- a/play/src/front/Chat/Components/ChatHeader.svelte
+++ b/play/src/front/Chat/Components/ChatHeader.svelte
@@ -32,10 +32,18 @@
     function handleToggleSearch() {
         searchActive = !searchActive;
 
-        if (!searchActive) {
-            chatSearchBarValue.set("");
-            joignableRoom.set([]);
-        }
+        if (!searchActive) clearSearch();
+    }
+
+    function clearSearch() {
+        clearTimeout(typingTimer);
+        chatSearchBarValue.set("");
+        joignableRoom.set([]);
+        // The user providers are shared and keep the text of the last search: reset their filter too,
+        // or the user list stays filtered while the search bar shows nothing.
+        userProviderMergerPromise
+            .then((userProviderMerger) => userProviderMerger.setFilter(""))
+            .catch((e) => console.error(e));
     }
 
     const handleKeyDown = () => {
@@ -82,11 +90,7 @@
     }
 
     onDestroy(() => {
-        if (typingTimer) {
-            clearTimeout(typingTimer);
-        }
-        chatSearchBarValue.set("");
-        joignableRoom.set([]);
+        clearSearch();
     });
 </script>
 


### PR DESCRIPTION
## Bug

Filter the user list, then close the search bar: the input clears but the list stays filtered.

## Cause

The search bar drives **two** filters:

- `chatSearchBarValue` — the client-side filter `RoomUserList` applies on the users it already has;
- `userProviderMerger.setFilter()` — the provider-level filter, which re-queries the Admin API and decides which users are loaded at all.

Closing the search bar (and `onDestroy`) only reset the first one, so the providers kept the last search text and kept serving a filtered set.

`SelectMatrixUser.svelte` already treats `chatSearchBarValue` as the source of truth for the provider filter (it re-pushes it when the member picker closes); `ChatHeader` was the one breaking that invariant.

## Fix

One `clearSearch()` used by both the close handler and `onDestroy`: clears the value, the joignable rooms, the pending debounce timer, and resets the provider filter.

Clearing the debounce also stops an in-flight 2s timer from re-filtering after the bar is closed.

## Test

Manual: open the user list, search a name, close the search bar → the full list comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)