### PR TITLE
fix(chat): look users up by profile instead of the user directory

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -2092,9 +2092,22 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     }
 
     async isUserExist(address: string): Promise<boolean> {
-        const user = await this.searchChatUsers(address, 1);
-        if (!user) return false;
-        return user && user.some((user) => user.id === address);
+        if (!this.client) {
+            throw new Error(CLIENT_NOT_INITIALIZED_ERROR_MSG);
+        }
+        // The user directory cannot answer this: it only lists users we already share a room with (or who
+        // are in a public room), it is indexed asynchronously, and it matches on words, so searching for a
+        // full "@someone:my.server" happily returns anybody else on the same server. The profile endpoint
+        // answers about that exact user: 404 means there is no such user.
+        try {
+            await this.client.getProfileInfo(address);
+            return true;
+        } catch (error) {
+            if (error instanceof MatrixError && error.httpStatus === 404) {
+                return false;
+            }
+            throw error;
+        }
     }
 
     getRoomByID(roomId: string): ChatRoom {

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -1,5 +1,5 @@
 import type { MatrixClient, Room } from "matrix-js-sdk";
-import { ClientEvent, EventType, PendingEventOrdering, RoomEvent, SyncState } from "matrix-js-sdk";
+import { ClientEvent, EventType, MatrixError, PendingEventOrdering, RoomEvent, SyncState } from "matrix-js-sdk";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { KnownMembership } from "matrix-js-sdk/lib/types";
 import type { Readable } from "svelte/store";
@@ -1204,6 +1204,55 @@ describe("MatrixChatConnection", () => {
             await matrixChatConnection["addDMRoomInAccountData"](userId, roomId);
 
             expect(mockSetAccountData).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("isUserExist", () => {
+        const getConnectionWithProfileInfo = async (getProfileInfo: ReturnType<typeof vi.fn>) => {
+            const mockMatrixClient = {
+                isGuest: vi.fn(),
+                on: vi.fn(),
+                once: vi.fn().mockImplementation((_, funcToResolve) => {
+                    funcToResolve(SyncState.Syncing);
+                }),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                createRoom: vi.fn(),
+                getRoom: vi.fn().mockReturnValue(null),
+                joinRoom: vi.fn().mockResolvedValue(""),
+                getProfileInfo,
+            } as unknown as MatrixClient;
+
+            return getMatrixConnection(Promise.resolve(mockMatrixClient));
+        };
+
+        it("should look the exact user up instead of searching the user directory", async () => {
+            // The user directory matches on words, so searching it for "@admin:matrix.localhost" returns any
+            // other user of matrix.localhost and reports an existing user as missing.
+            const getProfileInfo = vi.fn().mockResolvedValue({ displayname: "Admin" });
+            const matrixChatConnection = await getConnectionWithProfileInfo(getProfileInfo);
+
+            await expect(matrixChatConnection.isUserExist("@admin:matrix.localhost")).resolves.toBe(true);
+            expect(getProfileInfo).toHaveBeenCalledWith("@admin:matrix.localhost");
+        });
+
+        it("should return false when the homeserver knows no such user", async () => {
+            const matrixChatConnection = await getConnectionWithProfileInfo(
+                vi.fn().mockRejectedValue(new MatrixError({ errcode: "M_NOT_FOUND" }, 404)),
+            );
+
+            await expect(matrixChatConnection.isUserExist("@nobody:matrix.localhost")).resolves.toBe(false);
+        });
+
+        it("should rethrow any other error instead of reporting the user as missing", async () => {
+            const matrixChatConnection = await getConnectionWithProfileInfo(
+                vi.fn().mockRejectedValue(new MatrixError({ errcode: "M_UNKNOWN" }, 500)),
+            );
+
+            await expect(matrixChatConnection.isUserExist("@admin:matrix.localhost")).rejects.toThrow();
         });
     });
 


### PR DESCRIPTION
## The flake, and the bug behind it

`matrixChatModeration.spec.ts:60` — *should manage participants and permissions in public chat room* — failed in 2 of the last 19 failed master runs, both times on chromium, both times twice in a row (so the retry did not save it):

```
TimeoutError: locator.click: Timeout 20000ms exceeded.
  waiting for getByTestId('createRoomButton')
  - element is not enabled
```

The screenshot from the CI artifact says what actually happened — the invite never made it into the field:

> **Unable send invitations : _User not found_**

`SelectMatrixUser` validates every picked entry with `ChatConnection.isUserExist()`, drops the ones that come back invalid, and the "Send invitations" button is disabled while the list is empty. So this is not a test timing problem: **inviting an existing user by their full Matrix ID was genuinely reported as "user not found"**.

## Why

`isUserExist()` asked the Synapse **user directory** for the address and checked whether the single result it requested was that exact user. The user directory cannot answer that question:

- it only lists users who share a room with us or sit in a public room, and it is indexed asynchronously — an existing user is often simply absent (the `beforeEach` here deactivates and reactivates every Matrix user, which is exactly what empties it);
- it matches on **words**, so the term `@admin:matrix.example.com` also matches everyone else on `matrix.example.com`.

Confirmed against a running Synapse — searching for the exact MXID returns a *different* user:

```
POST /_matrix/client/v3/user_directory/search
{"search_term":"@admin:matrix.workadventure.localhost","limit":1}
→ {"results":[{"user_id":"@john.doe:matrix.workadventure.localhost", ...}]}
```

`some(user => user.id === address)` is then false, and a perfectly valid user is rejected. Raising the limit does not help: on that same server `@admin` is not in the directory at all.

The profile endpoint answers about that exact user:

```
GET /_matrix/client/v3/profile/@admin:matrix.workadventure.localhost      → 200
GET /_matrix/client/v3/profile/@nosuchuser:matrix.workadventure.localhost → 404
```

## The fix

Use `getProfileInfo()`. A 404 means there is no such user; **any other error is rethrown** instead of being silently turned into "user not found", so a transient failure no longer looks like a missing account.

This is a user-facing fix, not just a test fix: inviting someone by MXID whom you do not already share a room with was failing for real users too.

## Testing

- three new unit tests in `MatrixChatConnection.test.ts` (exact lookup, 404 → false, other errors rethrown); two of them fail against the old implementation and pass with the new one
- `MatrixChatConnection.test.ts` — 64 passed
- `src/front/Chat` — 161 passed (two suites fail to load in a plain checkout because `messages/src/JsonMessages` is generated at build time; unrelated and pre-existing)
- the E2E test itself is left to this PR's CI: my local stack is the dev compose, not the e2e one, so its Matrix users do not match what the chat specs expect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
