### PR TITLE
test(e2e): replace the lock-area unlock sleep with a retry

### DIFF
--- a/tests/tests/map_editor/map_editor_lock_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_lock_area.spec.ts
@@ -171,13 +171,22 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         // enter an area he is not allowed to enter otherwise.
         await page2.getByTestId("lock-button").click();
         await expect(page2.getByTestId("lock-button")).not.toHaveClass(/bg-danger/);
-        // Give the unlock broadcast time to reach Admin1's page before he starts his pathfinding move.
-        // eslint-disable-next-line playwright/no-wait-for-timeout
-        await page.waitForTimeout(500);
 
-        await Map.walkToPosition(page, 4 * 32, 4 * 32);
-        const adminPositionAfterUnlock = await Map.getPosition(page);
-        expect(adminPositionAfterUnlock.x).toBeGreaterThan(areaLeftBoundX);
+        // The unlock broadcast reaches Admin1's client a bit after it has updated Alice's lock button, and a
+        // move started before it arrives runs on a stale collision grid: since #6480 it walks up to the
+        // still-locked area and resolves there, leaving Admin1 outside. Retry the move until his grid has
+        // caught up instead of guessing how long the broadcast takes.
+        await expect
+            .poll(
+                async () => {
+                    await Map.walkToPosition(page, 4 * 32, 4 * 32).catch(() => {
+                        // Still locked on Admin1's side: retry.
+                    });
+                    return (await Map.getPosition(page)).x;
+                },
+                { timeout: 10_000 },
+            )
+            .toBeGreaterThan(areaLeftBoundX);
     });
 
     test("Locking an area mid-walk stops or reroutes a pathfinding move", async ({ browser, request }) => {


### PR DESCRIPTION
> Stacked on #6536 — review that one first; the base will switch to `master` once it merges.

## The flake

`map_editor_lock_area.spec.ts:138` — *Lock area also blocks pathfinding moves of a user allowed to edit the map* — failed on the `firefox 2/4` shard in 3 of the last 19 failed master runs. Always the same assertion, always the same value:

```
Expected: > 32
Received:   0
```

Admin1 never left his starting position after Alice unlocked the area.

## Why

The unlock broadcast updates Alice's lock button before it reaches Admin1's client. A move started in that window runs on a stale collision grid, and since #6480 that no longer errors — it walks up to the still-locked area and resolves there, leaving Admin1 outside.

#6496 covered this with `await page.waitForTimeout(500)`. That does not remove the race, it just makes it narrower, and a loaded CI runner can still lose it.

## The fix

Retry the move until Admin1's grid has caught up, instead of guessing how long the broadcast takes. No product change, no new e2e hook — just the existing `Map` helpers.

## Reproduced and verified locally

Removing the wait entirely (widest possible race window) makes the failure reproducible on demand:

- single move, no wait → **failed 3/3**, with the exact CI error (`expected > 32, received 0`)
- retry, no wait → **passed 3/3** in the same window

With the branch as it stands: `map_editor_lock_area.spec.ts` passes 3/3 on firefox and 3/3 on chromium.

## Left alone

The two other `waitForTimeout(500)` calls #6496 added. Neither has been observed failing, and the one in *Locking an area mid-walk* guards a move that gets interrupted halfway through, which a retry loop does not fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)