### PR TITLE
fix(screenshare): publish VP9 instead of AV1

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -11,7 +11,6 @@ import {
     VideoPresets,
     DisconnectReason,
     ConnectionState,
-    supportsAV1,
 } from "livekit-client";
 import type { Readable, Unsubscriber } from "svelte/store";
 import { get } from "svelte/store";
@@ -473,11 +472,11 @@ export class LiveKitRoom implements LiveKitRoomInterface {
 
             const screenSharePublishOptions: TrackPublishOptions = {
                 source: Track.Source.ScreenShare,
-                // When AV1 encoding is unavailable (Chrome on Android, Chromium builds without
-                // libaom, Firefox, Safari...), LiveKit silently rewrites the codec to its hardcoded
-                // default of VP8 rather than to `publishDefaults.videoCodec`. Fall back to VP9
-                // explicitly; LiveKit still degrades VP9 to VP8 on its own if VP9 is missing too.
-                videoCodec: supportsAV1() ? "av1" : "vp9",
+                // AV1 has no hardware encoder on most machines: publishers reported their whole
+                // computer slowing down while sharing their screen. VP9 is hardware-accelerated far
+                // more often and good enough for screen content. LiveKit degrades VP9 to VP8 on its
+                // own when the publisher has no VP9 encoder.
+                videoCodec: "vp9",
                 simulcast: true,
                 // Commented out: the default simulcast layers are sufficient for our use case
                 // screenShareSimulcastLayers: [ScreenSharePresets.h720fps30]

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -285,7 +285,9 @@ export class RemotePeer extends Peer implements Streamable {
                 }),
             },
             preferredCodecs: {
-                video: type === "video" ? ["video/VP9", "video/VP8"] : ["video/AV1", "video/VP9", "video/VP8"],
+                // AV1 is deliberately not offered for screen sharing: encoding it in software
+                // pegs the publisher's CPU (see LiveKitRoom.handleScreenShareUpdate).
+                video: ["video/VP9", "video/VP8"],
             },
             // Firefox works better with trickle ICE enabled
             ...(firefoxBrowser && { trickle: true }),

--- a/play/src/front/WebRtc/VideoPresets.ts
+++ b/play/src/front/WebRtc/VideoPresets.ts
@@ -208,8 +208,7 @@ const screenShareMaxPreset: Preset = {
 /**
  * Maximum capture resolution of a screen share, per quality setting.
  *
- * AV1 has no hardware encoder on most machines, and nothing downstream ever lowers the published
- * resolution.
+ * Nothing downstream ever lowers the published resolution, so cap it at capture time.
  */
 export const screenShareMaxResolution: Record<VideoQualitySetting, MediaTrackConstraints> = {
     low: { width: { max: 1280 }, height: { max: 720 } },
@@ -230,7 +229,7 @@ export function selectVideoPreset(
     fps: number;
 } {
     if (isScreenShare) {
-        return selectAV1Preset(displayWidth, displayHeight, quality);
+        return selectScreenSharePreset(displayWidth, displayHeight, quality);
     } else {
         return selectVP9Preset(displayWidth, displayHeight, Object.values(videoPresets), videoMaxPreset, quality);
     }
@@ -261,9 +260,9 @@ function selectVP9Preset(
 }
 
 /**
- * The bitrate for AV1 scales with the frame size (sqrt of the pixel ratio vs 1920x1080) and is capped by the selected quality maximum.
+ * The screen share bitrate scales with the frame size (sqrt of the pixel ratio vs 1920x1080) and is capped by the selected quality maximum.
  */
-export function selectAV1Preset(
+export function selectScreenSharePreset(
     width: number,
     height: number,
     quality: VideoQualitySetting,


### PR DESCRIPTION
## Problem

Screen sharing publishes in AV1 when the browser advertises AV1 encoding support. AV1 has no hardware encoder on most machines, so in practice that means software-encoding a 1080p/30 screen share on the CPU. Several users reported their whole computer becoming slow while sharing their screen.

## Fix

Publish VP9 for screen sharing instead. VP9 is hardware-accelerated far more often, and it is good enough for screen content.

Both screen sharing paths are changed, since both preferred AV1:

- `play/src/front/Livekit/LiveKitRoom.ts` — `videoCodec: supportsAV1() ? "av1" : "vp9"` becomes `videoCodec: "vp9"`. The `supportsAV1()` fallback existed only because LiveKit silently rewrites an unsupported AV1 to VP8 rather than to `publishDefaults.videoCodec`; with VP9 asked for directly it is no longer needed (LiveKit still degrades VP9 → VP8 on its own when the publisher has no VP9 encoder).
- `play/src/front/WebRtc/RemotePeer.ts` — the P2P fallback listed `video/AV1` first in `preferredCodecs` for screen sharing. Dropped, which makes the screen sharing list identical to the camera one.

Camera video is untouched: it was already VP9.

## Bitrates

Unchanged. `selectAV1Preset` (renamed to `selectScreenSharePreset`, same math) keeps the same caps — 1 / 3 / 4.5 Mbps for low / recommended / high. VP9 at the same bitrate is a small quality trade-off, against a CPU cost users are actively complaining about. Nothing else in the bitrate or resolution logic changes.

## Why now, and what comes after

This is a stop-gap for the hotfix branch. The proper fix — measuring encoder load and downgrading AV1 → VP9 automatically — lands in 1.34.

## Test

`npm run typecheck` and the `tests/front/WebRtc` vitest suite pass (40 tests). Worth a manual check that a screen share still comes up for a VP9-only and a VP8-only viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)