### PR TITLE
fix(pusher): stop re-sending a backpressured frame on every drain

### DIFF
--- a/play/src/front/Connection/WorkAdventureWebSocket.ts
+++ b/play/src/front/Connection/WorkAdventureWebSocket.ts
@@ -5,6 +5,7 @@ import {
     type ServerToClientMessage,
 } from "@workadventure/messages";
 import { BehaviorSubject } from "rxjs";
+import * as Sentry from "@sentry/svelte";
 import { v4 as uuidv4 } from "uuid";
 import { NoncedMessageStore } from "../../common/NoncedMessageStore";
 import { WS_CLOSE_CODE_SESSION_DESTROYED } from "../../common/WebSocketCloseCodes";
@@ -42,6 +43,7 @@ export class WorkAdventureWebSocket {
     private reconnectionTimeout: ReturnType<typeof setTimeout> | undefined;
     private nextOutgoingNonce = 1;
     private lastReceivedNonce = 0;
+    private duplicateNonceReported = false;
     private readonly outgoingMessagesStore = new NoncedMessageStore<Uint8Array<ArrayBuffer>>(
         CLIENT_DISCONNECTION_RETENTION_MS,
     );
@@ -155,6 +157,20 @@ export class WorkAdventureWebSocket {
         } catch (e) {
             console.error(e);
             this.close(1003, "Invalid message format");
+            return;
+        }
+
+        // The pusher must never send us the same nonce twice: it only replays frames the client reported
+        // as missing. A duplicate means the server-side bookkeeping is broken, and replaying a frame to
+        // the application layer corrupts state (double query answers, ghost users...). Drop it, loudly.
+        if (frame.nonce <= this.lastReceivedNonce) {
+            const message = `Received a duplicate message from the pusher (nonce ${frame.nonce}, last received nonce ${this.lastReceivedNonce}). Ignoring it.`;
+            console.warn(message);
+            if (!this.duplicateNonceReported) {
+                // Duplicates come in bursts (one per drain event), so only report the first one of this connection.
+                this.duplicateNonceReported = true;
+                Sentry.captureMessage(message);
+            }
             return;
         }
 

--- a/play/src/pusher/services/PusherWebSocket.ts
+++ b/play/src/pusher/services/PusherWebSocket.ts
@@ -30,6 +30,7 @@ export class PusherWebSocket {
     };
     private nextOutgoingNonce = 1;
     private lastSentNonce = 0;
+    private waitingForDrain = false;
     private lastReceivedNonce = 0;
     private transportAvailable = true;
     private readonly outgoingMessagesStore = new NoncedMessageStore<Uint8Array<ArrayBuffer>>(
@@ -54,7 +55,7 @@ export class PusherWebSocket {
         this.nextOutgoingNonce += 1;
         this.outgoingMessagesStore.add(nonce, payloadWithNonce);
 
-        if (!this.transportAvailable || nonce > this.lastSentNonce + 1) {
+        if (!this.transportAvailable || this.waitingForDrain || nonce > this.lastSentNonce + 1) {
             return 0;
         }
 
@@ -65,6 +66,7 @@ export class PusherWebSocket {
         if (!this.transportAvailable) {
             return;
         }
+        this.waitingForDrain = false;
         for (const { nonce, payload } of this.outgoingMessagesStore.getAfter(this.lastSentNonce)) {
             if (this.sendStoredPayload(nonce, payload) !== 1) {
                 return;
@@ -309,8 +311,15 @@ export class PusherWebSocket {
         }
 
         const sendStatus = this.socket.send(payload, true);
-        if (sendStatus === 1) {
+        // uWS send: 1 = written, 0 = buffered as backpressure (uWS still delivers it, in order), 2 = dropped
+        // because maxBackpressure was reached. Only a dropped message may be sent again on drain: resending
+        // a buffered one delivers it twice to the client.
+        if (sendStatus !== 2) {
             this.lastSentNonce = nonce;
+        }
+        if (sendStatus !== 1) {
+            // Stop feeding uWS until it drains, otherwise we pile up past maxBackpressure and get dropped.
+            this.waitingForDrain = true;
         }
         return sendStatus;
     }

--- a/play/tests/pusher/PusherRoomSocketController.test.ts
+++ b/play/tests/pusher/PusherRoomSocketController.test.ts
@@ -280,7 +280,8 @@ describe("PusherRoomSocketController reconnect retention", () => {
 
         await registeredHandlers?.drain(socket);
 
-        expect(getSendMock(socket)).toHaveBeenCalledTimes(3);
+        // The message held behind the backpressured one is flushed; the backpressured one is not sent again.
+        expect(getSendMock(socket)).toHaveBeenCalledTimes(2);
     });
 });
 
@@ -386,24 +387,61 @@ describe("PusherWebSocket backpressure", () => {
 
         wrapper.handleDrain();
 
-        expect(getSendMock(socket)).toHaveBeenCalledTimes(3);
+        // Only the second message is sent on drain: the first one is already buffered by uWS.
+        expect(getSendMock(socket)).toHaveBeenCalledTimes(2);
     });
 
-    it("keeps the drain tracker at the last accepted nonce when drain hits backpressure again", () => {
+    it("never hands a backpressured message to uWS twice, however many drains happen", () => {
         const socket = createSocket();
-        getSendMock(socket).mockReturnValueOnce(0).mockReturnValueOnce(1).mockReturnValueOnce(0).mockReturnValue(1);
+        getSendMock(socket).mockReturnValue(0);
+        const wrapper = createPusherWebSocket(socket);
+
+        wrapper.send({ message: undefined });
+        expect(getSendMock(socket)).toHaveBeenCalledTimes(1);
+
+        wrapper.handleDrain();
+        wrapper.handleDrain();
+
+        // uWS returned 0: it buffered the payload and will deliver it. Sending it again on every drain
+        // delivers it to the client several times (duplicate query answers, ghost users...).
+        expect(getSendMock(socket)).toHaveBeenCalledTimes(1);
+    });
+
+    it("sends a dropped message again on drain", () => {
+        const socket = createSocket();
+        getSendMock(socket).mockReturnValueOnce(2).mockReturnValue(1);
         const wrapper = createPusherWebSocket(socket);
 
         wrapper.send({ message: undefined });
         wrapper.send({ message: undefined });
-        wrapper.handleDrain();
-        wrapper.send({ message: undefined });
+        expect(getSendMock(socket)).toHaveBeenCalledTimes(1);
 
+        wrapper.handleDrain();
+
+        // uWS returned 2: maxBackpressure was reached and the payload was never queued, so both the
+        // dropped message and the one held behind it must be sent.
+        expect(getSendMock(socket)).toHaveBeenCalledTimes(3);
+    });
+
+    it("resumes at the next unsent message when drain hits backpressure again", () => {
+        const socket = createSocket();
+        getSendMock(socket).mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1);
+        const wrapper = createPusherWebSocket(socket);
+
+        wrapper.send({ message: undefined });
+        wrapper.send({ message: undefined });
+        wrapper.send({ message: undefined });
+        expect(getSendMock(socket)).toHaveBeenCalledTimes(1);
+
+        // Second message backpressures too, so the third one stays held.
+        wrapper.handleDrain();
+        expect(getSendMock(socket)).toHaveBeenCalledTimes(2);
+
+        wrapper.handleDrain();
         expect(getSendMock(socket)).toHaveBeenCalledTimes(3);
 
-        wrapper.handleDrain();
-
-        expect(getSendMock(socket)).toHaveBeenCalledTimes(5);
+        // Every payload reached uWS exactly once.
+        expect(new Set(getSendMock(socket).mock.calls.map(([payload]) => payload)).size).toBe(3);
     });
 });
 


### PR DESCRIPTION
## Symptom

A client could not fetch his recordings list. His console repeated:

```
Error while handling message from server Error: Got an answer to a query we have no track of: 3
    handleSocketMessage RoomConnection.ts:731
    handleMessageEvent WorkAdventureWebSocket.ts:170
```

7 copies of the answer to query 3 in 4 seconds, then `Timeout detected. No ping from the server received`, reconnect, and the same thing again.

## Cause

uWS `send()` returns **1** when it wrote the payload, **0** when it buffered it as backpressure *and will deliver it*, **2** when it dropped it because `maxBackpressure` (64 kB) was reached.

`sendStoredPayload()` only advanced `lastSentNonce` on `1`, so a buffered frame counted as unsent and `handleDrain()` handed it to uWS **again on every drain event**. Any message too big to be written in one go was delivered several times. The front does not deduplicate incoming nonces, so it resolved the query on the first copy and threw on all the others. The repeated sends also starved the keep-alive pings, which is what eventually killed the connection.

It surfaced on the recordings list because that answer embeds one presigned URL per thumbnail (one thumbnail / 120 s of recording) and is by far our biggest message — but the bug is generic.

## Fix

`lastSentNonce` was doing double duty: *"last frame uWS accepted"* and *"we are paused until drain"*. The second meaning moves to `waitingForDrain`, so we still stop feeding uWS while it is backpressured (piling up past `maxBackpressure` gets frames dropped for real), while never sending an already-buffered frame twice.

The front now ignores a nonce it has already processed, and warns to the console and Sentry if that ever happens — the pusher must never send one twice, so it is worth knowing. `console.warn` on every duplicate (they come in bursts, and the full burst is useful in an exported console log), Sentry once per connection to avoid a quota bomb.

## Tests

`PusherWebSocket backpressure` in `PusherRoomSocketController.test.ts`: a buffered frame is never handed to uWS twice however many drains happen, a dropped one is sent again, and drain resumes at the next unsent message. Three existing tests asserted the old call counts — i.e. they encoded the duplicate — and were updated.

All 4 fail on `hotfix` and pass here.

## Follow-up (not in this PR)

The recordings answer is still hundreds of KB of presigned URLs. At that size uWS can return `2` and those frames are genuinely lost, with no gap detection on either side. Signing thumbnails on demand (the front already has `getSignedUrlQuery`) would remove the payload bomb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)