### PR TITLE
fix(i18n): drop the stray $ shown before the calendar and todo list labels

### DIFF
--- a/play/src/front/Components/Calendar/Calendar.svelte
+++ b/play/src/front/Components/Calendar/Calendar.svelte
@@ -137,7 +137,7 @@
                                                 }
                                             }}
                                             class="text-xs text-right text-secondary-500"
-                                            target="_blank">${$LL.externalModule.calendar.joinMeeting()}</a
+                                            target="_blank">{$LL.externalModule.calendar.joinMeeting()}</a
                                         >
                                     {/if}
                                 </div>

--- a/play/src/front/Components/TodoList/TodoList.svelte
+++ b/play/src/front/Components/TodoList/TodoList.svelte
@@ -157,7 +157,7 @@
                     class="text-center text-xs text-gray-400 italic hover:underline cursor-pointer mt-5"
                     on:click={closeTodoList}
                 >
-                    ${$LL.externalModule.todoList.sentence()}
+                    {$LL.externalModule.todoList.sentence()}
                 </p>
             {/if}
         </div>


### PR DESCRIPTION
## Problem

In the **Calendar** and **Todo list** panels, two translated labels are rendered with a stray `$` in front of them:

- the "Join meeting" link of an event
- the closing sentence at the bottom of the todo list

## Cause

Both calls were written as `${$LL....()}` in the Svelte markup. `${...}` is only syntax inside a JS template literal; in an HTML template Svelte interpolates `{...}` and the leading `$` is rendered as plain text.

## Fix

Removed the extra `$` on both lines.

The other `${$LL...}` occurrences in the repo (chat, MapEditor, RefreshPrompt) are inside backticks — correct, left untouched.