### PR TITLE
Hide PiP button on mobile phones

### DIFF
--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -15,6 +15,7 @@
     import { hideActionBarStoreBecauseOfChatBar } from "../../Chat/ChatSidebarWidthStore";
     import { screenSharingAvailableStore } from "../../Stores/ScreenSharingStore";
     import { isInRemoteConversation } from "../../Stores/StreamableCollectionStore";
+    import { pictureInPictureSupportedStore } from "../../Stores/PeerStore";
     import MediaSettingsList from "./MediaSettingsList/MediaSettingsList.svelte";
     import CameraMenuItem from "./MenuIcons/CameraMenuItem.svelte";
     import MicrophoneMenuItem from "./MenuIcons/MicrophoneMenuItem.svelte";
@@ -122,7 +123,7 @@
                                 {#if $screenSharingAvailableStore}
                                     <ScreenSharingMenuItem />
                                 {/if}
-                                {#if $isInRemoteConversation}
+                                {#if $isInRemoteConversation && $pictureInPictureSupportedStore}
                                     <PictureInPictureMenuItem />
                                 {/if}
                                 <!-- NAV : SCREENSHARING END -->

--- a/play/src/front/Components/ActionBar/MenuIcons/PictureInPictureMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/PictureInPictureMenuItem.svelte
@@ -38,7 +38,7 @@
 <ActionBarButton
     classList="group/btn-picture-in-picture"
     disabledHelp={$openedMenuStore !== undefined}
-    state={$pictureInPictureSupportedStore ? ($activePictureInPictureStore ? "active" : "normal") : "disabled"}
+    state={$activePictureInPictureStore ? "active" : "normal"}
     dataTestId={$pictureInPictureSupportedStore ? "pictureInPictureButton" : "pictureInPictureButtonDisabled"}
     tooltipTitle={$LL.actionbar.help.pictureInPicture.title()}
     desc={$pictureInPictureSupportedStore

--- a/tests/tests/picture_in_picture.spec.ts
+++ b/tests/tests/picture_in_picture.spec.ts
@@ -62,8 +62,10 @@ test.describe("Picture In Picture", () => {
         await alicePage.mouse.move(300, 300);
         await bobPage.mouse.move(300, 300);
 
-        // Wait for the video call button to be visible
-        await expect(bobPage.getByTestId("pictureInPictureButtonDisabled")).toBeVisible({ timeout: 10_000 });
-        await expect(alicePage.getByTestId("pictureInPictureButtonDisabled")).toBeVisible({ timeout: 10_000 });
+        // Check the Picture in Picture button is not available
+        await expect(bobPage.getByTestId("screenShareButton")).toBeVisible({ timeout: 10_000 });
+        await expect(bobPage.getByTestId("pictureInPictureButtonDisabled")).toBeHidden({ timeout: 10_000 });
+        await expect(alicePage.getByTestId("screenShareButton")).toBeVisible({ timeout: 10_000 });
+        await expect(alicePage.getByTestId("pictureInPictureButtonDisabled")).toBeHidden({ timeout: 10_000 });
     });
 });


### PR DESCRIPTION
When PiP is not supported, there is no need to display the PiP button, even in disabled state.