### PR TITLE
feat(calendar): announce upcoming meetings and widen the agenda window

### DIFF
--- a/libs/shared-utils/src/Calendar/EventInterface.ts
+++ b/libs/shared-utils/src/Calendar/EventInterface.ts
@@ -13,6 +13,28 @@ export interface CalendarEventInterface {
         onlineMeeting?: {
             joinUrl?: string;
             passcode?: string;
+            /**
+             * True when the conference of this event is a WorkAdventure meeting (booked through the
+             * WorkAdventure add-on of the calendar provider). Such a meeting happens inside
+             * WorkAdventure: joining it is a navigation, not an external link.
+             */
+            isWorkAdventure?: boolean;
         };
     };
+}
+
+/**
+ * How far ahead the agenda looks. A calendar panel that stops at midnight is empty every evening,
+ * and hides the 9am meeting the user needs to see before logging off.
+ */
+export const CALENDAR_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The time window the agenda displays: from now to CALENDAR_WINDOW_MS later.
+ *
+ * Both bounds move with the clock, so an ongoing meeting stays visible (calendar APIs filter on the
+ * event end time) while a finished one drops out on the next refresh.
+ */
+export function calendarWindow(now: Date = new Date()): { from: Date; to: Date } {
+    return { from: now, to: new Date(now.getTime() + CALENDAR_WINDOW_MS) };
 }

--- a/play/src/front/Components/Calendar/Calendar.svelte
+++ b/play/src/front/Components/Calendar/Calendar.svelte
@@ -21,14 +21,26 @@
     }
 
     function formatHour(date: Date) {
+        // The agenda spans the next 24 hours, so name the day of anything that is not today.
+        const isToday = date.toDateString() === new Date().toDateString();
         // undefined locale: follow the browser's own date/time settings
         return date.toLocaleString(undefined, {
+            weekday: isToday ? undefined : "short",
             hour: "2-digit",
             minute: "2-digit",
         });
     }
 
     function openMeeting(event: CalendarEventInterface) {
+        const joinUrl = event.resource?.onlineMeeting?.joinUrl;
+
+        // A WorkAdventure meeting takes place in a room of this world: the link redirects to it, so
+        // follow it in place rather than opening a tab the user has to come back from.
+        if (event.resource?.onlineMeeting?.isWorkAdventure === true && joinUrl) {
+            window.location.assign(joinUrl);
+            return true;
+        }
+
         const gameScene = gameManager.getCurrentGameScene();
         if (!gameScene) return false;
 
@@ -118,7 +130,11 @@
                     {#each [...$calendarEventsStore.entries()] as [eventId, event] (eventId)}
                         <div class="flex flex-col justify-center">
                             <div class="flex flex-row justify-start w-full">
-                                <span class="text-xs">{formatHour(event.start)}</span>
+                                <span class="text-xs"
+                                    >{event.allDay
+                                        ? $LL.externalModule.calendar.allDay()
+                                        : formatHour(event.start)}</span
+                                >
                                 <hr class="border-gray-300 mx-2 w-full opacity-30 border-dashed" />
                             </div>
                             <div
@@ -140,15 +156,22 @@
                                                 }
                                             }}
                                             class="text-xs text-right text-secondary-500"
-                                            target="_blank">{$LL.externalModule.calendar.joinMeeting()}</a
+                                            target={event.resource.onlineMeeting.isWorkAdventure === true
+                                                ? undefined
+                                                : "_blank"}
+                                            >{event.resource.onlineMeeting.isWorkAdventure === true
+                                                ? $LL.externalModule.calendar.joinMeetingInWorkAdventure()
+                                                : $LL.externalModule.calendar.joinMeeting()}</a
                                         >
                                     {/if}
                                 </div>
                             </div>
-                            <div class="flex flex-row justify-start w-full">
-                                <span class="text-xs">{formatHour(event.end)}</span>
-                                <hr class="border-gray-300 mx-2 w-full opacity-30 border-dashed" />
-                            </div>
+                            {#if !event.allDay}
+                                <div class="flex flex-row justify-start w-full">
+                                    <span class="text-xs">{formatHour(event.end)}</span>
+                                    <hr class="border-gray-300 mx-2 w-full opacity-30 border-dashed" />
+                                </div>
+                            {/if}
                         </div>
                     {/each}
                 {/if}

--- a/play/src/front/Components/Calendar/CalendarReminder.ts
+++ b/play/src/front/Components/Calendar/CalendarReminder.ts
@@ -1,0 +1,74 @@
+import { get } from "svelte/store";
+import type { CalendarEventInterface } from "@workadventure/shared-utils";
+import { calendarEventsStore, isCalendarVisibleStore } from "../../Stores/CalendarStore";
+import { isTodoListVisibleStore } from "../../Stores/TodoListStore";
+import { notificationPlayingStore } from "../../Stores/NotificationStore";
+import LL from "../../../i18n/i18n-svelte";
+
+/** How long before it starts a meeting is announced. */
+export const REMINDER_LEAD_MS = 2 * 60 * 1000;
+
+const CHECK_INTERVAL_MS = 30 * 1000;
+
+/**
+ * Which meetings have already been announced. Module scope on purpose: MainLayout, the only caller of
+ * startCalendarReminders(), is destroyed and remounted on every room-to-room transition, and a set
+ * living inside the call would announce the same meeting again at every door the user walks through.
+ */
+const alreadyNotified = new Set<string>();
+
+/**
+ * The events that are about to start and have not been announced yet.
+ *
+ * An event that already started is not "about to start": we would be shouting about a meeting the
+ * user is either already in, or has knowingly skipped. A tab suspended across the whole lead window
+ * therefore misses its reminder, which is the right trade-off.
+ */
+export function dueReminders(
+    events: Iterable<CalendarEventInterface>,
+    alreadyNotified: ReadonlySet<string>,
+    now: Date
+): CalendarEventInterface[] {
+    return [...events].filter((event) => {
+        if (event.allDay === true || alreadyNotified.has(event.id)) {
+            return false;
+        }
+        const msUntilStart = event.start.getTime() - now.getTime();
+        return msUntilStart > 0 && msUntilStart <= REMINDER_LEAD_MS;
+    });
+}
+
+/**
+ * Announce meetings shortly before they start, whatever the calendar provider that filled the store.
+ * Returns the function stopping the reminders.
+ */
+export function startCalendarReminders(): () => void {
+    const check = () => {
+        const due = dueReminders(get(calendarEventsStore).values(), alreadyNotified, new Date());
+        if (due.length === 0) {
+            return;
+        }
+        for (const event of due) {
+            alreadyNotified.add(event.id);
+            notificationPlayingStore.playNotification(
+                get(LL).externalModule.calendar.meetingStartingSoon({ title: event.title }),
+                undefined,
+                `calendar-reminder-${event.id}`
+            );
+        }
+        // The agenda holds the join link: put it in front of the user rather than let him hunt for it.
+        // The to-do list shares the agenda's corner of the screen, so opening one closes the other,
+        // as every other opener of these panels does.
+        isCalendarVisibleStore.set(true);
+        isTodoListVisibleStore.set(false);
+    };
+
+    const interval = setInterval(check, CHECK_INTERVAL_MS);
+    // A refresh can bring in a meeting that is already inside the lead window.
+    const unsubscribe = calendarEventsStore.subscribe(check);
+
+    return () => {
+        clearInterval(interval);
+        unsubscribe();
+    };
+}

--- a/play/src/front/Components/MainLayout.svelte
+++ b/play/src/front/Components/MainLayout.svelte
@@ -45,6 +45,7 @@
     import type { WorkAdventureComponent } from "../../types/component";
     import { LL } from "../../i18n/i18n-svelte";
     import { mapEditorSideBarWidthStore } from "./MapEditor/MapEditorSideBarWidthStore";
+    import { startCalendarReminders } from "./Calendar/CalendarReminder";
     import ActionBar from "./ActionBar/ActionBar.svelte";
     import ActionBarButton from "./ActionBar/ActionBarButton.svelte";
 
@@ -168,9 +169,12 @@
         );
     }
 
+    let stopCalendarReminders: (() => void) | undefined;
+
     onMount(() => {
         document.addEventListener("focusin", handleFocusInEvent);
         document.addEventListener("focusout", handleFocusOutEvent);
+        stopCalendarReminders = startCalendarReminders();
     });
 
     onDestroy(() => {
@@ -180,6 +184,7 @@
         if (participantListAutoHideTimer) {
             clearTimeout(participantListAutoHideTimer);
         }
+        stopCalendarReminders?.();
     });
 
     let marginLeft = $derived($chatVisibilityStore ? $chatSidebarWidthStore : 0);

--- a/play/src/i18n/en-US/externalModule.ts
+++ b/play/src/i18n/en-US/externalModule.ts
@@ -107,8 +107,11 @@ const externalModule: BaseTranslation = {
             "You are already connected, please click on the button to logout and reconnect.",
     },
     calendar: {
-        title: "Your meeting today",
+        title: "Your upcoming meetings",
         joinMeeting: "Click here to join the meeting",
+        joinMeetingInWorkAdventure: "Click here to join the meeting in WorkAdventure",
+        allDay: "All day",
+        meetingStartingSoon: "“{title}” is about to start",
     },
     todoList: {
         title: "To Do",

--- a/play/src/i18n/fr-FR/externalModule.ts
+++ b/play/src/i18n/fr-FR/externalModule.ts
@@ -112,8 +112,11 @@ const externalModule: DeepPartial<Translation["externalModule"]> = {
             "Vous êtes déjà connecté, veuillez cliquer sur le bouton pour vous déconnecter et vous reconnecter.",
     },
     calendar: {
-        title: "Vos réunions aujourd’hui",
+        title: "Vos prochaines réunions",
         joinMeeting: "Cliquez ici pour rejoindre la réunion",
+        joinMeetingInWorkAdventure: "Cliquez ici pour rejoindre la réunion dans WorkAdventure",
+        allDay: "Toute la journée",
+        meetingStartingSoon: "« {title} » va commencer",
     },
     todoList: {
         title: "À faire",

--- a/play/tests/front/Components/Calendar/CalendarReminder.test.ts
+++ b/play/tests/front/Components/Calendar/CalendarReminder.test.ts
@@ -1,0 +1,44 @@
+import type { CalendarEventInterface } from "@workadventure/shared-utils";
+import { describe, expect, it } from "vitest";
+
+import { dueReminders, REMINDER_LEAD_MS } from "../../../../src/front/Components/Calendar/CalendarReminder";
+
+const NOW = new Date("2026-09-10T10:00:00.000Z");
+
+function event(id: string, startsInMs: number, allDay = false): CalendarEventInterface {
+    return {
+        id,
+        title: `Meeting ${id}`,
+        description: "",
+        start: new Date(NOW.getTime() + startsInMs),
+        end: new Date(NOW.getTime() + startsInMs + 30 * 60 * 1000),
+        allDay,
+    };
+}
+
+describe("dueReminders", () => {
+    it("announces a meeting inside the lead window", () => {
+        const due = dueReminders([event("soon", REMINDER_LEAD_MS - 1000)], new Set(), NOW);
+        expect(due.map((e) => e.id)).toEqual(["soon"]);
+    });
+
+    it("stays quiet for a meeting further away than the lead window", () => {
+        const due = dueReminders([event("later", REMINDER_LEAD_MS + 1000)], new Set(), NOW);
+        expect(due).toEqual([]);
+    });
+
+    it("stays quiet once the meeting has started", () => {
+        const due = dueReminders([event("started", -1000), event("starting-now", 0)], new Set(), NOW);
+        expect(due).toEqual([]);
+    });
+
+    it("announces a meeting only once", () => {
+        const due = dueReminders([event("soon", 60_000)], new Set(["soon"]), NOW);
+        expect(due).toEqual([]);
+    });
+
+    it("ignores all-day events, which have no start time to announce", () => {
+        const due = dueReminders([event("all-day", 60_000, true)], new Set(), NOW);
+        expect(due).toEqual([]);
+    });
+});


### PR DESCRIPTION
The calendar panel is fed by the external modules (Google, Microsoft), which each normalise their
events into `CalendarEventInterface`. Anything that only depends on those events belongs in the core
rather than in each module, so every provider gets it at once instead of one of them getting it twice.

## What this adds

**A shared agenda window.** `calendarWindow()` gives every provider the same span: from now to 24
hours later. Both modules were querying "today", so the panel was empty every evening and hid the 9am
meeting the user needed to see before logging off. Times outside today are now labelled with their
day.

**A reminder.** A meeting is announced two minutes before it starts: a notification, plus the agenda,
which carries the join link. Once per meeting, never for one that has already started, never for an
all-day one. `dueReminders()` is a pure function and is unit tested.

**All-day events.** `allDay` was in the interface but ignored by the panel, and hardcoded to `false`
by both modules. An all-day event now shows as such instead of as an hour that means nothing.

**`isWorkAdventure`.** Marks an event whose conference was booked through the WorkAdventure add-on of
the calendar provider. That meeting takes place in a room of this world, so the panel offers to join
it in place rather than opening a tab the user has to come back from. The modules fill the flag; the
core decides what to do with it.

## Notes for the reviewer

* The reminder is wired in `MainLayout`, which is destroyed and remounted on every room-to-room
  transition (`GameOverlay.svelte` keys it on `forceRefreshChatStore`). The set of already-announced
  meetings is therefore at module scope, not inside `startCalendarReminders()` — otherwise walking
  through a door inside the two-minute window re-announces the same meeting.
* Opening the agenda also closes the to-do list, as every other opener of these two panels does: they
  share the same corner of the screen and the same z-index.
* The companion change lives in the SaaS repository, where the Google module fills the new fields and
  both modules call `calendarWindow()`. It needs this one first, since it imports from
  `@workadventure/shared-utils`.

## Test plan

* `play/tests/front/Components/Calendar/CalendarReminder.test.ts` covers the reminder window: fires
  inside the lead time, silent before it, silent once the meeting has started, once per meeting,
  never for an all-day event.
* Manually: with a Google or Outlook account synced, an event starting in under two minutes should
  raise one notification and open the agenda; an all-day event should read "All day"; an event
  tomorrow morning should be listed with its weekday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)