### PR TITLE
fix(recording): stop sending one signed URL per thumbnail in the recordings list

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -717,6 +717,7 @@ export class SocketManager {
                 case "leaveSpaceQuery":
                 case "mapStorageJwtQuery":
                 case "getRecordingsQuery":
+                case "getRecordingThumbnailsQuery":
                 case "deleteRecordingQuery":
                 case "getSignedUrlQuery":
                 case "startRecordingQuery":

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -566,6 +566,7 @@ message QueryMessage {
     GetSignedUrlQuery getSignedUrlQuery = 19;
     StartRecordingQuery startRecordingQuery = 21;
     StopRecordingQuery stopRecordingQuery = 22;
+    GetRecordingThumbnailsQuery getRecordingThumbnailsQuery = 23;
   }
 }
 
@@ -647,6 +648,11 @@ message GetRecordingsQuery {
   optional string uuid = 2;
 }
 
+// Thumbnails of a single recording, fetched on demand: the list only carries one poster per recording.
+message GetRecordingThumbnailsQuery {
+  string baseFilename = 1;
+}
+
 message DeleteRecordingQuery {
   string recordingId = 1;
 }
@@ -684,6 +690,7 @@ message AnswerMessage {
     GetSignedUrlAnswer getSignedUrlAnswer = 21;
     StartRecordingAnswer startRecordingAnswer = 22;
     StopRecordingAnswer stopRecordingAnswer = 23;
+    GetRecordingThumbnailsAnswer getRecordingThumbnailsAnswer = 24;
   }
 }
 
@@ -773,6 +780,11 @@ message GetRecordingsAnswer {
   repeated Recording recordings = 1;
 }
 
+message GetRecordingThumbnailsAnswer {
+  // Signed URLs, evenly spaced over the recording, oldest first.
+  repeated string urls = 1;
+}
+
 message DeleteRecordingAnswer {
   bool success = 1;
   optional string errorMessage = 2;
@@ -814,22 +826,15 @@ message Recording {
   string timestamp = 1;
   string baseFilename = 2;
   VideoFile videoFile = 3;
-  repeated Thumbnail thumbnails = 4;
+  reserved 4; // was: repeated Thumbnail thumbnails, one signed URL every 10s of video. See GetRecordingThumbnailsQuery.
+  // Signed URL of the thumbnail shown in the list, empty if the recording has none.
+  string posterUrl = 5;
 }
 
 message VideoFile {
   string key = 1;
   string filename = 2;
   optional uint64 size = 3;
-}
-
-message Thumbnail {
-  string key = 1;
-  string url = 2;
-  string filename = 3;
-  optional uint64 size = 4;
-  optional int32 sequenceNumber = 5;
-  optional int32 timestampSeconds = 6;
 }
 
 /*********** PUSHER TO BACK QUERYMESSAGES *************/

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -826,9 +826,9 @@ message Recording {
   string timestamp = 1;
   string baseFilename = 2;
   VideoFile videoFile = 3;
-  reserved 4; // was: repeated Thumbnail thumbnails, one signed URL every 10s of video. See GetRecordingThumbnailsQuery.
   // Signed URL of the thumbnail shown in the list, empty if the recording has none.
-  string posterUrl = 5;
+  // The other thumbnails are fetched on demand, see GetRecordingThumbnailsQuery.
+  string posterUrl = 4;
 }
 
 message VideoFile {

--- a/play/src/front/Components/PopUp/Recording/RecordingsListModal.svelte
+++ b/play/src/front/Components/PopUp/Recording/RecordingsListModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onMount } from "svelte";
+    import { onDestroy, onMount } from "svelte";
     import type { NonUndefinedFields, Recording } from "@workadventure/messages";
     import type { GameScene } from "../../../Phaser/Game/GameScene";
     import PopUpContainer from "../PopUpContainer.svelte";
@@ -20,7 +20,7 @@
 
     type ViewMode = "list" | "card";
 
-    let viewMode: ViewMode = "list";
+    let viewMode: ViewMode = "card";
     let recordings: NonUndefinedFields<Recording>[] = [];
     let isLoading: boolean = false;
     let isError: boolean = false;
@@ -35,8 +35,13 @@
     }
 
     let hoveredRecordIndex: number = -1;
-    let thumbnailIndex: number = 1;
+    let thumbnailIndex: number = 0;
     let thumbnailInterval: number | null = null;
+    /** Signed thumbnail URLs of the recording being hovered, empty while they load. */
+    let hoveredThumbnails: string[] = [];
+    /** Thumbnails are fetched per recording, on hover: keep them for as long as the modal is open. */
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const thumbnailsRequests = new Map<string, Promise<string[]>>();
 
     /** Card mode: filename of the card showing the actions panel (download/delete), or null */
     let actionsCardFilename: string | null = null;
@@ -120,6 +125,8 @@
 
     async function queryRecordings(): Promise<void> {
         isLoading = true;
+        // The signed URLs these hold expire after an hour.
+        thumbnailsRequests.clear();
         if (!connection) return;
         try {
             const recordingsAnswer = await connection.queryRecordings();
@@ -133,14 +140,41 @@
         }
     }
 
-    function startThumbnailCycle(recordIndex: number, thumbnails: NonUndefinedFields<Recording>["thumbnails"]): void {
-        if (thumbnails.length <= 2) return;
+    /**
+     * The list only carries one poster per recording, so the frames of the hover preview are fetched
+     * for that recording only, the first time it is hovered.
+     */
+    function loadThumbnails(baseFilename: string): Promise<string[]> {
+        let request = thumbnailsRequests.get(baseFilename);
+        if (!request) {
+            request = (connection?.queryRecordingThumbnails(baseFilename) ?? Promise.resolve([])).catch((error) => {
+                console.error("Failed to query recording thumbnails:", error);
+                // Let a later hover try again.
+                thumbnailsRequests.delete(baseFilename);
+                return [];
+            });
+            thumbnailsRequests.set(baseFilename, request);
+        }
+        return request;
+    }
 
+    async function startThumbnailCycle(recordIndex: number, record: NonUndefinedFields<Recording>): Promise<void> {
         hoveredRecordIndex = recordIndex;
-        thumbnailIndex = 1;
+        thumbnailIndex = 0;
+        hoveredThumbnails = [];
 
+        const urls = await loadThumbnails(record.baseFilename);
+
+        // The pointer may have left, or moved to another recording, while the thumbnails were loading.
+        if (hoveredRecordIndex !== recordIndex || urls.length <= 1) return;
+
+        hoveredThumbnails = urls;
+        // Hovering the same recording twice while it loads resolves both calls: never leak the first interval.
+        if (thumbnailInterval) {
+            clearInterval(thumbnailInterval);
+        }
         thumbnailInterval = window.setInterval(() => {
-            thumbnailIndex = (thumbnailIndex + 1) % thumbnails.length || 1;
+            thumbnailIndex = (thumbnailIndex + 1) % urls.length;
         }, 650);
     }
 
@@ -150,7 +184,21 @@
             thumbnailInterval = null;
         }
         hoveredRecordIndex = -1;
-        thumbnailIndex = 1;
+        thumbnailIndex = 0;
+        hoveredThumbnails = [];
+    }
+
+    function thumbnailSrc(
+        record: NonUndefinedFields<Recording>,
+        isHovered: boolean,
+        index: number,
+        thumbnails: string[],
+    ): string | undefined {
+        if (isHovered && thumbnails.length > 0) {
+            return thumbnails[index];
+        }
+        // Recordings whose thumbnails failed to generate have no poster.
+        return record.posterUrl || undefined;
     }
 
     function getDaysUntilExpiration(filename: string): number | null {
@@ -201,6 +249,9 @@
             minute: "2-digit",
         });
     }
+
+    // The modal can be closed while a thumbnail cycle is running.
+    onDestroy(stopThumbnailCycle);
 
     onMount(async () => {
         try {
@@ -285,7 +336,7 @@
                                 <div
                                     role="presentation"
                                     class="group flex min-w-0 flex-1 items-stretch gap-3 overflow-hidden rounded border-none bg-white/[0.06] p-0 m-0 text-left text-inherit transition-all hover:-translate-y-px hover:bg-white/10"
-                                    onmouseenter={() => startThumbnailCycle(index, record.thumbnails)}
+                                    onmouseenter={() => startThumbnailCycle(index, record)}
                                     onmouseleave={stopThumbnailCycle}
                                 >
                                     <button
@@ -299,9 +350,12 @@
                                         >
                                             <img
                                                 class="absolute inset-0 h-full w-full object-cover"
-                                                src={hoveredRecordIndex === index
-                                                    ? record.thumbnails[thumbnailIndex]?.url
-                                                    : record.thumbnails[1]?.url}
+                                                src={thumbnailSrc(
+                                                    record,
+                                                    hoveredRecordIndex === index,
+                                                    thumbnailIndex,
+                                                    hoveredThumbnails,
+                                                )}
                                                 alt=""
                                             />
                                             <span
@@ -415,7 +469,7 @@
                                     <button
                                         type="button"
                                         class="flex min-w-0 flex-1 cursor-pointer flex-col overflow-hidden rounded border-none bg-transparent p-0 m-0 text-left text-inherit focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
-                                        onmouseenter={() => startThumbnailCycle(index, record.thumbnails)}
+                                        onmouseenter={() => startThumbnailCycle(index, record)}
                                         onmouseleave={stopThumbnailCycle}
                                         onclick={() =>
                                             openVideoInCoWebsite(record.videoFile.key, record.videoFile.filename)}
@@ -426,9 +480,12 @@
                                         >
                                             <img
                                                 class="absolute inset-0 h-full w-full object-cover"
-                                                src={hoveredRecordIndex === index
-                                                    ? record.thumbnails[thumbnailIndex]?.url
-                                                    : record.thumbnails[1]?.url}
+                                                src={thumbnailSrc(
+                                                    record,
+                                                    hoveredRecordIndex === index,
+                                                    thumbnailIndex,
+                                                    hoveredThumbnails,
+                                                )}
                                                 alt=""
                                             />
                                             <span

--- a/play/src/front/Components/PopUp/Recording/RecordingsListModal.svelte
+++ b/play/src/front/Components/PopUp/Recording/RecordingsListModal.svelte
@@ -341,12 +341,13 @@
                                 >
                                     <button
                                         type="button"
+                                        class="flex min-w-0 flex-1 cursor-pointer items-stretch gap-3 border-none bg-transparent p-0 m-0 text-left text-inherit focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
                                         onclick={() =>
                                             openVideoInCoWebsite(record.videoFile.key, record.videoFile.filename)}
                                         data-testid="recording-item-{index}"
                                     >
                                         <span
-                                            class="relative w-40 min-w-40 shrink-0 overflow-hidden rounded bg-black/30 aspect-video"
+                                            class="relative block w-40 min-w-40 shrink-0 self-center overflow-hidden rounded bg-black/30 aspect-video"
                                         >
                                             <img
                                                 class="absolute inset-0 h-full w-full object-cover"

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -1829,6 +1829,26 @@ export class RoomConnection implements RoomConnection {
         return nonUndefinedRecordingsAnswer;
     }
 
+    /**
+     * Signed URLs of the thumbnails of one recording, for the hover preview. The recordings list only
+     * carries one poster per recording, so these are fetched only for the recording being hovered.
+     */
+    public async queryRecordingThumbnails(baseFilename: string, signal?: AbortSignal): Promise<string[]> {
+        const answer = await this.query(
+            {
+                $case: "getRecordingThumbnailsQuery",
+                getRecordingThumbnailsQuery: {
+                    baseFilename,
+                },
+            },
+            { signal },
+        );
+        if (answer.$case !== "getRecordingThumbnailsAnswer") {
+            throw new Error("Unexpected answer");
+        }
+        return answer.getRecordingThumbnailsAnswer.urls;
+    }
+
     public async getSignedUrl(key: string): Promise<string> {
         const answer = await this.query({
             $case: "getSignedUrlQuery",

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -823,6 +823,20 @@ export class IoSocketController {
                                             this.sendAnswerMessage(socket, answerMessage);
                                             break;
                                         }
+                                        case "getRecordingThumbnailsQuery": {
+                                            const getRecordingThumbnailsAnswer =
+                                                await socketManager.handleGetRecordingThumbnailsQuery(
+                                                    socket,
+                                                    message.message.queryMessage.query.getRecordingThumbnailsQuery
+                                                        .baseFilename,
+                                                );
+                                            answerMessage.answer = {
+                                                $case: "getRecordingThumbnailsAnswer",
+                                                getRecordingThumbnailsAnswer,
+                                            };
+                                            this.sendAnswerMessage(socket, answerMessage);
+                                            break;
+                                        }
                                         case "deleteRecordingQuery": {
                                             const deleteRecordingAnswer =
                                                 await socketManager.handleDeleteRecordingQuery(

--- a/play/src/pusher/services/RecordingService.ts
+++ b/play/src/pusher/services/RecordingService.ts
@@ -8,7 +8,7 @@ import {
     type _Object,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import type { Recording, Thumbnail } from "@workadventure/messages";
+import type { Recording } from "@workadventure/messages";
 import {
     LIVEKIT_RECORDING_S3_ENDPOINT,
     LIVEKIT_RECORDING_S3_CDN_ENDPOINT,
@@ -21,6 +21,13 @@ import {
 export default class RecordingService {
     // Thumbnail signed URLs expire after 1 hour (for viewing in the recordings list)
     private static readonly THUMBNAIL_URL_EXPIRATION_SECONDS = 3600;
+    // The egress captures a thumbnail every 10s, so a long recording has hundreds of them. Signing them
+    // all would put hundreds of kB of URLs in a single websocket frame, for a preview nobody watches to
+    // the end. Spread this many over the video instead.
+    private static readonly MAX_THUMBNAILS_PER_RECORDING = 15;
+    // The very first thumbnail is often captured before anything is rendered, so the list shows the second one.
+    private static readonly POSTER_THUMBNAIL_INDEX = 1;
+    private static readonly BASE_FILENAME_REGEX = /^recording-(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$/;
 
     public static async getRecords(userUuid: string): Promise<Recording[]> {
         let client: S3Client;
@@ -42,15 +49,6 @@ export default class RecordingService {
             return [];
         }
 
-        // Intermediate type for collecting data before generating signed URLs
-        interface ThumbnailData {
-            key: string;
-            filename: string;
-            size: number | undefined;
-            sequenceNumber: number;
-            timestampSeconds: number;
-        }
-
         interface SessionData {
             timestamp: string;
             baseFilename: string;
@@ -61,7 +59,7 @@ export default class RecordingService {
                       size: number | undefined;
                   }
                 | undefined;
-            thumbnails: ThumbnailData[];
+            thumbnailKeys: { key: string; sequenceNumber: number }[];
         }
 
         const sessions = new Map<string, SessionData>();
@@ -83,7 +81,7 @@ export default class RecordingService {
                     timestamp: timestamp,
                     baseFilename: `recording-${timestamp}`,
                     videoFile: undefined,
-                    thumbnails: [],
+                    thumbnailKeys: [],
                 });
             }
 
@@ -96,17 +94,7 @@ export default class RecordingService {
                     size: item.Size !== undefined ? Number(item.Size) : undefined,
                 };
             } else if (fileType === "thumbnail") {
-                const sequenceMatch = filename.match(/_(\d+)\./);
-                const sequenceNumber = sequenceMatch ? parseInt(sequenceMatch[1], 10) : 0;
-                const timestampSeconds = (sequenceNumber - 1) * 120;
-
-                session.thumbnails.push({
-                    key: item.Key,
-                    filename: filename,
-                    size: item.Size !== undefined ? Number(item.Size) : undefined,
-                    sequenceNumber: sequenceNumber,
-                    timestampSeconds: timestampSeconds,
-                });
+                session.thumbnailKeys.push({ key: item.Key, sequenceNumber: this.getSequenceNumber(filename) });
             }
         });
 
@@ -115,35 +103,87 @@ export default class RecordingService {
             .filter((session) => session.videoFile !== undefined)
             .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 
-        // Generate signed URLs for all thumbnails
-        const recordings: Recording[] = await Promise.all(
+        // One signed URL per recording: the rest are fetched on demand, see getThumbnailUrls().
+        return Promise.all(
             sortedSessions.map(async (session) => {
-                const sortedThumbnails = session.thumbnails.sort(
-                    (a, b) => (a.sequenceNumber || 0) - (b.sequenceNumber || 0),
-                );
-
-                // Generate signed URLs for thumbnails
-                const thumbnailsWithSignedUrls: Thumbnail[] = await Promise.all(
-                    sortedThumbnails.map(async (thumb) => ({
-                        key: thumb.key,
-                        url: await this.generateThumbnailSignedUrl(thumb.key),
-                        filename: thumb.filename,
-                        size: thumb.size,
-                        sequenceNumber: thumb.sequenceNumber,
-                        timestampSeconds: thumb.timestampSeconds,
-                    })),
-                );
+                const sortedKeys = this.sortBySequenceNumber(session.thumbnailKeys);
+                const poster = sortedKeys[this.POSTER_THUMBNAIL_INDEX] ?? sortedKeys[0];
 
                 return {
                     timestamp: session.timestamp,
                     baseFilename: session.baseFilename,
                     videoFile: session.videoFile,
-                    thumbnails: thumbnailsWithSignedUrls,
+                    posterUrl: poster ? await this.generateThumbnailSignedUrl(poster.key) : "",
                 };
             }),
         );
+    }
 
-        return recordings;
+    /**
+     * Signed URLs for the thumbnails of a single recording, evenly spaced over the video and capped to
+     * MAX_THUMBNAILS_PER_RECORDING. Used by the hover preview, once the user asks for that recording.
+     */
+    public static async getThumbnailUrls(userUuid: string, baseFilename: string): Promise<string[]> {
+        const timestampMatch = baseFilename.match(this.BASE_FILENAME_REGEX);
+        if (!timestampMatch) {
+            throw new Error("Invalid recording name");
+        }
+
+        let client: S3Client;
+        try {
+            client = this.getS3Client();
+        } catch (error) {
+            console.error("Error getting S3 client:", error);
+            return [];
+        }
+
+        if (!LIVEKIT_RECORDING_S3_BUCKET) {
+            console.error("LIVEKIT_RECORDING_S3_BUCKET is not configured");
+            return [];
+        }
+
+        // The prefix keeps the listing inside the user's own folder, whatever the client asked for.
+        const prefix = `${userUuid}/thumbnail-${timestampMatch[1]}_`;
+        const contents = await this.listAllObjects(client, LIVEKIT_RECORDING_S3_BUCKET, prefix);
+
+        const sortedKeys = this.sortBySequenceNumber(
+            contents.flatMap((item) =>
+                item.Key ? [{ key: item.Key, sequenceNumber: this.getSequenceNumber(item.Key) }] : [],
+            ),
+        );
+
+        // Skip the pre-roll frame, like the poster does.
+        const usableKeys = sortedKeys.length > 1 ? sortedKeys.slice(this.POSTER_THUMBNAIL_INDEX) : sortedKeys;
+
+        return Promise.all(
+            this.evenlySpaced(usableKeys, this.MAX_THUMBNAILS_PER_RECORDING).map((thumbnail) =>
+                this.generateThumbnailSignedUrl(thumbnail.key),
+            ),
+        );
+    }
+
+    /**
+     * Picks at most `max` items, evenly spaced over the whole array (first and last always included).
+     */
+    private static evenlySpaced<T>(items: T[], max: number): T[] {
+        if (items.length <= max) {
+            return items;
+        }
+
+        const step = (items.length - 1) / (max - 1);
+        return Array.from({ length: max }, (_, index) => items[Math.round(index * step)]);
+    }
+
+    private static getSequenceNumber(filename: string): number {
+        const sequenceMatch = filename.match(/_(\d+)\./);
+        return sequenceMatch ? parseInt(sequenceMatch[1], 10) : 0;
+    }
+
+    /**
+     * Thumbnails are numbered _1.jpg.._360.jpg, so they must be ordered numerically, not alphabetically.
+     */
+    private static sortBySequenceNumber<T extends { sequenceNumber: number }>(thumbnails: T[]): T[] {
+        return [...thumbnails].sort((a, b) => a.sequenceNumber - b.sequenceNumber);
     }
 
     /**

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -17,6 +17,7 @@ import type {
     GetMemberAnswer,
     GetMemberQuery,
     GetRecordingsAnswer,
+    GetRecordingThumbnailsAnswer,
     DeleteRecordingAnswer,
     JoinRoomMessage,
     MemberData,
@@ -1514,6 +1515,16 @@ export class SocketManager implements ZoneEventListener {
         const records = await RecordingService.getRecords(userUuid);
         return {
             recordings: records,
+        };
+    }
+
+    async handleGetRecordingThumbnailsQuery(
+        client: PusherWebSocket,
+        baseFilename: string,
+    ): Promise<GetRecordingThumbnailsAnswer> {
+        const { userUuid } = client.getUserData();
+        return {
+            urls: await RecordingService.getThumbnailUrls(userUuid, baseFilename),
         };
     }
 

--- a/play/tests/pusher/RecordingServiceThumbnails.test.ts
+++ b/play/tests/pusher/RecordingServiceThumbnails.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/pusher/enums/EnvironmentVariable", async () => ({
+    ...(await import("./mocks/pusherEnvironmentVariableMock")),
+    LIVEKIT_RECORDING_S3_ENDPOINT: "https://s3.example.com",
+    LIVEKIT_RECORDING_S3_CDN_ENDPOINT: "https://cdn.example.com",
+    LIVEKIT_RECORDING_S3_ACCESS_KEY: "access-key",
+    LIVEKIT_RECORDING_S3_SECRET_KEY: "secret-key",
+    LIVEKIT_RECORDING_S3_BUCKET: "recordings",
+    LIVEKIT_RECORDING_S3_REGION: "eu-west-1",
+}));
+
+const listedKeys: string[] = [];
+const listPrefixes: (string | undefined)[] = [];
+
+vi.mock("@aws-sdk/client-s3", () => ({
+    S3Client: class {
+        send(command: { input: { Prefix?: string } }) {
+            listPrefixes.push(command.input.Prefix);
+            return Promise.resolve({
+                Contents: listedKeys
+                    .filter((key) => !command.input.Prefix || key.startsWith(command.input.Prefix))
+                    .map((key) => ({ Key: key, Size: 10 })),
+                IsTruncated: false,
+            });
+        }
+    },
+    ListObjectsCommand: class {
+        constructor(public readonly input: Record<string, unknown>) {}
+    },
+    GetObjectCommand: class {
+        constructor(public readonly input: { Key: string }) {}
+    },
+    DeleteObjectCommand: class {
+        constructor(public readonly input: { Key: string }) {}
+    },
+}));
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+    getSignedUrl: (_client: unknown, command: { input: { Key: string } }) =>
+        Promise.resolve(`signed:${command.input.Key}`),
+}));
+
+import RecordingService from "../../src/pusher/services/RecordingService";
+
+const USER = "user-uuid";
+const TIMESTAMP = "2026-09-11T10:00:00";
+
+function thumbnailKey(sequence: number): string {
+    return `${USER}/thumbnail-${TIMESTAMP}_${sequence}.jpg`;
+}
+
+function givenRecording(thumbnailCount: number): void {
+    listedKeys.length = 0;
+    listedKeys.push(`${USER}/recording-${TIMESTAMP}.mp4`);
+    for (let sequence = 1; sequence <= thumbnailCount; sequence++) {
+        listedKeys.push(thumbnailKey(sequence));
+    }
+}
+
+describe("RecordingService thumbnails", () => {
+    beforeEach(() => {
+        listPrefixes.length = 0;
+    });
+
+    it("puts a single poster in the recordings list, whatever the recording length", async () => {
+        givenRecording(360);
+
+        const recordings = await RecordingService.getRecords(USER);
+
+        expect(recordings).toHaveLength(1);
+        // The first thumbnail is captured before anything is rendered, so the poster is the second one.
+        expect(recordings[0].posterUrl).toBe(`signed:${thumbnailKey(2)}`);
+        expect(JSON.stringify(recordings[0])).not.toContain(thumbnailKey(3));
+    });
+
+    it("leaves the poster empty when the recording has no thumbnail", async () => {
+        listedKeys.length = 0;
+        listedKeys.push(`${USER}/recording-${TIMESTAMP}.mp4`);
+
+        const recordings = await RecordingService.getRecords(USER);
+
+        expect(recordings).toHaveLength(1);
+        expect(recordings[0].posterUrl).toBe("");
+    });
+
+    it("caps the hover thumbnails and spreads them over the whole recording", async () => {
+        givenRecording(360);
+
+        const urls = await RecordingService.getThumbnailUrls(USER, `recording-${TIMESTAMP}`);
+
+        expect(urls).toHaveLength(15);
+        // Evenly spaced from the second thumbnail (the first is the pre-roll frame) to the last one.
+        expect(urls[0]).toBe(`signed:${thumbnailKey(2)}`);
+        expect(urls[urls.length - 1]).toBe(`signed:${thumbnailKey(360)}`);
+        expect(new Set(urls).size).toBe(urls.length);
+    });
+
+    it("returns every thumbnail of a short recording, in capture order", async () => {
+        givenRecording(4);
+
+        const urls = await RecordingService.getThumbnailUrls(USER, `recording-${TIMESTAMP}`);
+
+        expect(urls).toEqual([2, 3, 4].map((sequence) => `signed:${thumbnailKey(sequence)}`));
+    });
+
+    it("orders thumbnails numerically, not alphabetically", async () => {
+        givenRecording(12);
+
+        const urls = await RecordingService.getThumbnailUrls(USER, `recording-${TIMESTAMP}`);
+
+        // Alphabetical order would put _10 right after _1.
+        expect(urls).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((s) => `signed:${thumbnailKey(s)}`));
+    });
+
+    it("only ever lists the caller's own folder", async () => {
+        givenRecording(4);
+
+        await RecordingService.getThumbnailUrls(USER, `recording-${TIMESTAMP}`);
+
+        expect(listPrefixes).toEqual([`${USER}/thumbnail-${TIMESTAMP}_`]);
+    });
+
+    it("rejects a recording name that is not one of ours", async () => {
+        givenRecording(4);
+
+        await expect(RecordingService.getThumbnailUrls(USER, "../other-user/thumbnail-")).rejects.toThrow(
+            "Invalid recording name",
+        );
+        await expect(RecordingService.getThumbnailUrls(USER, "recording-2026-09-11T10:00:00 extra")).rejects.toThrow(
+            "Invalid recording name",
+        );
+        expect(listPrefixes).toEqual([]);
+    });
+});


### PR DESCRIPTION
Follow-up to #6528, which fixed the duplicate-frame bug this payload exposed.

## Problem

The egress captures a thumbnail every 10 s (`captureInterval: 10`), and `GetRecordingsAnswer` carried a presigned URL for **every** one of them. A presigned URL is ~500 bytes, so:

| | payload per 1 h recording |
|---|---|
| before | ~180 kB |
| after | ~0.5 kB |

…in a single websocket frame, growing with the number of recordings, and signing each URL is HMAC work on the pusher's event loop. The list only ever draws **one** image per row, so all but one of those URLs was signed, sent, and never looked at.

## Change

- `Recording` carries a single `posterUrl`.
- New `GetRecordingThumbnailsQuery(baseFilename)` returns the frames for **one** recording, capped at 15 evenly spaced over the video, fetched on hover and kept for the lifetime of the modal.
- The query validates `baseFilename` against `recording-<timestamp>` and always lists under `${userUuid}/`, so it cannot reach another user's folder.

This also fixes the preview itself. It used to cycle *every* thumbnail at one per 650 ms: hovering a one-hour recording showed the first 6.5 seconds of the meeting and would have needed four minutes to loop. Fifteen spaced frames show the whole recording in ten seconds.

`Thumbnail` leaves the protocol with it, including its unused `sequenceNumber` and `timestampSeconds` — the latter computed as `(sequenceNumber - 1) * 120`, a capture interval that has not been true since the egress was set to 10 s.

Also: **the recordings list now opens in card mode by default** (a stored preference still wins).

## Protocol break

This changes `messages.proto`, so every connected client is disconnected on upgrade. That is why the dead `Thumbnail` fields are removed in the same PR rather than in a follow-up — one forced disconnect, not two.

## Tests

`play/tests/pusher/RecordingServiceThumbnails.test.ts` — poster selection, the cap and its spacing, numeric (not alphabetical) ordering of `_1..._360`, a recording with no thumbnails, prefix scoping, and rejection of a malformed `baseFilename`.

**Not verified in a running app**: exercising the modal needs LiveKit egress and a populated S3 bucket, and there is no e2e coverage for recordings today. The pusher logic is unit-tested; the hover interaction has been reviewed but not clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)