### PR TITLE
fix(pusher): let the admin socket receive a large listen message

### DIFF
--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -83,6 +83,11 @@ export class IoSocketController {
 
     adminRoomSocket(): void {
         this.app.ws<AdminSocketData>("/ws/admin/rooms", {
+            // The "listen" message carries the admin JWT (which embeds every authorized room URL)
+            // plus the same room list again, so a large organization goes over uWS' 16kB default.
+            // uWS then drops such a message by closing the socket with no close frame at all, so
+            // the admin only sees a bare 1006 and silently loses its "users connected" counters.
+            maxPayloadLength: 16 * 1024 * 1024,
             maxBackpressure: PUSHER_ADMIN_WS_MAX_BACKPRESSURE_BYTES,
             upgrade: (res, req, context) => {
                 const websocketKey = req.getHeader("sec-websocket-key");


### PR DESCRIPTION
## Problem

`/ws/admin/rooms` is the only websocket route that declares no `maxPayloadLength`, so it runs on uWS' **16kB default** — `/ws/room` right below it asks for 16MB.

The admin back office opens that socket and sends a `listen` message built from:

- the admin JWT, whose payload embeds **every authorized room URL** (`Team::getAdminSocketToken()` on the admin side), base64-encoded, and
- the **same room list again**, in clear, as `roomIds`.

That costs roughly **186 bytes per room**, so an organization crosses 16kB at about **90 rooms** across all of its worlds.

Past the limit, uWS closes the connection **without a close frame**. The consequences are entirely silent:

- the browser only reports `CloseEvent { code: 1006, reason: "", wasClean: false }`,
- no `Error` message is sent, because the handler never runs,
- nothing is logged on the pusher and nothing reaches Sentry,
- the back office just stops showing connected users.

Measured against a staging organization: **17.0kB** of `listen` for a **16.4kB** ceiling — about 91 rooms.

## Reproduced

Same server, same invalid JWT, only the payload size changes:

```
~1kB   → code=1008  reason="Access refused"  + {"type":"Error", ...}
~18kB  → code=1006  reason=""                + nothing
```

## Fix

Give the route the same 16MB ceiling as `/ws/room`. The JWT is still verified on the first message, so this does not widen what an unauthenticated client can do — it only lets the pusher *read* the message before refusing it.

## Note

This is not a regression: the route has never had a `maxPayloadLength`, including when `maxBackpressure` was added in #6090. Organizations simply grow into it, and they do so silently.
