### PR TITLE
ci(uploader): run the S3 tests against RustFS instead of MinIO

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4453,16 +4453,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@testcontainers/minio": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@testcontainers/minio/-/minio-12.0.1.tgz",
-      "integrity": "sha512-Are/zcFeMnhLIWbl/7QS8zGyr3xAMOeOBqnK3ghEZNRkV1sHoYSmME1XkY2JxpxJAVjTPmqC6Z15T4Cp0NjLGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "testcontainers": "^12.0.1"
-      }
-    },
     "node_modules/@total-typescript/ts-reset": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.6.1.tgz",
@@ -20716,7 +20706,6 @@
         "uuid": "^14.0.0"
       },
       "devDependencies": {
-        "@testcontainers/minio": "^12.0.1",
         "@types/body-parser": "^1.19.6",
         "@types/busboy": "^1.5.4",
         "@types/cors": "^2.8.19",

--- a/uploader/package.json
+++ b/uploader/package.json
@@ -60,7 +60,6 @@
     "uuid": "^14.0.0"
   },
   "devDependencies": {
-    "@testcontainers/minio": "^12.0.1",
     "@types/body-parser": "^1.19.6",
     "@types/busboy": "^1.5.4",
     "@types/cors": "^2.8.19",

--- a/uploader/tests/S3Uploader.test.ts
+++ b/uploader/tests/S3Uploader.test.ts
@@ -1,7 +1,7 @@
 import type {ChildProcess} from "child_process";
 import { asError } from "catch-unknown";
-import type { StartedMinioContainer} from "@testcontainers/minio";
-import {MinioContainer} from "@testcontainers/minio";
+import type { StartedTestContainer} from "testcontainers";
+import {GenericContainer, Wait} from "testcontainers";
 import AWS from "aws-sdk";
 import {describe, expect, vi, it, beforeAll, beforeEach, afterAll, afterEach} from 'vitest';
 import {PLAY_URL} from "../src/Enum/EnvironmentVariable";
@@ -9,9 +9,12 @@ import {uploadHtmlFileTest, uploadMultipleFilesTest, uploadSingleFileTest} from 
 import startTestServer, {stopTestServer} from "./startTestServer";
 import isPortReachable from "./utils/isPortReachable";
 
-const MINIO_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z";
-const MINIO_ACCESS_KEY = "fake-access-key";
-const MINIO_SECRET_KEY = "fake-secret";
+// RustFS is the S3-compatible server the docker-compose stacks already use. It replaces minio/minio,
+// which can no longer be pulled from Docker Hub ("repository does not exist or may require login").
+const RUSTFS_IMAGE = "rustfs/rustfs:1.0.0-alpha.83";
+const RUSTFS_S3_PORT = 9000;
+const S3_ACCESS_KEY = "fake-access-key";
+const S3_SECRET_KEY = "fake-secret";
 const TEST_BUCKET = "storage-bucket";
 
 vi.mock('../src/Enum/EnvironmentVariable', () => ({
@@ -24,37 +27,42 @@ describe("S3 Uploader tests", () => {
     const APP_PORT = 7374
     const UPLOADER_URL = `http://localhost:${APP_PORT}`
     let server: ChildProcess| undefined;
-    let minioContainer: StartedMinioContainer | undefined
+    let s3Container: StartedTestContainer | undefined
     let endpoint: string
 
     let s3: AWS.S3
     vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 })
     beforeAll(async ()=> {
-        minioContainer = await new MinioContainer(MINIO_IMAGE)
-            .withUsername(MINIO_ACCESS_KEY)
-            .withPassword(MINIO_SECRET_KEY)
+        s3Container = await new GenericContainer(RUSTFS_IMAGE)
+            .withCommand(["/data"])
+            .withEnvironment({
+                RUSTFS_ACCESS_KEY: S3_ACCESS_KEY,
+                RUSTFS_SECRET_KEY: S3_SECRET_KEY,
+            })
+            .withExposedPorts(RUSTFS_S3_PORT)
+            .withWaitStrategy(Wait.forLogMessage(/started successfully/))
             .start()
 
-        endpoint = minioContainer.getConnectionUrl()
+        endpoint = `http://${s3Container.getHost()}:${s3Container.getMappedPort(RUSTFS_S3_PORT)}`
 
         AWS.config.update({
-            accessKeyId: MINIO_ACCESS_KEY,
-            secretAccessKey: MINIO_SECRET_KEY,
+            accessKeyId: S3_ACCESS_KEY,
+            secretAccessKey: S3_SECRET_KEY,
             region: "us-east-1"
         });
         const options = {
             s3ForcePathStyle: true,
             endpoint: endpoint,
-            accessKeyId: MINIO_ACCESS_KEY,
-            secretAccessKey: MINIO_SECRET_KEY
+            accessKeyId: S3_ACCESS_KEY,
+            secretAccessKey: S3_SECRET_KEY
         };
         s3 = new AWS.S3(options);
 
         server = startTestServer({
             SERVER_PORT: APP_PORT,
-            AWS_ACCESS_KEY_ID: MINIO_ACCESS_KEY,
+            AWS_ACCESS_KEY_ID: S3_ACCESS_KEY,
             AWS_BUCKET: TEST_BUCKET,
-            AWS_SECRET_ACCESS_KEY: MINIO_SECRET_KEY,
+            AWS_SECRET_ACCESS_KEY: S3_SECRET_KEY,
             AWS_DEFAULT_REGION: "us-east-1",
             AWS_ENDPOINT: endpoint,
             REDIS_HOST: "",
@@ -88,15 +96,15 @@ describe("S3 Uploader tests", () => {
 
     afterAll(async ()=> {
         await stopTestServer(server)
-        if (minioContainer) {
-            const stream = await minioContainer.logs();
+        if (s3Container) {
+            const stream = await s3Container.logs();
             stream
                 //.on("data", line => console.log(line))
                 .on("err", line => console.error(line))
                 .on("end", () => console.log("Stream closed"));
         }
 
-        await minioContainer?.stop()
+        await s3Container?.stop()
     })
 
     it("should upload one file to s3", async ()=> {


### PR DESCRIPTION
## The breakage

The **Continuous Integration Uploader** job started failing today on every branch:

```
FAIL tests/S3Uploader.test.ts > S3 Uploader tests
Error: (HTTP code 404) unexpected - pull access denied for minio/minio,
repository does not exist or may require 'docker login': denied: requested
access to the resource is denied
```

`minio/minio` is no longer pullable from Docker Hub, so the testcontainer backing `tests/S3Uploader.test.ts` cannot start and the whole suite fails (19 passed, 3 skipped, 1 failed suite).

## The fix

Use `rustfs/rustfs:1.0.0-alpha.83` — the S3-compatible server this repo already runs in `docker-compose.rustfs.yaml` (map storage) and `docker-compose.livekit.yaml` (recordings), so it is a tag CI already pulls and the team already maintains.

RustFS has no dedicated testcontainers module, so the container is a plain `GenericContainer`: command `/data`, credentials through `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY`, S3 API on port 9000, waiting on the `started successfully` startup line. Nothing else in the test changes — the AWS SDK client, the bucket lifecycle and the three assertions are untouched.

`@testcontainers/minio` is no longer needed and is removed from `uploader/package.json` and the lockfile.

No production code is affected: MinIO only ever appeared in this test.

## Testing

Locally, against a cold container each time:

- `npm test` in `uploader/` → **22 passed (22)**, no skips, including the 3 S3 tests
- the S3 suite alone re-run 4 times in a row → passed every time (checking the startup wait is not racy)
- `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)